### PR TITLE
[connector][hotfix] Fix fluss connector limit scan out of bound.

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/PushdownUtils.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/PushdownUtils.java
@@ -365,7 +365,7 @@ public class PushdownUtils {
                                 .collect(Collectors.toList()));
             }
 
-            return rowDataList.subList(0, (int) limit);
+            return limit < responseList.size() ? rowDataList.subList(0, (int) limit) : rowDataList;
         } catch (Exception e) {
             throw new FlussRuntimeException(e);
         }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceBatchITCase.java
@@ -207,6 +207,13 @@ class FlinkTableSourceBatchITCase extends FlinkTestBase {
         assertThat(collected).isSubsetOf(expected);
         assertThat(collected).hasSize(2);
 
+        // limit which is larger than all the data.
+        query = String.format("SELECT * FROM %s limit 10", tableName);
+        iterRows = tEnv.executeSql(query).collect();
+        collected = assertAndCollectRecords(iterRows, 5);
+        assertThat(collected).isSubsetOf(expected);
+        assertThat(collected).hasSize(5);
+
         // projection scan
         query = String.format("SELECT id, name FROM %s limit 3", tableName);
         iterRows = tEnv.executeSql(query).collect();


### PR DESCRIPTION
Current, if the limit number it greater than the actual records number, an IndexOutofBoundExceptuon will throws.

