### PR TITLE
[connector] Fluss Connector support batch source.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridFilesReader.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridFilesReader.java
@@ -1,0 +1,253 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.scanner.snapshot;
+
+import com.alibaba.fluss.client.scanner.ScanRecord;
+import com.alibaba.fluss.client.scanner.log.LogScanner;
+import com.alibaba.fluss.client.scanner.log.ScanRecords;
+import com.alibaba.fluss.metadata.KvFormat;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.row.BinaryRow;
+import com.alibaba.fluss.row.BinaryString;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.row.TimestampLtz;
+import com.alibaba.fluss.row.TimestampNtz;
+import com.alibaba.fluss.row.compacted.CompactedRow;
+import com.alibaba.fluss.row.encode.KeyEncoder;
+import com.alibaba.fluss.row.encode.RowEncoder;
+import com.alibaba.fluss.row.encode.ValueEncoder;
+import com.alibaba.fluss.types.DataType;
+import com.alibaba.fluss.utils.IOUtils;
+
+import org.rocksdb.RocksDBException;
+
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+/**
+ * A reader to read kv snapshot files to {@link ScanRecord}s and merge a piece of log. It will
+ * return the {@link ScanRecord}s as an iterator.
+ */
+@NotThreadSafe
+public class HybridFilesReader extends SnapshotFilesReader {
+    private static final Duration POLL_TIMEOUT = Duration.ofMillis(10000L);
+
+    private final short schemaId;
+    private final KeyEncoder keyEncoder;
+    private final RowEncoder rowEncoder;
+    private final KvFormat kvFormat;
+    private final DataType[] fieldTypes;
+    private final long startingOffset;
+    private final long stoppingOffset;
+    private final TableBucket tableBucket;
+    private final LogScanner logScanner;
+
+    // key is index of a projected field in the whole table, value is index of the projected field
+    // in whole project fields
+    private final Map<Integer, Integer> logProjectedFieldSet;
+
+    InternalRow.FieldGetter[] logFieldGetters;
+
+    public HybridFilesReader(
+            KvFormat kvFormat,
+            Path rocksDbPath,
+            short schemaId,
+            Schema tableSchema,
+            @Nullable int[] targetProjectedFields,
+            @Nullable int[] logProjectedFields,
+            long startingOffset,
+            long stoppingOffset,
+            TableBucket tableBucket,
+            LogScanner logScanner) {
+        super(kvFormat, rocksDbPath, tableSchema, targetProjectedFields);
+        this.schemaId = schemaId;
+        this.keyEncoder =
+                new KeyEncoder(tableSchema.toRowType(), tableSchema.getPrimaryKeyIndexes());
+        DataType[] dataTypes = tableSchema.toRowType().getChildren().toArray(new DataType[0]);
+        this.rowEncoder = RowEncoder.create(kvFormat, dataTypes);
+        this.kvFormat = kvFormat;
+        this.fieldTypes = dataTypes;
+        this.startingOffset = startingOffset;
+        this.stoppingOffset = stoppingOffset;
+        this.tableBucket = tableBucket;
+        this.logScanner = logScanner;
+
+        if (logProjectedFields == null) {
+            logProjectedFields = IntStream.range(0, dataTypes.length).toArray();
+        }
+
+        this.logProjectedFieldSet = new HashMap<>();
+        for (int i = 0; i < logProjectedFields.length; i++) {
+            logProjectedFieldSet.put(logProjectedFields[i], i);
+        }
+
+        logFieldGetters = new InternalRow.FieldGetter[logProjectedFields.length];
+        for (int i = 0; i < logProjectedFields.length; i++) {
+            DataType fieldDataType = dataTypes[logProjectedFields[i]];
+            logFieldGetters[i] = InternalRow.createFieldGetter(fieldDataType, i);
+        }
+    }
+
+    /** Override init to subscribe and apply logs before init iterator. */
+    @Override
+    public void init() throws IOException {
+        try {
+            initRocksDB(rocksDbPath, false);
+            subscribeAndApplyLogs();
+            initRocksIterator();
+        } catch (Throwable t) {
+            releaseSnapshot();
+            // If anything goes wrong, clean up our stuff. If things went smoothly the
+            // merging iterator is now responsible for closing the resources
+            IOUtils.closeQuietly(closeableRegistry);
+            throw new IOException("Error creating RocksDB snapshot reader.", t);
+        }
+    }
+
+    private void subscribeAndApplyLogs() throws RocksDBException {
+        if (startingOffset >= stoppingOffset || stoppingOffset == 0) {
+            return;
+        }
+
+        if (tableBucket.getPartitionId() != null) {
+            logScanner.subscribe(
+                    tableBucket.getPartitionId(), tableBucket.getBucket(), startingOffset);
+        } else {
+            logScanner.subscribe(tableBucket.getBucket(), startingOffset);
+        }
+
+        boolean readEnd = false;
+        do {
+            ScanRecords scanRecords = logScanner.poll(POLL_TIMEOUT);
+            for (ScanRecord scanRecord : scanRecords) {
+                // apply log to snapshot.
+                if (scanRecord.getOffset() <= stoppingOffset - 1) {
+                    applyLogs(scanRecord);
+                }
+                if (scanRecord.getOffset() >= stoppingOffset - 1) {
+                    readEnd = true;
+                    break;
+                }
+            }
+
+        } while (!readEnd);
+    }
+
+    private void applyLogs(ScanRecord scanRecord) throws RocksDBException {
+        BinaryRow row = castProjectRowToEntireRow(scanRecord.getRow());
+        byte[] key = keyEncoder.encode(row);
+        switch (scanRecord.getRowKind()) {
+            case APPEND_ONLY:
+                throw new UnsupportedOperationException(
+                        "Hybrid File Reader can not apply append only logs.");
+            case INSERT:
+            case UPDATE_AFTER:
+                byte[] value = ValueEncoder.encodeValue(schemaId, row);
+                db.put(key, value);
+                break;
+            case DELETE:
+            case UPDATE_BEFORE:
+                db.delete(key);
+        }
+    }
+
+    /**
+     * The row of log is projection result while the row of snapshot is entire row, thus need to put
+     * a placeholder value at un-projection indexes.
+     */
+    private BinaryRow castProjectRowToEntireRow(InternalRow row) {
+        if (KvFormat.COMPACTED.equals(kvFormat)) {
+            return castToAnEntireCompactedRow(row);
+        } else {
+            return castToAnEntireIndexedRow(row);
+        }
+    }
+
+    private BinaryRow castToAnEntireIndexedRow(InternalRow row) {
+        rowEncoder.startNewRow();
+        for (Integer projectField : logProjectedFieldSet.keySet()) {
+            rowEncoder.encodeField(
+                    projectField,
+                    logFieldGetters[logProjectedFieldSet.get(projectField)].getFieldOrNull(row));
+        }
+        return rowEncoder.finishRow();
+    }
+
+    private BinaryRow castToAnEntireCompactedRow(InternalRow row) {
+        if (row instanceof CompactedRow) {
+            return (CompactedRow) row;
+        }
+        rowEncoder.startNewRow();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            if (logProjectedFieldSet.containsKey(i)) {
+                rowEncoder.encodeField(
+                        i, logFieldGetters[logProjectedFieldSet.get(i)].getFieldOrNull(row));
+            } else {
+                // When use ProjectedRow to read projection columns from compacted row in rocksdb,
+                // deserialize the entire row at first. Thus, must put into placeholder value though
+                // it is no use later, nor un-projection columns maybe out of bound.
+                rowEncoder.encodeField(i, getPlaceHolderValueOfCompactedRow(fieldTypes[i]));
+            }
+        }
+        return rowEncoder.finishRow();
+    }
+
+    private static Object getPlaceHolderValueOfCompactedRow(DataType fieldType) {
+        if (fieldType.isNullable()) {
+            return null;
+        }
+
+        switch (fieldType.getTypeRoot()) {
+            case CHAR:
+            case STRING:
+                return BinaryString.blankString(1);
+            case BOOLEAN:
+                return false;
+            case BINARY:
+            case BYTES:
+                return new byte[0];
+            case DECIMAL:
+                return BigDecimal.ZERO;
+            case TINYINT:
+            case SMALLINT:
+            case INTEGER:
+            case DATE:
+            case TIME_WITHOUT_TIME_ZONE:
+            case BIGINT:
+            case FLOAT:
+            case DOUBLE:
+                return 0;
+            case TIMESTAMP_WITHOUT_TIME_ZONE:
+                return TimestampNtz.now();
+            case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+                return TimestampLtz.fromInstant(Instant.MIN);
+            default:
+                throw new IllegalArgumentException(
+                        "Unsupported type for CompactedRow: " + fieldType);
+        }
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridScan.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridScan.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.scanner.snapshot;
+
+import com.alibaba.fluss.annotation.PublicEvolving;
+import com.alibaba.fluss.fs.FsPathAndFileName;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableBucket;
+
+import javax.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * A class to describe hybrid scan for a single bucket, which include the snapshot files and a piece
+ * of log.
+ *
+ * <p>It also contains the starting offset and ending offset comparing {@link SnapshotScan}
+ *
+ * @since 0.3
+ */
+@PublicEvolving
+public class HybridScan extends SnapshotScan {
+    private final long logStartingOffset;
+    private final long logStoppingOffset;
+
+    public HybridScan(
+            TableBucket tableBucket,
+            List<FsPathAndFileName> fsPathAndFileNames,
+            Schema tableSchema,
+            @Nullable int[] projectedFields,
+            long logStartingOffset,
+            long logStoppingOffset) {
+        super(tableBucket, fsPathAndFileNames, tableSchema, projectedFields);
+        this.logStartingOffset = logStartingOffset;
+        this.logStoppingOffset = logStoppingOffset;
+    }
+
+    public long getLogStartingOffset() {
+        return logStartingOffset;
+    }
+
+    public long getLogStoppingOffset() {
+        return logStoppingOffset;
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridScanner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/snapshot/HybridScanner.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.scanner.snapshot;
+
+import com.alibaba.fluss.client.scanner.RemoteFileDownloader;
+import com.alibaba.fluss.client.scanner.log.LogScanner;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.KvFormat;
+
+import javax.annotation.Nullable;
+
+/** A hybrid scanner to merge snapshot and bounded log. */
+public class HybridScanner extends SnapshotScanner {
+
+    private final byte schemaId;
+    private final LogScanner logScanner;
+    private final int[] logProjectedFields;
+
+    public HybridScanner(
+            Configuration conf,
+            KvFormat kvFormat,
+            RemoteFileDownloader remoteFileDownloader,
+            byte schemaId,
+            HybridScan hybridScan,
+            @Nullable int[] logProjectedFields,
+            LogScanner logScanner) {
+        super(conf, kvFormat, remoteFileDownloader, hybridScan);
+        this.logScanner = logScanner;
+        this.schemaId = schemaId;
+        this.logProjectedFields = logProjectedFields;
+    }
+
+    /**
+     * Override initReader to provide {@link HybridFilesReader} and subscribe and apply a piece of
+     * logs.
+     */
+    @Override
+    protected SnapshotFilesReader createSnapshotReader() {
+        return new HybridFilesReader(
+                kvFormat,
+                snapshotLocalDirectory,
+                schemaId,
+                snapshotScan.getTableSchema(),
+                snapshotScan.getProjectedFields(),
+                logProjectedFields,
+                ((HybridScan) snapshotScan).getLogStartingOffset(),
+                ((HybridScan) snapshotScan).getLogStoppingOffset(),
+                snapshotScan.getTableBucket(),
+                logScanner);
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
@@ -21,6 +21,8 @@ import com.alibaba.fluss.client.Connection;
 import com.alibaba.fluss.client.scanner.ScanRecord;
 import com.alibaba.fluss.client.scanner.log.LogScan;
 import com.alibaba.fluss.client.scanner.log.LogScanner;
+import com.alibaba.fluss.client.scanner.snapshot.HybridScan;
+import com.alibaba.fluss.client.scanner.snapshot.HybridScanner;
 import com.alibaba.fluss.client.scanner.snapshot.SnapshotScan;
 import com.alibaba.fluss.client.scanner.snapshot.SnapshotScanner;
 import com.alibaba.fluss.client.table.writer.AppendWriter;
@@ -112,4 +114,12 @@ public interface Table extends AutoCloseable {
      * @return the {@link SnapshotScanner} to scan data from this table.
      */
     SnapshotScanner getSnapshotScanner(SnapshotScan snapshotScan);
+
+    /**
+     * Get a {@link HybridScanner} to scan data from this table according to provided {@link
+     * HybridScan} and merge a piece of log.
+     *
+     * @return the {@link HybridScanner} to scan data from this table.
+     */
+    HybridScanner getHybridScanner(HybridScan hybridScan);
 }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/snapshot/HybridScannerITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/snapshot/HybridScannerITCase.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.scanner.snapshot;
+
+import com.alibaba.fluss.client.admin.OffsetSpec;
+import com.alibaba.fluss.client.scanner.ScanRecord;
+import com.alibaba.fluss.client.table.Table;
+import com.alibaba.fluss.client.table.snapshot.BucketSnapshotInfo;
+import com.alibaba.fluss.client.table.snapshot.BucketsSnapshotInfo;
+import com.alibaba.fluss.client.table.snapshot.KvSnapshotInfo;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.row.GenericRow;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.row.ProjectedRow;
+import com.alibaba.fluss.types.RowType;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** IT Case for {@link HybridScanner}. */
+public class HybridScannerITCase extends SnapshotScannerITCase {
+    private static final String DEFAULT_DB = "test-hybrid-scan-db";
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testScanHybrid(boolean hybridScanWithoutSnapshotFile) throws Exception {
+        TablePath tablePath =
+                TablePath.of(DEFAULT_DB, "test-table-hybrid-" + hybridScanWithoutSnapshotFile);
+        long tableId = createTable(tablePath, DEFAULT_TABLE_DESCRIPTOR, true);
+
+        // scan the snapshot
+        Map<TableBucket, List<InternalRow>> expectedRowByBuckets = putRows(tableId, tablePath, 10);
+        // test read snapshot without waiting snapshot finish.
+        testHybridRead(tablePath, expectedRowByBuckets, hybridScanWithoutSnapshotFile, null);
+
+        // test again with waiting snapshot finish.
+        expectedRowByBuckets = putRows(tableId, tablePath, 20);
+        waitUtilAllSnapshotFinished(expectedRowByBuckets.keySet(), 0);
+        testHybridRead(tablePath, expectedRowByBuckets, hybridScanWithoutSnapshotFile, null);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testScanHybridWithProjection(boolean hybridScanWithoutSnapshotFile) throws Exception {
+        TablePath tablePath =
+                TablePath.of(
+                        DEFAULT_DB,
+                        "test-table-hybrid-projection-" + hybridScanWithoutSnapshotFile);
+        long tableId = createTable(tablePath, DEFAULT_TABLE_DESCRIPTOR, true);
+
+        // scan the snapshot
+        Map<TableBucket, List<InternalRow>> expectedRowByBuckets = putRows(tableId, tablePath, 10);
+        // test read snapshot without waiting snapshot finish.
+        testHybridRead(
+                tablePath, expectedRowByBuckets, hybridScanWithoutSnapshotFile, new int[] {0});
+        // test again with waiting snapshot finish.
+        expectedRowByBuckets = putRows(tableId, tablePath, 20);
+        waitUtilAllSnapshotFinished(expectedRowByBuckets.keySet(), 0);
+        testHybridRead(
+                tablePath, expectedRowByBuckets, hybridScanWithoutSnapshotFile, new int[] {1});
+
+        // test read snapshot again
+        expectedRowByBuckets = putRows(tableId, tablePath, 20);
+        testHybridRead(
+                tablePath, expectedRowByBuckets, hybridScanWithoutSnapshotFile, new int[] {1, 0});
+    }
+
+    private void testHybridRead(
+            TablePath tablePath,
+            Map<TableBucket, List<InternalRow>> bucketRows,
+            boolean hybridScanWithoutSnapshotFile,
+            int[] projectedFields)
+            throws Exception {
+        KvSnapshotInfo tableSnapshotInfo = admin.getKvSnapshot(tablePath).get();
+        Map<Integer, Long> latestOffsets =
+                admin.listOffsets(
+                                PhysicalTablePath.of(tablePath, null),
+                                bucketRows.keySet().stream()
+                                        .map(TableBucket::getBucket)
+                                        .collect(Collectors.toSet()),
+                                new OffsetSpec.LatestSpec())
+                        .all()
+                        .get();
+
+        BucketsSnapshotInfo bucketsSnapshotInfo = tableSnapshotInfo.getBucketsSnapshots();
+        long tableId = tableSnapshotInfo.getTableId();
+        try (Table table = conn.getTable(tablePath)) {
+            for (int bucketId : bucketsSnapshotInfo.getBucketIds()) {
+                TableBucket tableBucket = new TableBucket(tableId, bucketId);
+                Optional<BucketSnapshotInfo> bucketSnapshotInfo =
+                        bucketsSnapshotInfo.getBucketSnapshotInfo(bucketId);
+                // get the expected rows
+                List<InternalRow> expectedRows = bucketRows.get(tableBucket);
+                if (projectedFields != null) {
+                    expectedRows =
+                            expectedRows.stream()
+                                    .map(row -> ProjectedRow.from(projectedFields).replaceRow(row))
+                                    .collect(Collectors.toList());
+                }
+
+                // create the hybrid scan according to the snapshot files
+                HybridScan hybridScan =
+                        new HybridScan(
+                                tableBucket,
+                                bucketSnapshotInfo.isPresent() && !hybridScanWithoutSnapshotFile
+                                        ? bucketSnapshotInfo.get().getSnapshotFiles()
+                                        : Collections.emptyList(),
+                                DEFAULT_SCHEMA,
+                                projectedFields,
+                                bucketSnapshotInfo.isPresent() && !hybridScanWithoutSnapshotFile
+                                        ? bucketSnapshotInfo.get().getLogOffset()
+                                        : -2,
+                                latestOffsets.get(bucketId));
+                HybridScanner hybridScanner = table.getHybridScanner(hybridScan);
+
+                // collect all the records from the scanner
+                List<ScanRecord> scanRecords = collectRecords(hybridScanner);
+
+                // check the records
+                if (projectedFields == null) {
+                    assertScanRecords(scanRecords, expectedRows);
+                } else {
+                    InternalRow.FieldGetter[] fieldGetters =
+                            new InternalRow.FieldGetter[projectedFields.length];
+                    RowType rowType = admin.getTableSchema(tablePath).get().getSchema().toRowType();
+                    for (int i = 0; i < projectedFields.length; i++) {
+                        fieldGetters[i] =
+                                InternalRow.createFieldGetter(
+                                        rowType.getTypeAt(projectedFields[i]), i);
+                    }
+                    assertScanRecords(scanRecords, expectedRows, fieldGetters);
+                }
+            }
+        }
+    }
+
+    private void assertScanRecords(
+            List<ScanRecord> actualScanRecords,
+            List<InternalRow> expectRows,
+            InternalRow.FieldGetter[] fieldGetters) {
+        List<ScanRecord> expectedScanRecords = new ArrayList<>(expectRows.size());
+        // Transform to GenericRow for comparing value rather than object.
+        actualScanRecords =
+                actualScanRecords.stream()
+                        .map(
+                                record -> {
+                                    GenericRow genericRow = new GenericRow(fieldGetters.length);
+                                    for (int i = 0; i < fieldGetters.length; i++) {
+                                        genericRow.setField(
+                                                i, fieldGetters[i].getFieldOrNull(record.getRow()));
+                                    }
+                                    return new ScanRecord(
+                                            record.getOffset(),
+                                            record.getTimestamp(),
+                                            record.getRowKind(),
+                                            genericRow);
+                                })
+                        .collect(Collectors.toList());
+        for (InternalRow row : expectRows) {
+            GenericRow genericRow = new GenericRow(fieldGetters.length);
+            for (int i = 0; i < fieldGetters.length; i++) {
+                genericRow.setField(i, fieldGetters[i].getFieldOrNull(row));
+            }
+
+            expectedScanRecords.add(new ScanRecord(genericRow));
+        }
+
+        assertThat(actualScanRecords).containsExactlyInAnyOrderElementsOf(expectedScanRecords);
+    }
+}

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/snapshot/SnapshotScannerITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/snapshot/SnapshotScannerITCase.java
@@ -55,14 +55,14 @@ class SnapshotScannerITCase extends ClientToServerITCaseBase {
 
     private static final int DEFAULT_BUCKET_NUM = 3;
 
-    private static final Schema DEFAULT_SCHEMA =
+    protected static final Schema DEFAULT_SCHEMA =
             Schema.newBuilder()
                     .primaryKey("id")
                     .column("id", DataTypes.INT())
                     .column("name", DataTypes.STRING())
                     .build();
 
-    private static final TableDescriptor DEFAULT_TABLE_DESCRIPTOR =
+    protected static final TableDescriptor DEFAULT_TABLE_DESCRIPTOR =
             TableDescriptor.builder()
                     .schema(DEFAULT_SCHEMA)
                     .distributedBy(DEFAULT_BUCKET_NUM, "id")
@@ -117,8 +117,8 @@ class SnapshotScannerITCase extends ClientToServerITCaseBase {
         testSnapshotRead(tablePath, expectedRowByBuckets);
     }
 
-    private Map<TableBucket, List<InternalRow>> putRows(long tableId, TablePath tablePath, int rows)
-            throws Exception {
+    protected Map<TableBucket, List<InternalRow>> putRows(
+            long tableId, TablePath tablePath, int rows) throws Exception {
         Map<TableBucket, List<InternalRow>> rowsByBuckets = new HashMap<>();
         try (Table table = conn.getTable(tablePath)) {
             UpsertWriter upsertWriter = table.getUpsertWriter();
@@ -172,13 +172,13 @@ class SnapshotScannerITCase extends ClientToServerITCaseBase {
         return DEFAULT_BUCKET_ASSIGNER.assignBucket(key, Cluster.empty());
     }
 
-    private void waitUtilAllSnapshotFinished(Set<TableBucket> tableBuckets, long snapshotId) {
+    protected void waitUtilAllSnapshotFinished(Set<TableBucket> tableBuckets, long snapshotId) {
         for (TableBucket tableBucket : tableBuckets) {
             FLUSS_CLUSTER_EXTENSION.waitUtilSnapshotFinished(tableBucket, snapshotId);
         }
     }
 
-    private List<ScanRecord> collectRecords(SnapshotScanner snapshotScanner) {
+    protected List<ScanRecord> collectRecords(SnapshotScanner snapshotScanner) {
         List<ScanRecord> scanRecords = new ArrayList<>();
         Iterator<ScanRecord> recordIterator = snapshotScanner.poll(Duration.ofSeconds(10));
         while (recordIterator != null) {
@@ -192,7 +192,7 @@ class SnapshotScannerITCase extends ClientToServerITCaseBase {
         return scanRecords;
     }
 
-    private void assertScanRecords(
+    protected void assertScanRecords(
             List<ScanRecord> actualScanRecords, List<InternalRow> expectRows) {
         List<ScanRecord> expectedScanRecords = new ArrayList<>(expectRows.size());
         for (InternalRow row : expectRows) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkSource.java
@@ -136,6 +136,7 @@ public class FlinkSource implements Source<RowData, SourceSplitBase, SourceEnume
                 sourceOutputType,
                 context,
                 projectedFields,
-                flinkSourceReaderMetrics);
+                flinkSourceReaderMetrics,
+                streaming);
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -263,10 +263,6 @@ public class FlinkTableSource
                                         + modificationScanType
                                         + " statement with conditions on primary key.");
                     }
-                    if (!isDataLakeEnabled) {
-                        throw new UnsupportedOperationException(
-                                "Currently, Fluss only support queries on table with datalake enabled or point queries on primary key when it's in batch execution mode.");
-                    }
                     return source;
                 }
             };

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/NoStoppingOffsetsInitializer.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/NoStoppingOffsetsInitializer.java
@@ -19,8 +19,10 @@ package com.alibaba.fluss.connector.flink.source.enumerator.initializer;
 import javax.annotation.Nullable;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPING_OFFSET;
 
 /**
  * An implementation of {@link OffsetsInitializer} which does not initialize anything.
@@ -36,6 +38,7 @@ public class NoStoppingOffsetsInitializer implements OffsetsInitializer {
             @Nullable String partitionName,
             Collection<Integer> buckets,
             OffsetsInitializer.BucketOffsetsRetriever bucketOffsetsRetriever) {
-        return Collections.emptyMap();
+        return buckets.stream()
+                .collect(Collectors.toMap(bucketId -> bucketId, bucketId -> NO_STOPPING_OFFSET));
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkRecordsWithSplitIds.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkRecordsWithSplitIds.java
@@ -103,7 +103,7 @@ public class FlinkRecordsWithSplitIds implements RecordsWithSplitIds<RecordAndPo
         this.splitRecords = splitRecords;
         this.splitIterator = splitIterator;
         this.tableBucketIterator = tableBucketIterator;
-        this.finishedSplits = finishedSplits;
+        this.finishedSplits = new HashSet<>(finishedSplits);
         this.flinkSourceReaderMetrics = flinkSourceReaderMetrics;
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReader.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReader.java
@@ -56,7 +56,8 @@ public class FlinkSourceReader
             RowType sourceOutputType,
             SourceReaderContext context,
             @Nullable int[] projectedFields,
-            FlinkSourceReaderMetrics flinkSourceReaderMetrics) {
+            FlinkSourceReaderMetrics flinkSourceReaderMetrics,
+            boolean streaming) {
         super(
                 elementsQueue,
                 new FlinkSourceFetcherManager(
@@ -67,7 +68,8 @@ public class FlinkSourceReader
                                         tablePath,
                                         sourceOutputType,
                                         projectedFields,
-                                        flinkSourceReaderMetrics),
+                                        flinkSourceReaderMetrics,
+                                        streaming),
                         (ignore) -> {}),
                 new FlinkRecordEmitter(sourceOutputType),
                 context.getConfiguration(),

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.connector.flink.source.split;
 
+import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPING_OFFSET;
+
 /** The state of {@link HybridSnapshotLogSplit}. */
 public class HybridSnapshotLogSplitState extends SourceSplitState {
 
@@ -40,7 +42,8 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
                 hybridSnapshotLogSplit.getSnapshotFiles(),
                 recordsToSkip,
                 snapshotFinished,
-                offset);
+                offset,
+                hybridSnapshotLogSplit.getLogStoppingOffset().orElse(NO_STOPPING_OFFSET));
     }
 
     public void setRecordsToSkip(long recordsToSkip) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.connector.flink.source.split;
 
+import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPING_OFFSET;
+
 /** The state of {@link LogSplit}. */
 public class LogSplitState extends SourceSplitState {
 
@@ -32,6 +34,10 @@ public class LogSplitState extends SourceSplitState {
     @Override
     public LogSplit toSourceSplit() {
         final LogSplit logSplit = (LogSplit) split;
-        return new LogSplit(logSplit.tableBucket, logSplit.getPartitionName(), offset);
+        return new LogSplit(
+                logSplit.tableBucket,
+                logSplit.getPartitionName(),
+                offset,
+                logSplit.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReaderTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReaderTest.java
@@ -21,6 +21,7 @@ import com.alibaba.fluss.connector.flink.source.event.PartitionBucketsUnsubscrib
 import com.alibaba.fluss.connector.flink.source.event.PartitionsRemovedEvent;
 import com.alibaba.fluss.connector.flink.source.metrics.FlinkSourceReaderMetrics;
 import com.alibaba.fluss.connector.flink.source.split.LogSplit;
+import com.alibaba.fluss.connector.flink.source.split.SourceSplitState;
 import com.alibaba.fluss.connector.flink.source.testutils.FlinkTestBase;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -34,11 +35,15 @@ import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.synchronization.FutureCompletingBlockingQueue;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderContext;
 import org.apache.flink.connector.testutils.source.reader.TestingReaderOutput;
+import org.apache.flink.core.io.InputStatus;
 import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,6 +53,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPING_OFFSET;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,7 +90,8 @@ class FlinkSourceReaderTest extends FlinkTestBase {
                         clientConf,
                         tablePath,
                         tableDescriptor.getSchema().toRowType(),
-                        readerContext)) {
+                        readerContext,
+                        Collections.emptyList())) {
 
             // first of all, add all splits of all partitions to the reader
             Map<Long, Set<TableBucket>> assignedBuckets = new HashMap<>();
@@ -154,11 +161,108 @@ class FlinkSourceReaderTest extends FlinkTestBase {
         }
     }
 
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testHandleAddSplit(boolean isStreamingMode) throws Exception {
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "test-flink-table-" + isStreamingMode);
+        TableDescriptor tableDescriptor = DEFAULT_AUTO_PARTITIONED_PK_TABLE_DESCRIPTOR;
+        long tableId = createTable(tablePath, tableDescriptor);
+        RowType rowType = tableDescriptor.getSchema().toRowType();
+
+        // wait util partitions are created
+        ZooKeeperClient zooKeeperClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+        Map<Long, String> partitionNameByIds = waitUntilPartitions(zooKeeperClient, tablePath);
+
+        // now, write rows to the table
+        Map<Long, List<String>> partitionWrittenRows = new HashMap<>();
+        for (Map.Entry<Long, String> partitionIdAndName : partitionNameByIds.entrySet()) {
+            partitionWrittenRows.put(
+                    partitionIdAndName.getKey(),
+                    writeRowsToPartition(
+                            tablePath,
+                            rowType,
+                            Collections.singleton(partitionIdAndName.getValue())));
+        }
+
+        // try to write some rows to the table
+        TestingReaderContext readerContext = new TestingReaderContext();
+        List<String> finishedSplit = new ArrayList<>();
+        try (final FlinkSourceReader reader =
+                createReader(
+                        clientConf,
+                        tablePath,
+                        tableDescriptor.getSchema().toRowType(),
+                        readerContext,
+                        finishedSplit)) {
+
+            // first of all, add all splits of all partitions to the reader
+            Map<Long, Set<TableBucket>> assignedBuckets = new HashMap<>();
+            for (Long partitionId : partitionNameByIds.keySet()) {
+                // get the latest offset of each bucket.
+                Map<Integer, Long> latestOffsets =
+                        getLatestOffsets(
+                                tablePath,
+                                partitionNameByIds.get(partitionId),
+                                Arrays.asList(0, 1, 2));
+                for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
+                    TableBucket tableBucket = new TableBucket(tableId, partitionId, i);
+                    reader.addSplits(
+                            Collections.singletonList(
+                                    new LogSplit(
+                                            tableBucket,
+                                            partitionNameByIds.get(partitionId),
+                                            0,
+                                            isStreamingMode
+                                                    ? NO_STOPPING_OFFSET
+                                                    : latestOffsets.get(i))));
+                    assignedBuckets
+                            .computeIfAbsent(partitionId, k -> new HashSet<>())
+                            .add(tableBucket);
+                }
+            }
+
+            // first, add no more split to the reader.
+            reader.notifyNoMoreSplits();
+
+            List<String> expectRows = new ArrayList<>();
+            for (Map.Entry<Long, List<String>> partitionIdAndWrittenRows :
+                    partitionWrittenRows.entrySet()) {
+                expectRows.addAll(partitionIdAndWrittenRows.getValue());
+            }
+
+            TestingReaderOutput<RowData> output = new TestingReaderOutput<>();
+
+            while (output.getEmittedRecords().size() < expectRows.size()) {
+                reader.pollNext(output);
+            }
+
+            // get the actual rows, the row format will be +I(x,x,x)
+            // we need to convert to +I[x, x, x] to match the expected rows format
+            List<String> actualRows =
+                    output.getEmittedRecords().stream()
+                            .map(Object::toString)
+                            .map(row -> row.replace("(", "[").replace(")", "]").replace(",", ", "))
+                            .collect(Collectors.toList());
+            assertThat(actualRows).containsExactlyInAnyOrderElementsOf(expectRows);
+
+            if (!isStreamingMode) {
+                InputStatus inputStatus;
+                do {
+                    inputStatus = reader.pollNext(output);
+                } while (InputStatus.NOTHING_AVAILABLE == inputStatus);
+                assertThat(inputStatus).isEqualTo(InputStatus.END_OF_INPUT);
+                assertThat(finishedSplit.size())
+                        .isEqualTo(partitionNameByIds.size() * DEFAULT_BUCKET_NUM);
+            }
+        }
+    }
+
     private FlinkSourceReader createReader(
             Configuration flussConf,
             TablePath tablePath,
             RowType sourceOutputType,
-            SourceReaderContext context) {
+            SourceReaderContext context,
+            List<String> finishedSplits) {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<RecordAndPos>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
         return new FlinkSourceReader(
@@ -168,6 +272,13 @@ class FlinkSourceReaderTest extends FlinkTestBase {
                 sourceOutputType,
                 context,
                 null,
-                new FlinkSourceReaderMetrics(context.metricGroup()));
+                new FlinkSourceReaderMetrics(context.metricGroup()),
+                true) {
+
+            @Override
+            protected void onSplitFinished(Map<String, SourceSplitState> map) {
+                finishedSplits.addAll(map.keySet());
+            }
+        };
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/split/SourceSplitSerializerTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/split/SourceSplitSerializerTest.java
@@ -61,7 +61,7 @@ class SourceSplitSerializerTest {
 
         split =
                 new HybridSnapshotLogSplit(
-                        bucket, partitionName, snapshotFiles, recordsToSkip, true, 5);
+                        bucket, partitionName, snapshotFiles, recordsToSkip, true, 5, 2);
         serialized = serializer.serialize(split);
         deserializedSplit = serializer.deserialize(serializer.getVersion(), serialized);
         assertThat(deserializedSplit).isEqualTo(split);


### PR DESCRIPTION
Fix https://github.com/alibaba/fluss/issues/40, Support batch read table without datalake enabled. 
* For primary table, batch read will apply cdc log which includes [+I, -U, +U, -D] to snapshot data, and then emit to downstream,
* For Log table, batch read will read a segment of log which only include +I and then emit to downstream directly.