### PR TITLE
[hotfix] fix code style violations

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
@@ -119,7 +119,10 @@ public class PeriodicSnapshotManager implements Closeable {
         this.periodicExecutor = periodicExecutor;
         this.guardedExecutor = guardedExecutor;
         this.asyncOperationsThreadPool = asyncOperationsThreadPool;
-        this.initialDelay = periodicSnapshotDelay > 0 ? MathUtils.murmurHash(tableBucket.hashCode()) % periodicSnapshotDelay : 0;
+        this.initialDelay =
+                periodicSnapshotDelay > 0
+                        ? MathUtils.murmurHash(tableBucket.hashCode()) % periodicSnapshotDelay
+                        : 0;
 
         registerMetrics(bucketMetricGroup);
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
@@ -138,13 +138,12 @@ class PeriodicSnapshotManagerTest {
     }
 
     private PeriodicSnapshotManager createSnapshotManager(
-        PeriodicSnapshotManager.SnapshotTarget target) {
+            PeriodicSnapshotManager.SnapshotTarget target) {
         return createSnapshotManager(periodicMaterializeDelay, target);
     }
 
     private PeriodicSnapshotManager createSnapshotManager(
-            long periodicMaterializeDelay,
-            PeriodicSnapshotManager.SnapshotTarget target) {
+            long periodicMaterializeDelay, PeriodicSnapshotManager.SnapshotTarget target) {
         return new PeriodicSnapshotManager(
                 tableBucket,
                 target,


### PR DESCRIPTION

```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.27.1:check (spotless-check) on project fluss-server: The following files had format violations:
[ERROR]     src/test/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
[ERROR]         @@ -138,13 +138,12 @@
[ERROR]          ····}
[ERROR]          
[ERROR]          ····private·PeriodicSnapshotManager·createSnapshotManager(
[ERROR]         -········PeriodicSnapshotManager.SnapshotTarget·target)·{
[ERROR]         +············PeriodicSnapshotManager.SnapshotTarget·target)·{
[ERROR]          ········return·createSnapshotManager(periodicMaterializeDelay,·target);
[ERROR]          ····}
[ERROR]          
[ERROR]          ····private·PeriodicSnapshotManager·createSnapshotManager(
[ERROR]         -············long·periodicMaterializeDelay,
[ERROR]         -············PeriodicSnapshotManager.SnapshotTarget·target)·{
[ERROR]         +············long·periodicMaterializeDelay,·PeriodicSnapshotManager.SnapshotTarget·target)·{
[ERROR]          ········return·new·PeriodicSnapshotManager(
[ERROR]          ················tableBucket,
[ERROR]          ················target,
[ERROR]     src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
[ERROR]         @@ -119,7 +119,10 @@
[ERROR]          ········this.periodicExecutor·=·periodicExecutor;
[ERROR]          ········this.guardedExecutor·=·guardedExecutor;
[ERROR]          ········this.asyncOperationsThreadPool·=·asyncOperationsThreadPool;
[ERROR]         -········this.initialDelay·=·periodicSnapshotDelay·>·0·?·MathUtils.murmurHash(tableBucket.hashCode())·%·periodicSnapshotDelay·:·0;
[ERROR]         +········this.initialDelay·=
[ERROR]         +················periodicSnapshotDelay·>·0
[ERROR]         +························?·MathUtils.murmurHash(tableBucket.hashCode())·%·periodicSnapshotDelay
[ERROR]         +························:·0;
[ERROR]          
[ERROR]          ········registerMetrics(bucketMetricGroup);
[ERROR]          ····}
[ERROR] Run 'mvn spotless:apply' to fix these violations.
[ERROR] -> [Help 1]

```