### PR TITLE
[connector] primary key table datalake support count(*) in batch mode. 

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -410,19 +410,12 @@ public class FlinkTableSource
             List<AggregateExpression> aggregateExpressions,
             DataType dataType) {
         // Only supports 'select count(*)/count(1) from source' for log table now.
-        if (streaming || aggregateExpressions.size() != 1) {
-            return false;
-        }
-
-        if (hasPrimaryKey()) {
-            throw new IllegalArgumentException(
-                    "Currently, Fluss Connector doesn't support COUNT(*) query on primary-key table in batch execution mode.");
-        }
-
-        if (groupingSets.size() > 1
+        if (streaming
+                || aggregateExpressions.size() != 1
+                || hasPrimaryKey()
+                || groupingSets.size() > 1
                 || (groupingSets.size() == 1 && groupingSets.get(0).length > 0)) {
-            throw new IllegalArgumentException(
-                    "Currently, Fluss Connector doesn't support Group Aggregation on log table in batch execution mode.");
+            return false;
         }
 
         FunctionDefinition functionDefinition = aggregateExpressions.get(0).getFunctionDefinition();

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceBatchITCase.java
@@ -291,7 +291,7 @@ class FlinkTableSourceBatchITCase extends FlinkTestBase {
                                                         tableName))
                                         .wait())
                 .hasMessageContaining(
-                        "Currently, Fluss Connector doesn't support Group Aggregation on log table in batch execution mode.");
+                        "Currently, Fluss only support queries on table with datalake enabled or point queries on primary key when it's in batch execution mode.");
 
         // test not support primary key now
         String primaryTableName = prepareSourceTable(new String[] {"id"}, null);
@@ -303,7 +303,7 @@ class FlinkTableSourceBatchITCase extends FlinkTestBase {
                                                         primaryTableName))
                                         .wait())
                 .hasMessageContaining(
-                        "Currently, Fluss Connector doesn't support COUNT(*) query on primary-key table in batch execution mode.");
+                        "Currently, Fluss only support queries on table with datalake enabled or point queries on primary key when it's in batch execution mode.");
     }
 
     private String prepareSourceTable(String[] keys, String partitionedKey) throws Exception {


### PR DESCRIPTION
Current, Fluss Connector doesn't support COUNT(*) query on primary-key table in batch execution mode.
However, primary key table datalake is also support batch read, and also need count(*). This PR just not to apply count pushdown rather than throw exception.