### PR TITLE
[Improve] util class naming improvements

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/HashBucketAssigner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/HashBucketAssigner.java
@@ -24,7 +24,7 @@ import com.alibaba.fluss.utils.Preconditions;
 
 import javax.annotation.Nullable;
 
-import static com.alibaba.fluss.utils.UnsafeUtil.BYTE_ARRAY_BASE_OFFSET;
+import static com.alibaba.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
 
 /** Hash bucket assigner. */
 @Internal

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/Configuration.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/Configuration.java
@@ -17,7 +17,7 @@
 package com.alibaba.fluss.config;
 
 import com.alibaba.fluss.annotation.PublicStable;
-import com.alibaba.fluss.utils.CollectionUtil;
+import com.alibaba.fluss.utils.CollectionUtils;
 import com.alibaba.fluss.utils.Preconditions;
 
 import org.slf4j.Logger;
@@ -573,7 +573,7 @@ public class Configuration implements Serializable, ReadableConfig {
     public Map<String, String> toMap() {
         synchronized (this.confData) {
             Map<String, String> ret =
-                    CollectionUtil.newHashMapWithExpectedSize(this.confData.size());
+                    CollectionUtils.newHashMapWithExpectedSize(this.confData.size());
             for (Map.Entry<String, Object> entry : confData.entrySet()) {
                 ret.put(entry.getKey(), ConfigurationUtils.convertToString(entry.getValue()));
             }

--- a/fluss-common/src/main/java/com/alibaba/fluss/fs/SafetyNetCloseableRegistry.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/fs/SafetyNetCloseableRegistry.java
@@ -22,7 +22,7 @@ import com.alibaba.fluss.utils.CloseableRegistry;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.Preconditions;
 import com.alibaba.fluss.utils.WrappingProxy;
-import com.alibaba.fluss.utils.WrappingProxyUtil;
+import com.alibaba.fluss.utils.WrappingProxyUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -106,7 +106,7 @@ public class SafetyNetCloseableRegistry
 
         assert Thread.holdsLock(getSynchronizationLock());
 
-        Closeable innerCloseable = WrappingProxyUtil.stripProxy(wrappingProxyCloseable);
+        Closeable innerCloseable = WrappingProxyUtils.stripProxy(wrappingProxyCloseable);
 
         if (null == innerCloseable) {
             return;
@@ -126,7 +126,7 @@ public class SafetyNetCloseableRegistry
 
         assert Thread.holdsLock(getSynchronizationLock());
 
-        Closeable innerCloseable = WrappingProxyUtil.stripProxy(closeable);
+        Closeable innerCloseable = WrappingProxyUtils.stripProxy(closeable);
 
         return null != innerCloseable && closeableMap.remove(innerCloseable) != null;
     }
@@ -171,7 +171,7 @@ public class SafetyNetCloseableRegistry
 
             super(referent, q);
             this.innerCloseable =
-                    Preconditions.checkNotNull(WrappingProxyUtil.stripProxy(referent));
+                    Preconditions.checkNotNull(WrappingProxyUtils.stripProxy(referent));
             this.closeableRegistry = Preconditions.checkNotNull(closeableRegistry);
             this.debugString = referent.toString();
         }

--- a/fluss-common/src/main/java/com/alibaba/fluss/fs/token/CredentialsJsonSerde.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/fs/token/CredentialsJsonSerde.java
@@ -19,7 +19,7 @@ package com.alibaba.fluss.fs.token;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import com.alibaba.fluss.utils.json.JsonDeserializer;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.JsonSerializer;
 
 import java.io.IOException;
@@ -65,11 +65,11 @@ public class CredentialsJsonSerde
 
     /** Serialize the {@link Credentials} to json bytes. */
     public static byte[] toJson(Credentials credentials) {
-        return JsonSerdeUtil.writeValueAsBytes(credentials, INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(credentials, INSTANCE);
     }
 
     /** Deserialize the json bytes to {@link Credentials}. */
     public static Credentials fromJson(byte[] json) {
-        return JsonSerdeUtil.readValue(json, INSTANCE);
+        return JsonSerdeUtils.readValue(json, INSTANCE);
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/Schema.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/Schema.java
@@ -24,7 +24,7 @@ import com.alibaba.fluss.types.RowType;
 import com.alibaba.fluss.utils.EncodingUtils;
 import com.alibaba.fluss.utils.Preconditions;
 import com.alibaba.fluss.utils.StringUtils;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.SchemaJsonSerde;
 
 import javax.annotation.Nullable;
@@ -99,7 +99,7 @@ public final class Schema implements Serializable {
      * @see SchemaJsonSerde
      */
     public byte[] toJsonBytes() {
-        return JsonSerdeUtil.writeValueAsBytes(this, SchemaJsonSerde.INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(this, SchemaJsonSerde.INSTANCE);
     }
 
     /**
@@ -108,7 +108,7 @@ public final class Schema implements Serializable {
      * @see SchemaJsonSerde
      */
     public static Schema fromJsonBytes(byte[] json) {
-        return JsonSerdeUtil.readValue(json, SchemaJsonSerde.INSTANCE);
+        return JsonSerdeUtils.readValue(json, SchemaJsonSerde.INSTANCE);
     }
 
     /** Returns all column names. It does not distinguish between different kinds of columns. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
@@ -24,7 +24,7 @@ import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.config.ConfigurationUtils;
 import com.alibaba.fluss.utils.AutoPartitionStrategy;
 import com.alibaba.fluss.utils.Preconditions;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.TableDescriptorJsonSerde;
 
 import javax.annotation.Nullable;
@@ -273,7 +273,7 @@ public final class TableDescriptor implements Serializable {
      * @see TableDescriptorJsonSerde
      */
     public byte[] toJsonBytes() {
-        return JsonSerdeUtil.writeValueAsBytes(this, TableDescriptorJsonSerde.INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(this, TableDescriptorJsonSerde.INSTANCE);
     }
 
     /**
@@ -282,7 +282,7 @@ public final class TableDescriptor implements Serializable {
      * @see TableDescriptorJsonSerde
      */
     public static TableDescriptor fromJsonBytes(byte[] json) {
-        return JsonSerdeUtil.readValue(json, TableDescriptorJsonSerde.INSTANCE);
+        return JsonSerdeUtils.readValue(json, TableDescriptorJsonSerde.INSTANCE);
     }
 
     @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TablePartition.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TablePartition.java
@@ -17,7 +17,7 @@
 package com.alibaba.fluss.metadata;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.TablePartitionJsonSerde;
 
 import java.util.Objects;
@@ -47,11 +47,11 @@ public class TablePartition {
     }
 
     public byte[] toJsonBytes() {
-        return JsonSerdeUtil.writeValueAsBytes(this, TablePartitionJsonSerde.INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(this, TablePartitionJsonSerde.INSTANCE);
     }
 
     public static TablePartition fromJsonBytes(byte[] json) {
-        return JsonSerdeUtil.readValue(json, TablePartitionJsonSerde.INSTANCE);
+        return JsonSerdeUtils.readValue(json, TablePartitionJsonSerde.INSTANCE);
     }
 
     @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/metrics/reporter/ReporterSetup.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metrics/reporter/ReporterSetup.java
@@ -20,7 +20,7 @@ import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.plugin.PluginManager;
 import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Iterators;
-import com.alibaba.fluss.utils.CollectionUtil;
+import com.alibaba.fluss.utils.CollectionUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +61,7 @@ public class ReporterSetup {
     private static Map<String, MetricReporterPlugin> loadAvailableReporterPlugins(
             @Nullable PluginManager pluginManager) {
         final Map<String, MetricReporterPlugin> reporterPlugins =
-                CollectionUtil.newHashMapWithExpectedSize(2);
+                CollectionUtils.newHashMapWithExpectedSize(2);
         final Iterator<MetricReporterPlugin> pluginIterator = getAllReporterPlugins(pluginManager);
         // do not use streams or for-each loops here because they do not allow catching individual
         // ServiceConfigurationErrors

--- a/fluss-common/src/main/java/com/alibaba/fluss/row/compacted/CompactedRowWriter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/row/compacted/CompactedRowWriter.java
@@ -26,7 +26,7 @@ import com.alibaba.fluss.row.Decimal;
 import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
 import com.alibaba.fluss.types.DataType;
-import com.alibaba.fluss.utils.UnsafeUtil;
+import com.alibaba.fluss.utils.UnsafeUtils;
 
 import java.io.IOException;
 import java.io.Serializable;
@@ -120,12 +120,12 @@ public class CompactedRowWriter {
     }
 
     public void setNullAt(int pos) {
-        UnsafeUtil.bitSet(buffer, 0, pos);
+        UnsafeUtils.bitSet(buffer, 0, pos);
     }
 
     public void writeByte(byte value) {
         ensureCapacity(1);
-        UnsafeUtil.putByte(buffer, position++, value);
+        UnsafeUtils.putByte(buffer, position++, value);
     }
 
     public void writeString(BinaryString value) {
@@ -172,7 +172,7 @@ public class CompactedRowWriter {
 
     private void writeBoolean(boolean value) {
         ensureCapacity(1);
-        UnsafeUtil.putBoolean(buffer, position++, value);
+        UnsafeUtils.putBoolean(buffer, position++, value);
     }
 
     public void writeBytes(byte[] value) {
@@ -190,7 +190,7 @@ public class CompactedRowWriter {
 
     public void writeShort(short value) {
         ensureCapacity(2);
-        UnsafeUtil.putShort(buffer, position, value);
+        UnsafeUtils.putShort(buffer, position, value);
         position += 2;
     }
 
@@ -198,40 +198,40 @@ public class CompactedRowWriter {
         ensureCapacity(MAX_INT_SIZE);
         // UNSAFE + Loop unrolling faster.
         if ((value & ~0x7F) == 0) {
-            UnsafeUtil.putByte(buffer, position++, (byte) value);
+            UnsafeUtils.putByte(buffer, position++, (byte) value);
             return;
         }
-        UnsafeUtil.putByte(buffer, position++, (byte) (value | 0x80));
+        UnsafeUtils.putByte(buffer, position++, (byte) (value | 0x80));
         value >>>= 7;
         if ((value & ~0x7F) == 0) {
-            UnsafeUtil.putByte(buffer, position++, (byte) value);
+            UnsafeUtils.putByte(buffer, position++, (byte) value);
             return;
         }
-        UnsafeUtil.putByte(buffer, position++, (byte) (value | 0x80));
+        UnsafeUtils.putByte(buffer, position++, (byte) (value | 0x80));
         value >>>= 7;
         if ((value & ~0x7F) == 0) {
-            UnsafeUtil.putByte(buffer, position++, (byte) value);
+            UnsafeUtils.putByte(buffer, position++, (byte) value);
             return;
         }
-        UnsafeUtil.putByte(buffer, position++, (byte) (value | 0x80));
+        UnsafeUtils.putByte(buffer, position++, (byte) (value | 0x80));
         value >>>= 7;
         if ((value & ~0x7F) == 0) {
-            UnsafeUtil.putByte(buffer, position++, (byte) value);
+            UnsafeUtils.putByte(buffer, position++, (byte) value);
             return;
         }
-        UnsafeUtil.putByte(buffer, position++, (byte) (value | 0x80));
+        UnsafeUtils.putByte(buffer, position++, (byte) (value | 0x80));
         value >>>= 7;
-        UnsafeUtil.putByte(buffer, position++, (byte) value);
+        UnsafeUtils.putByte(buffer, position++, (byte) value);
     }
 
     public void writeLong(long value) {
         ensureCapacity(MAX_LONG_SIZE);
         while (true) {
             if ((value & ~0x7FL) == 0) {
-                UnsafeUtil.putByte(buffer, position++, (byte) value);
+                UnsafeUtils.putByte(buffer, position++, (byte) value);
                 return;
             } else {
-                UnsafeUtil.putByte(buffer, position++, (byte) (((int) value & 0x7F) | 0x80));
+                UnsafeUtils.putByte(buffer, position++, (byte) (((int) value & 0x7F) | 0x80));
                 value >>>= 7;
             }
         }
@@ -239,13 +239,13 @@ public class CompactedRowWriter {
 
     private void writeFloat(float value) {
         ensureCapacity(4);
-        UnsafeUtil.putFloat(buffer, position, value);
+        UnsafeUtils.putFloat(buffer, position, value);
         position += 4;
     }
 
     private void writeDouble(double value) {
         ensureCapacity(8);
-        UnsafeUtil.putDouble(buffer, position, value);
+        UnsafeUtils.putDouble(buffer, position, value);
         position += 8;
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/row/encode/ValueEncoder.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/row/encode/ValueEncoder.java
@@ -17,7 +17,7 @@
 package com.alibaba.fluss.row.encode;
 
 import com.alibaba.fluss.row.BinaryRow;
-import com.alibaba.fluss.utils.UnsafeUtil;
+import com.alibaba.fluss.utils.UnsafeUtils;
 
 /** An encoder to encode {@link BinaryRow} with a schema id as value to be stored in kv store. */
 public class ValueEncoder {
@@ -33,7 +33,7 @@ public class ValueEncoder {
      */
     public static byte[] encodeValue(short schemaId, BinaryRow row) {
         byte[] values = new byte[SCHEMA_ID_LENGTH + row.getSizeInBytes()];
-        UnsafeUtil.putShort(values, 0, schemaId);
+        UnsafeUtils.putShort(values, 0, schemaId);
         row.copyTo(values, SCHEMA_ID_LENGTH);
         return values;
     }

--- a/fluss-common/src/main/java/com/alibaba/fluss/row/indexed/IndexedRowWriter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/row/indexed/IndexedRowWriter.java
@@ -27,7 +27,7 @@ import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
 import com.alibaba.fluss.types.DataType;
 import com.alibaba.fluss.types.RowType;
-import com.alibaba.fluss.utils.UnsafeUtil;
+import com.alibaba.fluss.utils.UnsafeUtils;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -77,46 +77,46 @@ public class IndexedRowWriter extends OutputStream implements MemorySegmentWrita
 
     /** Default not null. */
     public void setNullAt(int pos) {
-        UnsafeUtil.bitSet(buffer, 0, pos);
+        UnsafeUtils.bitSet(buffer, 0, pos);
     }
 
     public void writeBoolean(boolean value) {
         ensureCapacity(1);
-        UnsafeUtil.putBoolean(buffer, position++, value);
+        UnsafeUtils.putBoolean(buffer, position++, value);
     }
 
     public void writeByte(byte value) {
         ensureCapacity(1);
-        UnsafeUtil.putByte(buffer, position++, value);
+        UnsafeUtils.putByte(buffer, position++, value);
     }
 
     public void writeShort(short value) {
         ensureCapacity(2);
-        UnsafeUtil.putShort(buffer, position, value);
+        UnsafeUtils.putShort(buffer, position, value);
         position += 2;
     }
 
     public void writeInt(int value) {
         ensureCapacity(4);
-        UnsafeUtil.putInt(buffer, position, value);
+        UnsafeUtils.putInt(buffer, position, value);
         position += 4;
     }
 
     public void writeLong(long value) {
         ensureCapacity(8);
-        UnsafeUtil.putLong(buffer, position, value);
+        UnsafeUtils.putLong(buffer, position, value);
         position += 8;
     }
 
     public void writeFloat(float value) {
         ensureCapacity(4);
-        UnsafeUtil.putFloat(buffer, position, value);
+        UnsafeUtils.putFloat(buffer, position, value);
         position += 4;
     }
 
     public void writeDouble(double value) {
         ensureCapacity(8);
-        UnsafeUtil.putDouble(buffer, position, value);
+        UnsafeUtils.putDouble(buffer, position, value);
         position += 8;
     }
 
@@ -242,7 +242,7 @@ public class IndexedRowWriter extends OutputStream implements MemorySegmentWrita
         if (variableLengthPosition - nullBitsSizeInBytes + 4 > variableColumnLengthListInBytes) {
             throw new IllegalArgumentException();
         }
-        UnsafeUtil.putInt(buffer, variableLengthPosition, length);
+        UnsafeUtils.putInt(buffer, variableLengthPosition, length);
         variableLengthPosition += 4;
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/CollectionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/CollectionUtils.java
@@ -19,7 +19,7 @@ package com.alibaba.fluss.utils;
 import java.util.HashMap;
 
 /** Simple utility to work with Java collections. */
-public class CollectionUtil {
+public class CollectionUtils {
     /** The default load factor for hash maps create with this util class. */
     static final float HASH_MAP_DEFAULT_LOAD_FACTOR = 0.75f;
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/InstantiationUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/InstantiationUtils.java
@@ -38,7 +38,7 @@ import java.util.HashMap;
 
 /** Utility class to create instances from class objects and checking failure reasons. */
 @Internal
-public class InstantiationUtil {
+public class InstantiationUtils {
 
     /** A custom ObjectInputStream that can load classes using a specific ClassLoader. */
     public static class ClassLoaderObjectInputStream extends ObjectInputStream {
@@ -112,7 +112,7 @@ public class InstantiationUtil {
         // ------------------------------------------------
 
         private static final HashMap<String, Class<?>> primitiveClasses =
-                CollectionUtil.newHashMapWithExpectedSize(9);
+                CollectionUtils.newHashMapWithExpectedSize(9);
 
         static {
             primitiveClasses.put("boolean", boolean.class);
@@ -157,7 +157,7 @@ public class InstantiationUtil {
         final ClassLoader old = Thread.currentThread().getContextClassLoader();
         // not using resource try to avoid AutoClosable's close() on the given stream
         try {
-            ObjectInputStream oois = new InstantiationUtil.ClassLoaderObjectInputStream(in, cl);
+            ObjectInputStream oois = new InstantiationUtils.ClassLoaderObjectInputStream(in, cl);
             Thread.currentThread().setContextClassLoader(cl);
             return (T) oois.readObject();
         } finally {
@@ -335,7 +335,7 @@ public class InstantiationUtil {
     // --------------------------------------------------------------------------------------------
 
     /** Private constructor to prevent instantiation. */
-    private InstantiationUtil() {
+    private InstantiationUtils() {
         throw new RuntimeException();
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/SerializedValue.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/SerializedValue.java
@@ -58,12 +58,12 @@ public class SerializedValue<T> implements java.io.Serializable {
      */
     public SerializedValue(T value) throws IOException {
         Preconditions.checkNotNull(value, "Value must not be null");
-        this.serializedData = InstantiationUtil.serializeObject(value);
+        this.serializedData = InstantiationUtils.serializeObject(value);
     }
 
     public T deserializeValue(ClassLoader loader) throws IOException, ClassNotFoundException {
         Preconditions.checkNotNull(loader, "No classloader has been passed");
-        return InstantiationUtil.deserializeObject(serializedData, loader);
+        return InstantiationUtils.deserializeObject(serializedData, loader);
     }
 
     /**

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/UnsafeUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/UnsafeUtils.java
@@ -23,7 +23,7 @@ import com.alibaba.fluss.memory.MemoryUtils;
  * additional information regarding copyright ownership. */
 
 /** Utility class for working with unsafe operations. */
-public class UnsafeUtil {
+public class UnsafeUtils {
 
     public static final long BYTE_ARRAY_BASE_OFFSET =
             MemoryUtils.UNSAFE.arrayBaseOffset(byte[].class);

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/WrappingProxyUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/WrappingProxyUtils.java
@@ -24,11 +24,11 @@ import static java.lang.String.format;
 
 /** Utilities for working with {@link WrappingProxy}. */
 @Internal
-public final class WrappingProxyUtil {
+public final class WrappingProxyUtils {
 
     static final int SAFETY_NET_MAX_ITERATIONS = 128;
 
-    private WrappingProxyUtil() {
+    private WrappingProxyUtils() {
         throw new AssertionError();
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/json/JsonSerdeUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/json/JsonSerdeUtils.java
@@ -28,7 +28,7 @@ import java.io.UncheckedIOException;
 
 /** A utility class that provide abilities for JSON serialization and deserialization. */
 @Internal
-public class JsonSerdeUtil {
+public class JsonSerdeUtils {
 
     /**
      * Object mapper shared instance to serialize and deserialize the plan. Note that creating and
@@ -72,5 +72,5 @@ public class JsonSerdeUtil {
         }
     }
 
-    private JsonSerdeUtil() {}
+    private JsonSerdeUtils() {}
 }

--- a/fluss-common/src/test/java/com/alibaba/fluss/fs/FileSystemTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/fs/FileSystemTest.java
@@ -20,7 +20,7 @@ import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.fs.local.LocalFileSystem;
 import com.alibaba.fluss.plugin.PluginManager;
 import com.alibaba.fluss.utils.WrappingProxy;
-import com.alibaba.fluss.utils.WrappingProxyUtil;
+import com.alibaba.fluss.utils.WrappingProxyUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -162,7 +162,7 @@ class FileSystemTest {
 
         if (fileSystem instanceof WrappingProxy) {
             //noinspection unchecked
-            return WrappingProxyUtil.stripProxy((WrappingProxy<FileSystem>) fileSystem);
+            return WrappingProxyUtils.stripProxy((WrappingProxy<FileSystem>) fileSystem);
         }
 
         return fileSystem;

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/InstantiationUtilTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/InstantiationUtilTest.java
@@ -24,17 +24,17 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link com.alibaba.fluss.utils.InstantiationUtil}. */
+/** Test for {@link InstantiationUtils}. */
 public class InstantiationUtilTest {
 
     @Test
     void testSerDeserializeObject() throws Exception {
         TestClass testClass = new TestClass(1, "f2");
-        byte[] bytes = InstantiationUtil.serializeObject(testClass);
+        byte[] bytes = InstantiationUtils.serializeObject(testClass);
         // deserialize with classloader
         try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes)) {
             TestClass deserializedTestClass =
-                    InstantiationUtil.deserializeObject(
+                    InstantiationUtils.deserializeObject(
                             byteArrayInputStream, this.getClass().getClassLoader());
             assertThat(deserializedTestClass).isEqualTo(testClass);
         }
@@ -42,7 +42,7 @@ public class InstantiationUtilTest {
         // deserialize without classloader
         try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes)) {
             TestClass deserializedTestClass =
-                    InstantiationUtil.deserializeObject(byteArrayInputStream, null);
+                    InstantiationUtils.deserializeObject(byteArrayInputStream, null);
             assertThat(deserializedTestClass).isEqualTo(testClass);
         }
     }
@@ -50,17 +50,17 @@ public class InstantiationUtilTest {
     @Test
     void testClone() throws Exception {
         // test clone null
-        Object clonedObj = InstantiationUtil.clone(null);
+        Object clonedObj = InstantiationUtils.clone(null);
         assertThat(clonedObj).isNull();
         // test clone null with classloader
-        clonedObj = InstantiationUtil.clone(null, Thread.currentThread().getContextClassLoader());
+        clonedObj = InstantiationUtils.clone(null, Thread.currentThread().getContextClassLoader());
         assertThat(clonedObj).isNull();
         // test clone a string
         String testString = "testString";
-        assertThat(InstantiationUtil.clone(testString)).isEqualTo(testString);
+        assertThat(InstantiationUtils.clone(testString)).isEqualTo(testString);
         // test clone a string with classloader
         assertThat(
-                        InstantiationUtil.clone(
+                        InstantiationUtils.clone(
                                 testString, Thread.currentThread().getContextClassLoader()))
                 .isEqualTo(testString);
     }

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/SerializedValueTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/SerializedValueTest.java
@@ -31,7 +31,7 @@ class SerializedValueTest {
         // get the bytes of serializedValue
         byte[] serializedValueBytes = serializedValue.getByteArray();
         // verify the serializedBytes
-        assertThat(serializedValueBytes).isEqualTo(InstantiationUtil.serializeObject(value));
+        assertThat(serializedValueBytes).isEqualTo(InstantiationUtils.serializeObject(value));
 
         String deserializeValue =
                 (String)

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/WrappingProxyUtilTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/WrappingProxyUtilTest.java
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-/** Tests for {@link com.alibaba.fluss.utils.WrappingProxyUtil}. */
+/** Tests for {@link WrappingProxyUtils}. */
 public class WrappingProxyUtilTest {
 
     @Test
     void testThrowsExceptionIfTooManyProxies() {
         try {
-            WrappingProxyUtil.stripProxy(
-                    new SelfWrappingProxy(WrappingProxyUtil.SAFETY_NET_MAX_ITERATIONS));
+            WrappingProxyUtils.stripProxy(
+                    new SelfWrappingProxy(WrappingProxyUtils.SAFETY_NET_MAX_ITERATIONS));
             fail("Expected exception not thrown");
         } catch (final IllegalArgumentException e) {
             assertThat(e.getMessage()).contains("Are there loops in the object graph?");
@@ -38,8 +38,8 @@ public class WrappingProxyUtilTest {
     @Test
     public void testStripsAllProxies() {
         final SelfWrappingProxy wrappingProxy =
-                new SelfWrappingProxy(WrappingProxyUtil.SAFETY_NET_MAX_ITERATIONS - 1);
-        assertThat(WrappingProxyUtil.stripProxy(wrappingProxy))
+                new SelfWrappingProxy(WrappingProxyUtils.SAFETY_NET_MAX_ITERATIONS - 1);
+        assertThat(WrappingProxyUtils.stripProxy(wrappingProxy))
                 .isNotInstanceOf(SelfWrappingProxy.class);
     }
 

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/json/JsonSerdeTestBase.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/json/JsonSerdeTestBase.java
@@ -57,14 +57,14 @@ public abstract class JsonSerdeTestBase<T> {
                 expectedJsons.length);
         for (int i = 0; i < testObjects.length; i++) {
             T value = testObjects[i];
-            final byte[] json = JsonSerdeUtil.writeValueAsBytes(value, serializer);
-            JsonNode jsonNode = JsonSerdeUtil.OBJECT_MAPPER_INSTANCE.readTree(json);
+            final byte[] json = JsonSerdeUtils.writeValueAsBytes(value, serializer);
+            JsonNode jsonNode = JsonSerdeUtils.OBJECT_MAPPER_INSTANCE.readTree(json);
             checkFieldNameLowerCase(jsonNode);
 
             // assert the compatibility of json string while the json serde evolving
             assertThat(new String(json, StandardCharsets.UTF_8)).isEqualTo(expectedJsons[i]);
 
-            final T actual = JsonSerdeUtil.readValue(json, deserializer);
+            final T actual = JsonSerdeUtils.readValue(json, deserializer);
             assertEquals(actual, value);
         }
     }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
@@ -22,7 +22,7 @@ import com.alibaba.fluss.client.admin.Admin;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.connector.flink.lakehouse.LakeCatalog;
-import com.alibaba.fluss.connector.flink.utils.CatalogExceptionUtil;
+import com.alibaba.fluss.connector.flink.utils.CatalogExceptionUtils;
 import com.alibaba.fluss.connector.flink.utils.FlinkConversions;
 import com.alibaba.fluss.exception.FlussRuntimeException;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -166,7 +166,7 @@ public class FlinkCatalog implements Catalog {
             admin.createDatabase(databaseName, ignoreIfExists).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isDatabaseAlreadyExist(t)) {
+            if (CatalogExceptionUtils.isDatabaseAlreadyExist(t)) {
                 throw new DatabaseAlreadyExistException(getName(), databaseName);
             } else {
                 throw new CatalogException(
@@ -184,9 +184,9 @@ public class FlinkCatalog implements Catalog {
             admin.deleteDatabase(databaseName, ignoreIfNotExists, cascade).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isDatabaseNotExist(t)) {
+            if (CatalogExceptionUtils.isDatabaseNotExist(t)) {
                 throw new DatabaseNotExistException(getName(), databaseName);
-            } else if (CatalogExceptionUtil.isDatabaseNotEmpty(t)) {
+            } else if (CatalogExceptionUtils.isDatabaseNotEmpty(t)) {
                 throw new DatabaseNotEmptyException(getName(), databaseName);
             } else {
                 throw new CatalogException(
@@ -209,7 +209,7 @@ public class FlinkCatalog implements Catalog {
             return admin.listTables(databaseName).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isDatabaseNotExist(t)) {
+            if (CatalogExceptionUtils.isDatabaseNotExist(t)) {
                 throw new DatabaseNotExistException(getName(), databaseName);
             }
             throw new CatalogException(
@@ -263,7 +263,7 @@ public class FlinkCatalog implements Catalog {
             return catalogTable.copy(newOptions);
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isTableNotExist(t)) {
+            if (CatalogExceptionUtils.isTableNotExist(t)) {
                 throw new TableNotExistException(getName(), objectPath);
             } else {
                 throw new CatalogException(
@@ -307,7 +307,7 @@ public class FlinkCatalog implements Catalog {
             admin.deleteTable(tablePath, ignoreIfNotExists).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isTableNotExist(t)) {
+            if (CatalogExceptionUtils.isTableNotExist(t)) {
                 throw new TableNotExistException(getName(), objectPath);
             } else {
                 throw new CatalogException(
@@ -339,9 +339,9 @@ public class FlinkCatalog implements Catalog {
             admin.createTable(tablePath, tableDescriptor, ignoreIfExist).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (CatalogExceptionUtil.isDatabaseNotExist(t)) {
+            if (CatalogExceptionUtils.isDatabaseNotExist(t)) {
                 throw new DatabaseNotExistException(getName(), objectPath.getDatabaseName());
-            } else if (CatalogExceptionUtil.isTableAlreadyExist(t)) {
+            } else if (CatalogExceptionUtils.isTableAlreadyExist(t)) {
                 throw new TableAlreadyExistException(getName(), objectPath);
             } else {
                 throw new CatalogException(

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -22,7 +22,7 @@ import com.alibaba.fluss.connector.flink.FlinkConnectorOptions;
 import com.alibaba.fluss.connector.flink.lakehouse.LakeTableFactory;
 import com.alibaba.fluss.connector.flink.sink.FlinkTableSink;
 import com.alibaba.fluss.connector.flink.source.FlinkTableSource;
-import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtil;
+import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.metadata.TablePath;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
@@ -78,13 +78,13 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                         == RuntimeExecutionMode.STREAMING;
 
         final ReadableConfig tableOptions = helper.getOptions();
-        FlinkConnectorOptionsUtil.validateTableSourceOptions(tableOptions);
+        FlinkConnectorOptionsUtils.validateTableSourceOptions(tableOptions);
 
         ZoneId timeZone =
-                FlinkConnectorOptionsUtil.getLocalTimeZone(
+                FlinkConnectorOptionsUtils.getLocalTimeZone(
                         context.getConfiguration().get(TableConfigOptions.LOCAL_TIME_ZONE));
-        final FlinkConnectorOptionsUtil.StartupOptions startupOptions =
-                FlinkConnectorOptionsUtil.getStartupOptions(tableOptions, timeZone);
+        final FlinkConnectorOptionsUtils.StartupOptions startupOptions =
+                FlinkConnectorOptionsUtils.getStartupOptions(tableOptions, timeZone);
 
         ResolvedSchema resolvedSchema = context.getCatalogTable().getResolvedSchema();
         ResolvedCatalogTable resolvedCatalogTable = context.getCatalogTable();

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -22,7 +22,7 @@ import com.alibaba.fluss.connector.flink.source.enumerator.initializer.OffsetsIn
 import com.alibaba.fluss.connector.flink.source.lookup.FlinkAsyncLookupFunction;
 import com.alibaba.fluss.connector.flink.source.lookup.FlinkLookupFunction;
 import com.alibaba.fluss.connector.flink.source.lookup.LookupNormalizer;
-import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtil;
+import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.connector.flink.utils.FlinkConversions;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.ValueConversion;
@@ -92,7 +92,7 @@ public class FlinkTableSource
     private final int[] primaryKeyIndexes;
     private final List<String> partitionKeys;
     private final boolean streaming;
-    private final FlinkConnectorOptionsUtil.StartupOptions startupOptions;
+    private final FlinkConnectorOptionsUtils.StartupOptions startupOptions;
 
     // options for lookup source
     private final int lookupMaxRetryTimes;
@@ -125,7 +125,7 @@ public class FlinkTableSource
             int[] primaryKeyIndexes,
             List<String> partitionKeys,
             boolean streaming,
-            FlinkConnectorOptionsUtil.StartupOptions startupOptions,
+            FlinkConnectorOptionsUtils.StartupOptions startupOptions,
             int lookupMaxRetryTimes,
             boolean lookupAsync,
             @Nullable LookupCache cache,

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/CatalogExceptionUtils.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/CatalogExceptionUtils.java
@@ -23,9 +23,9 @@ import com.alibaba.fluss.exception.TableAlreadyExistException;
 import com.alibaba.fluss.exception.TableNotExistException;
 
 /** Utility class for catalog exceptions. */
-public class CatalogExceptionUtil {
+public class CatalogExceptionUtils {
 
-    private CatalogExceptionUtil() {}
+    private CatalogExceptionUtils() {}
 
     public static boolean isDatabaseNotExist(Throwable throwable) {
         return throwable instanceof DatabaseNotExistException;

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/CatalogPropertiesUtils.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/CatalogPropertiesUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.connector.flink.catalog;
+package com.alibaba.fluss.connector.flink.utils;
 
 import org.apache.flink.table.api.Schema;
 import org.apache.flink.table.api.TableException;
@@ -44,7 +44,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *
  * <p>Copied from Flink.
  */
-public class CatalogPropertiesUtil {
+public class CatalogPropertiesUtils {
 
     // --------------------------------------------------------------------------------------------
     // Helper methods and constants
@@ -170,7 +170,7 @@ public class CatalogPropertiesUtil {
     private static String[] serializeColumnDataTypes(List<Column> columns) {
         return columns.stream()
                 .map(Column::getDataType)
-                .map(CatalogPropertiesUtil::serializeDataType)
+                .map(CatalogPropertiesUtils::serializeDataType)
                 .toArray(String[]::new);
     }
 
@@ -374,5 +374,5 @@ public class CatalogPropertiesUtil {
         }
     }
 
-    private CatalogPropertiesUtil() {}
+    private CatalogPropertiesUtils() {}
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtils.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtils.java
@@ -32,7 +32,7 @@ import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.SCAN_START
 import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.ScanStartupMode.TIMESTAMP;
 
 /** Utility class for {@link FlinkConnectorOptions}. */
-public class FlinkConnectorOptionsUtil {
+public class FlinkConnectorOptionsUtils {
 
     private static final DateTimeFormatter DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
@@ -22,7 +22,6 @@ import com.alibaba.fluss.config.FlussConfigUtils;
 import com.alibaba.fluss.config.MemorySize;
 import com.alibaba.fluss.config.Password;
 import com.alibaba.fluss.connector.flink.FlinkConnectorOptions;
-import com.alibaba.fluss.connector.flink.catalog.CatalogPropertiesUtil;
 import com.alibaba.fluss.connector.flink.catalog.FlinkCatalogFactory;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -109,12 +108,12 @@ public class FlinkConversions {
                         .collect(Collectors.toList());
         int columnCount =
                 physicalColumns.size()
-                        + CatalogPropertiesUtil.nonPhysicalColumnsCount(
+                        + CatalogPropertiesUtils.nonPhysicalColumnsCount(
                                 newOptions, physicalColumns);
 
         int physicalColumnIndex = 0;
         for (int i = 0; i < columnCount; i++) {
-            String optionalName = newOptions.get(CatalogPropertiesUtil.columnKey(i));
+            String optionalName = newOptions.get(CatalogPropertiesUtils.columnKey(i));
             if (optionalName == null) {
                 // build physical column from table row field
                 Schema.Column column = schema.getColumns().get(physicalColumnIndex++);
@@ -125,7 +124,7 @@ public class FlinkConversions {
                 }
             } else {
                 // build non-physical column from options
-                CatalogPropertiesUtil.deserializeComputedColumn(newOptions, i, schemaBuilder);
+                CatalogPropertiesUtils.deserializeComputedColumn(newOptions, i, schemaBuilder);
             }
         }
 
@@ -145,13 +144,13 @@ public class FlinkConversions {
         }
 
         // deserialize watermark
-        CatalogPropertiesUtil.deserializeWatermark(newOptions, schemaBuilder);
+        CatalogPropertiesUtils.deserializeWatermark(newOptions, schemaBuilder);
 
         return CatalogTable.of(
                 schemaBuilder.build(),
                 tableDescriptor.getComment().orElse(null),
                 tableDescriptor.getPartitionKeys(),
-                CatalogPropertiesUtil.deserializeOptions(newOptions));
+                CatalogPropertiesUtils.deserializeOptions(newOptions));
     }
 
     /** Convert Flink's table to Fluss's table. */
@@ -201,9 +200,9 @@ public class FlinkConversions {
                         });
 
         Map<String, String> customProperties = flinkTableConf.toMap();
-        CatalogPropertiesUtil.serializeComputedColumns(
+        CatalogPropertiesUtils.serializeComputedColumns(
                 customProperties, resolvedSchema.getColumns());
-        CatalogPropertiesUtil.serializeWatermarkSpecs(
+        CatalogPropertiesUtils.serializeWatermarkSpecs(
                 customProperties, catalogTable.getResolvedSchema().getWatermarkSpecs());
 
         String comment = catalogTable.getComment();

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtilTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtilTest.java
@@ -22,11 +22,11 @@ import org.junit.jupiter.api.Test;
 import java.time.ZoneId;
 
 import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.SCAN_STARTUP_TIMESTAMP;
-import static com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtil.parseTimestamp;
+import static com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils.parseTimestamp;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test for {@link com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtil}. */
+/** Test for {@link FlinkConnectorOptionsUtils}. */
 class FlinkConnectorOptionsUtilTest {
     @Test
     void testParseTimestamp() {

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiMethod.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiMethod.java
@@ -19,7 +19,7 @@ package com.alibaba.fluss.rpc.protocol;
 import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.rpc.messages.ApiMessage;
 import com.alibaba.fluss.shaded.guava32.com.google.common.collect.ImmutableList;
-import com.alibaba.fluss.utils.InstantiationUtil;
+import com.alibaba.fluss.utils.InstantiationUtils;
 
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -115,7 +115,7 @@ public class ApiMethod {
 
         @Override
         public ApiMessage get() {
-            return (ApiMessage) InstantiationUtil.instantiate(messageClass);
+            return (ApiMessage) InstantiationUtils.instantiate(messageClass);
         }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -36,7 +36,7 @@ import java.util.LinkedList;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.alibaba.fluss.utils.UnsafeUtil.BYTE_ARRAY_BASE_OFFSET;
+import static com.alibaba.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
 
 /**
  * An in-memory pre-write buffer for putting kv records. The kv records will first be put into the

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/CompletedSnapshotJsonSerde.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/CompletedSnapshotJsonSerde.java
@@ -21,7 +21,7 @@ import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import com.alibaba.fluss.utils.json.JsonDeserializer;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.JsonSerializer;
 
 import java.io.IOException;
@@ -185,11 +185,11 @@ public class CompletedSnapshotJsonSerde
 
     /** Serialize the {@link CompletedSnapshot} to json bytes. */
     public static byte[] toJson(CompletedSnapshot completedSnapshot) {
-        return JsonSerdeUtil.writeValueAsBytes(completedSnapshot, INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(completedSnapshot, INSTANCE);
     }
 
     /** Deserialize the json bytes to {@link CompletedSnapshot}. */
     public static CompletedSnapshot fromJson(byte[] json) {
-        return JsonSerdeUtil.readValue(json, INSTANCE);
+        return JsonSerdeUtils.readValue(json, INSTANCE);
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
@@ -119,7 +119,10 @@ public class PeriodicSnapshotManager implements Closeable {
         this.periodicExecutor = periodicExecutor;
         this.guardedExecutor = guardedExecutor;
         this.asyncOperationsThreadPool = asyncOperationsThreadPool;
-        this.initialDelay = periodicSnapshotDelay > 0 ? MathUtils.murmurHash(tableBucket.hashCode()) % periodicSnapshotDelay : 0;
+        this.initialDelay =
+                periodicSnapshotDelay > 0
+                        ? MathUtils.murmurHash(tableBucket.hashCode()) % periodicSnapshotDelay
+                        : 0;
 
         registerMetrics(bucketMetricGroup);
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
@@ -24,7 +24,7 @@ import com.alibaba.fluss.record.LogRecordBatch;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import com.alibaba.fluss.utils.json.JsonDeserializer;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.JsonSerializer;
 
 import org.slf4j.Logger;
@@ -612,11 +612,11 @@ public class WriterStateManager {
         }
 
         private static WriterSnapshotMap fromJsonBytes(byte[] json) {
-            return JsonSerdeUtil.readValue(json, WriterSnapshotMapJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, WriterSnapshotMapJsonSerde.INSTANCE);
         }
 
         private byte[] toJsonBytes() {
-            return JsonSerdeUtil.writeValueAsBytes(this, WriterSnapshotMapJsonSerde.INSTANCE);
+            return JsonSerdeUtils.writeValueAsBytes(this, WriterSnapshotMapJsonSerde.INSTANCE);
         }
 
         @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManifestJsonSerde.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManifestJsonSerde.java
@@ -22,7 +22,7 @@ import com.alibaba.fluss.remote.RemoteLogSegment;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
 import com.alibaba.fluss.utils.json.JsonDeserializer;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 import com.alibaba.fluss.utils.json.JsonSerializer;
 
 import java.io.IOException;
@@ -134,10 +134,10 @@ public class RemoteLogManifestJsonSerde
     }
 
     public static RemoteLogManifest fromJson(byte[] json) {
-        return JsonSerdeUtil.readValue(json, INSTANCE);
+        return JsonSerdeUtils.readValue(json, INSTANCE);
     }
 
     public static byte[] toJson(RemoteLogManifest t) {
-        return JsonSerdeUtil.writeValueAsBytes(t, INSTANCE);
+        return JsonSerdeUtils.writeValueAsBytes(t, INSTANCE);
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ZkData.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ZkData.java
@@ -21,7 +21,7 @@ import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePartition;
 import com.alibaba.fluss.metadata.TablePath;
-import com.alibaba.fluss.utils.json.JsonSerdeUtil;
+import com.alibaba.fluss.utils.json.JsonSerdeUtils;
 
 import javax.annotation.Nullable;
 
@@ -100,12 +100,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(TableRegistration tableRegistration) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     tableRegistration, TableRegistrationJsonSerde.INSTANCE);
         }
 
         public static TableRegistration decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, TableRegistrationJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, TableRegistrationJsonSerde.INSTANCE);
         }
     }
 
@@ -246,12 +246,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(CoordinatorAddress coordinatorAddress) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     coordinatorAddress, CoordinatorAddressJsonSerde.INSTANCE);
         }
 
         public static CoordinatorAddress decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, CoordinatorAddressJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, CoordinatorAddressJsonSerde.INSTANCE);
         }
     }
 
@@ -292,12 +292,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(TabletServerRegistration tsRegistration) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     tsRegistration, TabletServerRegistrationJsonSerde.INSTANCE);
         }
 
         public static TabletServerRegistration decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, TabletServerRegistrationJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, TabletServerRegistrationJsonSerde.INSTANCE);
         }
     }
 
@@ -336,12 +336,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(TableAssignment tableAssignment) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     tableAssignment, TableAssignmentJsonSerde.INSTANCE);
         }
 
         public static TableAssignment decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, TableAssignmentJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, TableAssignmentJsonSerde.INSTANCE);
         }
     }
 
@@ -358,12 +358,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(PartitionAssignment tableAssignment) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     tableAssignment, PartitionAssignmentJsonSerde.INSTANCE);
         }
 
         public static PartitionAssignment decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, PartitionAssignmentJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, PartitionAssignmentJsonSerde.INSTANCE);
         }
     }
 
@@ -413,11 +413,11 @@ public final class ZkData {
         }
 
         public static byte[] encode(LeaderAndIsr leaderAndIsr) {
-            return JsonSerdeUtil.writeValueAsBytes(leaderAndIsr, LeaderAndIsrJsonSerde.INSTANCE);
+            return JsonSerdeUtils.writeValueAsBytes(leaderAndIsr, LeaderAndIsrJsonSerde.INSTANCE);
         }
 
         public static LeaderAndIsr decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, LeaderAndIsrJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, LeaderAndIsrJsonSerde.INSTANCE);
         }
     }
 
@@ -473,12 +473,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(BucketSnapshot bucketSnapshot) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     bucketSnapshot, BucketSnapshotJsonSerde.INSTANCE);
         }
 
         public static BucketSnapshot decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, BucketSnapshotJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, BucketSnapshotJsonSerde.INSTANCE);
         }
     }
 
@@ -511,12 +511,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(RemoteLogManifestHandle remoteLogManifestHandle) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     remoteLogManifestHandle, RemoteLogManifestHandleJsonSerde.INSTANCE);
         }
 
         public static RemoteLogManifestHandle decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, RemoteLogManifestHandleJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, RemoteLogManifestHandleJsonSerde.INSTANCE);
         }
     }
 
@@ -531,12 +531,12 @@ public final class ZkData {
         }
 
         public static byte[] encode(LakeTableSnapshot lakeTableSnapshot) {
-            return JsonSerdeUtil.writeValueAsBytes(
+            return JsonSerdeUtils.writeValueAsBytes(
                     lakeTableSnapshot, LakeTableSnapshotJsonSerde.INSTANCE);
         }
 
         public static LakeTableSnapshot decode(byte[] json) {
-            return JsonSerdeUtil.readValue(json, LakeTableSnapshotJsonSerde.INSTANCE);
+            return JsonSerdeUtils.readValue(json, LakeTableSnapshotJsonSerde.INSTANCE);
         }
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
@@ -138,13 +138,12 @@ class PeriodicSnapshotManagerTest {
     }
 
     private PeriodicSnapshotManager createSnapshotManager(
-        PeriodicSnapshotManager.SnapshotTarget target) {
+            PeriodicSnapshotManager.SnapshotTarget target) {
         return createSnapshotManager(periodicMaterializeDelay, target);
     }
 
     private PeriodicSnapshotManager createSnapshotManager(
-            long periodicMaterializeDelay,
-            PeriodicSnapshotManager.SnapshotTarget target) {
+            long periodicMaterializeDelay, PeriodicSnapshotManager.SnapshotTarget target) {
         return new PeriodicSnapshotManager(
                 tableBucket,
                 target,


### PR DESCRIPTION
[Improve] util class naming improvements

The naming of util classes in the project needs to be more consistent. Most are named xxUtils, while a few are named xxUtil. We should standardize the naming conventions for improved clarity.
