### PR TITLE
[hotfix] Make KvFileHandle Serializable

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/KvFileHandle.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/KvFileHandle.java
@@ -20,11 +20,13 @@ import com.alibaba.fluss.fs.FileSystem;
 import com.alibaba.fluss.fs.FsPath;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.Optional;
 
 /** A handle to a single file(a remote path after updated) of kv. */
-public class KvFileHandle {
+public class KvFileHandle implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     /** The path to the kv file. */
     private final FsPath filePath;


### PR DESCRIPTION
Since the child class of `KvFileHandle` declares uid field, we'd better make it `Serializable`.