### PR TITLE
[docs][quick-start] add version to compatible docker-compose lower version

### DIFF
--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -26,6 +26,9 @@ cd fluss-quickstart-flink
 ```
 
 2. Create `docker-compose.yml` file with the following content:
+
+> **Note:** Depending on the docker-compose version installed on your system, you might need to specify a version field at the beginning of your yaml file.
+
 ```yaml
 services:
   coordinator-server:


### PR DESCRIPTION
add version to compatible docker-compose lower version, for docker-compose 1.2x.x, execute `docker-compose up -d` will meet the following problem:

<img width="934" alt="image" src="https://github.com/user-attachments/assets/a73bfd9d-3268-482d-8ba2-00ba2510fbc2">
