### PR TITLE
[tests] Fix FlinkConnectorOptionsUtilTest

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtilTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtilTest.java
@@ -28,21 +28,23 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtil}. */
 class FlinkConnectorOptionsUtilTest {
+    private final long expectedTimestamp = 1702156152000L;
+
     @Test
     void testParseTimestamp() {
         assertThat(
                         parseTimestamp(
-                                "1702134552000",
+                                "1702156152000",
                                 SCAN_STARTUP_TIMESTAMP.key(),
                                 ZoneId.systemDefault()))
-                .isEqualTo(1702134552000L);
+                .isEqualTo(expectedTimestamp);
 
         assertThat(
                         parseTimestamp(
                                 "2023-12-09 23:09:12",
                                 SCAN_STARTUP_TIMESTAMP.key(),
                                 ZoneId.systemDefault()))
-                .isEqualTo(1702134552000L);
+                .isEqualTo(expectedTimestamp);
 
         assertThatThrownBy(
                         () ->


### PR DESCRIPTION
Test was failing with:
```
org.opentest4j.AssertionFailedError: 
expected: 1702134552000L
 but was: 1702156152000L
Expected :1702134552000L
Actual   :1702156152000L
```