### PR TITLE
[docs]Download Flink and shell commands do not match, in the engine link/setting started page

### DIFF
--- a/website/docs/engine-flink/ddl.md
+++ b/website/docs/engine-flink/ddl.md
@@ -10,7 +10,7 @@ Fluss supports creating and managing tables through the Fluss Catalog.
 ```sql 
 CREATE CATALOG fluss_catalog WITH (
   'type' = 'fluss',
-  'bootstrap.servers' = 'fluss-server-1:9123',
+  'bootstrap.servers' = 'fluss-server-1:9123'
 );
 
 USE CATALOG fluss_catalog;

--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -36,9 +36,8 @@ Fluss only supports Apache Flink's Table API.
 Flink runs on all UNIX-like environments, i.e. Linux, Mac OS X, and Cygwin (for Windows).
 If you haven’t downloaded Flink, you can download [the binary release](https://flink.apache.org/downloads.html) of Flink, then extract the archive with the following command.
 ```shell
-tar -xzf fluss-0.5.0-bin.tgz
+tar -xzf flink-1.20.0-bin-scala_2.12.tgz
 ```
-
 - **Copy Fluss Connector Jar**
 
 Download [Fluss connector jar](/downloads#fluss-connector) and copy to the lib directory of your Flink home.


### PR DESCRIPTION
Download Flink and shell commands do not match

![5cb1f3282f8b35934ae96c82967e3e9](https://github.com/user-attachments/assets/192a7b31-69b5-412f-8514-f3ce42d0ba82)
