### PR TITLE
[kv] Support index lookup for primary key table

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/AbstractLookup.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/AbstractLookup.java
@@ -17,37 +17,25 @@
 package com.alibaba.fluss.client.lookup;
 
 import com.alibaba.fluss.annotation.Internal;
-import com.alibaba.fluss.metadata.TableBucket;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-/**
- * Class to represent a Lookup operation, it contains the table bucket that the key should lookup
- * from, the bytes of the key, and a future for the lookup operation.
- */
+/** Abstract Class to represent a lookup operation. */
 @Internal
-public class Lookup extends AbstractLookup {
+public abstract class AbstractLookup {
 
-    private final TableBucket tableBucket;
-    private final CompletableFuture<List<byte[]>> future;
+    private final byte[] key;
 
-    Lookup(TableBucket tableBucket, byte[] key) {
-        super(key);
-        this.tableBucket = tableBucket;
-        this.future = new CompletableFuture<>();
+    public AbstractLookup(byte[] key) {
+        this.key = key;
     }
 
-    public TableBucket tableBucket() {
-        return tableBucket;
+    public byte[] key() {
+        return key;
     }
 
-    @Override
-    public LookupType lookupType() {
-        return LookupType.LOOKUP;
-    }
+    public abstract LookupType lookupType();
 
-    public CompletableFuture<List<byte[]>> future() {
-        return future;
-    }
+    public abstract CompletableFuture<List<byte[]>> future();
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/AbstractLookupBatch.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/AbstractLookupBatch.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.lookup;
+
+import com.alibaba.fluss.annotation.Internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/** An abstract lookup batch. */
+@Internal
+public abstract class AbstractLookupBatch {
+
+    protected final List<AbstractLookup> lookups;
+
+    public AbstractLookupBatch() {
+        this.lookups = new ArrayList<>();
+    }
+
+    public void addLookup(AbstractLookup lookup) {
+        lookups.add(lookup);
+    }
+
+    public List<AbstractLookup> lookups() {
+        return lookups;
+    }
+
+    /** Complete the lookup operations using given values . */
+    public abstract void complete(List<List<byte[]>> values);
+
+    /** Complete the get operations with given exception. */
+    public abstract void completeExceptionally(Exception exception);
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/IndexLookup.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/IndexLookup.java
@@ -17,37 +17,54 @@
 package com.alibaba.fluss.client.lookup;
 
 import com.alibaba.fluss.annotation.Internal;
-import com.alibaba.fluss.metadata.TableBucket;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /**
- * Class to represent a Lookup operation, it contains the table bucket that the key should lookup
- * from, the bytes of the key, and a future for the lookup operation.
+ * Class to represent an index lookup operation, it contains the table id, bucketNums and related
+ * CompletableFuture.
  */
 @Internal
-public class Lookup extends AbstractLookup {
-
-    private final TableBucket tableBucket;
+public class IndexLookup extends AbstractLookup {
+    private final int destination;
+    private final long tableId;
+    private final int bucketId;
+    private final String indexName;
     private final CompletableFuture<List<byte[]>> future;
 
-    Lookup(TableBucket tableBucket, byte[] key) {
-        super(key);
-        this.tableBucket = tableBucket;
+    public IndexLookup(
+            int destination, long tableId, int bucketId, String indexName, byte[] indexKey) {
+        super(indexKey);
+        this.destination = destination;
+        this.tableId = tableId;
+        this.bucketId = bucketId;
+        this.indexName = indexName;
         this.future = new CompletableFuture<>();
     }
 
-    public TableBucket tableBucket() {
-        return tableBucket;
+    public int destination() {
+        return destination;
     }
 
-    @Override
-    public LookupType lookupType() {
-        return LookupType.LOOKUP;
+    public long tableId() {
+        return tableId;
+    }
+
+    public int bucketId() {
+        return bucketId;
+    }
+
+    public String indexName() {
+        return indexName;
     }
 
     public CompletableFuture<List<byte[]>> future() {
         return future;
+    }
+
+    @Override
+    public LookupType lookupType() {
+        return LookupType.INDEX_LOOKUP;
     }
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/LookupResult.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/LookupResult.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.client.table;
+package com.alibaba.fluss.client.lookup;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
+import com.alibaba.fluss.client.table.Table;
 import com.alibaba.fluss.row.InternalRow;
 
-import javax.annotation.Nullable;
-
-import java.util.Objects;
+import java.util.List;
 
 /**
  * The result of {@link Table#lookup(InternalRow)}.
@@ -30,14 +29,14 @@ import java.util.Objects;
  */
 @PublicEvolving
 public final class LookupResult {
-    private final @Nullable InternalRow row;
+    private final List<InternalRow> rowList;
 
-    public LookupResult(@Nullable InternalRow row) {
-        this.row = row;
+    public LookupResult(List<InternalRow> rowList) {
+        this.rowList = rowList;
     }
 
-    public @Nullable InternalRow getRow() {
-        return row;
+    public List<InternalRow> getRowList() {
+        return rowList;
     }
 
     @Override
@@ -50,16 +49,16 @@ public final class LookupResult {
         }
 
         LookupResult lookupResult = (LookupResult) o;
-        return Objects.equals(row, lookupResult.row);
+        return rowList.equals(lookupResult.rowList);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(row);
+        return rowList.hashCode();
     }
 
     @Override
     public String toString() {
-        return "LookupResult{row=" + row + '}';
+        return "LookupResult{" + "rowList=" + rowList + '}';
     }
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/LookupType.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/LookupType.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.lookup;
+
+import com.alibaba.fluss.annotation.Internal;
+
+/** Enum to represent the type of lookup operation. */
+@Internal
+enum LookupType {
+    LOOKUP,
+    INDEX_LOOKUP;
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.client.table;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.lookup.LookupResult;
 import com.alibaba.fluss.client.scanner.ScanRecord;
 import com.alibaba.fluss.client.scanner.log.LogScan;
 import com.alibaba.fluss.client.scanner.log.LogScanner;
@@ -62,6 +63,21 @@ public interface Table extends AutoCloseable {
      * @return the result of get.
      */
     CompletableFuture<LookupResult> lookup(InternalRow key);
+
+    /**
+     * Lookup certain rows from the given table by index key.
+     *
+     * <p>Only available for Primary Key Table. Will throw exception when the table isn't a Primary
+     * Key Table.
+     *
+     * <p>The index need to be created while creating the table. If this table doesn't have an index
+     * belong to the given index key, the exception will throw.
+     *
+     * @param indexName the given table index name.
+     * @param indexKey the given table index key.
+     * @return the result of index lookup.
+     */
+    CompletableFuture<LookupResult> indexLookup(String indexName, InternalRow indexKey);
 
     /**
      * Extracts limit number of rows from the given table bucket.

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientRpcMessageUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientRpcMessageUtils.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.client.utils;
 
 import com.alibaba.fluss.client.admin.OffsetSpec;
+import com.alibaba.fluss.client.lookup.IndexLookupBatch;
 import com.alibaba.fluss.client.lookup.LookupBatch;
 import com.alibaba.fluss.client.table.lake.LakeTableSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.BucketSnapshotInfo;
@@ -43,12 +44,14 @@ import com.alibaba.fluss.rpc.messages.GetFileSystemSecurityTokenResponse;
 import com.alibaba.fluss.rpc.messages.GetKvSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.GetLakeTableSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.GetPartitionSnapshotResponse;
+import com.alibaba.fluss.rpc.messages.IndexLookupRequest;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosResponse;
 import com.alibaba.fluss.rpc.messages.LookupRequest;
 import com.alibaba.fluss.rpc.messages.MetadataRequest;
 import com.alibaba.fluss.rpc.messages.PbBucketSnapshot;
 import com.alibaba.fluss.rpc.messages.PbFetchLogRespForBucket;
+import com.alibaba.fluss.rpc.messages.PbIndexLookupReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbKeyValue;
 import com.alibaba.fluss.rpc.messages.PbLakeSnapshotForBucket;
 import com.alibaba.fluss.rpc.messages.PbLakeStorageInfo;
@@ -181,6 +184,22 @@ public class ClientRpcMessageUtils {
                         pbLookupReqForBucket.setPartitionId(tb.getPartitionId());
                     }
                     batch.lookups().forEach(get -> pbLookupReqForBucket.addKey(get.key()));
+                });
+        return request;
+    }
+
+    public static IndexLookupRequest makeIndexLookupRequest(
+            long tableId, Collection<IndexLookupBatch> lookupBatches) {
+        IndexLookupRequest request = new IndexLookupRequest().setTableId(tableId);
+        lookupBatches.forEach(
+                (batch) -> {
+                    TableBucket tb = batch.tableBucket();
+                    PbIndexLookupReqForBucket pbIndexLookupReqForBucket =
+                            request.addBucketsReq().setBucketId(tb.getBucket());
+                    if (tb.getPartitionId() != null) {
+                        pbIndexLookupReqForBucket.setPartitionId(tb.getPartitionId());
+                    }
+                    batch.lookups().forEach(get -> pbIndexLookupReqForBucket.addKey(get.key()));
                 });
         return request;
     }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussPartitionedTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussPartitionedTableITCase.java
@@ -83,7 +83,8 @@ class FlussPartitionedTableITCase extends ClientToServerITCaseBase {
                 InternalRow lookupRow =
                         table.lookup(keyRow(schema, new Object[] {i, null, partition}))
                                 .get()
-                                .getRow();
+                                .getRowList()
+                                .get(0);
                 assertThat(lookupRow).isEqualTo(actualRow);
             }
         }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
@@ -329,7 +329,7 @@ class FlussTableITCase extends ClientToServerITCaseBase {
     private InternalRow lookupRow(TablePath tablePath, IndexedRow keyRow) throws Exception {
         try (Table table = conn.getTable(tablePath)) {
             // lookup this key.
-            return table.lookup(keyRow).get().getRow();
+            return table.lookup(keyRow).get().getRowList().get(0);
         }
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -727,6 +727,12 @@ public class ConfigOptions {
                     .withDescription(
                             "The maximum number of unacknowledged lookup requests for lookup operations.");
 
+    public static final ConfigOption<Duration> CLIENT_LOOKUP_BATCH_TIMEOUT =
+            key("client.lookup.batch-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(1))
+                    .withDescription("The lookup batch timeout ms.");
+
     public static final ConfigOption<Integer> CLIENT_SCANNER_REMOTE_LOG_PREFETCH_NUM =
             key("client.scanner.remote-log.prefetch-num")
                     .intType()
@@ -883,6 +889,18 @@ public class ConfigOptions {
                             "Whether enable lakehouse storage for the table. Disabled by default. "
                                     + "When this option is set to ture and the datalake tiering service is up,"
                                     + " the table will be tiered and compacted into datalake format stored on lakehouse storage.");
+
+    public static final ConfigOption<String> TABLE_INDEX_KEY =
+            key("table.index.key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The index key is used to build non-key secondary indexes on a pk table, "
+                                    + "enabling fast data queries. You can define multiple index keys, separated by ';'."
+                                    + " Each index key can specify a index name, like indexName=indexKeyFields. "
+                                    + " indexKeyFields support multiple fields, which can be nullable filed,"
+                                    + " and fields within a key are separated by ','."
+                                    + " For example: 'index1=num_orders;index2=num_orders,total_amount'");
 
     // ------------------------------------------------------------------------
     //  ConfigOptions for Kv

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidIndexKeysException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidIndexKeysException.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+import com.alibaba.fluss.annotation.PublicEvolving;
+
+/**
+ * Try to build a table with some invalid index keys. like the column in index key not exist or the
+ * column is repeated, like (a, b) and (b, a).
+ *
+ * @since 0.3
+ */
+@PublicEvolving
+public class InvalidIndexKeysException extends ApiException {
+    public InvalidIndexKeysException(String message) {
+        super(message);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.config.ConfigOption;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.config.ConfigurationUtils;
+import com.alibaba.fluss.exception.InvalidIndexKeysException;
 import com.alibaba.fluss.utils.AutoPartitionStrategy;
 import com.alibaba.fluss.utils.Preconditions;
 import com.alibaba.fluss.utils.json.JsonSerdeUtil;
@@ -135,6 +136,76 @@ public final class TableDescriptor implements Serializable {
         }
     }
 
+    /** Validate the table descriptor. */
+    public void validate() throws InvalidIndexKeysException {
+        validateIndexKeys();
+    }
+
+    private void validateIndexKeys() throws InvalidIndexKeysException {
+        Configuration conf = configuration();
+        if (!conf.contains(ConfigOptions.TABLE_INDEX_KEY)) {
+            return;
+        }
+
+        String indexKeysString = conf.get(ConfigOptions.TABLE_INDEX_KEY);
+        String indexKeysError = detectInvalidIndexKeys(indexKeysString);
+        if (indexKeysError != null) {
+            throw new InvalidIndexKeysException(
+                    "Option 'table.index.key' = '"
+                            + indexKeysString
+                            + "' is invalid: "
+                            + indexKeysError);
+        }
+    }
+
+    private String detectInvalidIndexKeys(String indexKeysString) {
+        List<String> columnNames =
+                schema.getColumns().stream()
+                        .map(Schema.Column::getName)
+                        .collect(Collectors.toList());
+        String[] indexKeyStringList = indexKeysString.split(";");
+        if (indexKeyStringList.length <= 0) {
+            return "Index key is empty or index key doesn't split by ';'.";
+        }
+
+        List<int[]> orderedIndexKey = new ArrayList<>();
+        for (String indexKeyFieldsStr : indexKeyStringList) {
+            String[] indexNameAndFields = indexKeyFieldsStr.split("=");
+            if (indexNameAndFields.length != 2) {
+                return "There is an index key not follow the format 'indexKeyName=indexKeyFields'.";
+            }
+
+            String[] fieldStrings = indexNameAndFields[1].split(",");
+            if (fieldStrings.length <= 0) {
+                return "There is an index key is empty or column field in index key doesn't split by ','.";
+            }
+
+            List<Integer> indexKeyPosList = new ArrayList<>();
+            for (String field : fieldStrings) {
+                int fieldIndex = columnNames.indexOf(field);
+                if (fieldIndex < 0) {
+                    return "Index key '" + field + "' does not exist in the schema.";
+                }
+                indexKeyPosList.add(fieldIndex);
+            }
+
+            Collections.sort(indexKeyPosList);
+            if (orderedIndexKey.stream()
+                    .anyMatch(
+                            f ->
+                                    Arrays.equals(
+                                            f,
+                                            indexKeyPosList.stream()
+                                                    .mapToInt(Integer::intValue)
+                                                    .toArray()))) {
+                return "There is an index key is duplicate.";
+            }
+            orderedIndexKey.add(indexKeyPosList.stream().mapToInt(Integer::intValue).toArray());
+        }
+
+        return null;
+    }
+
     /** Creates a builder for building table descriptor. */
     public static Builder builder() {
         return new Builder();
@@ -237,6 +308,32 @@ public final class TableDescriptor implements Serializable {
     /** Gets the local segments to retain for tiered log of the table. */
     public int getTieredLogLocalSegments() {
         return configuration().get(ConfigOptions.TABLE_TIERED_LOG_LOCAL_SEGMENTS);
+    }
+
+    /** Return a list of index key indexes in the table. */
+    public Map<String, int[]> getIndexKeyIndexes() {
+        Configuration conf = configuration();
+        if (!conf.contains(ConfigOptions.TABLE_INDEX_KEY)) {
+            return Collections.emptyMap();
+        }
+
+        List<String> columnNames =
+                schema.getColumns().stream()
+                        .map(Schema.Column::getName)
+                        .collect(Collectors.toList());
+
+        Map<String, int[]> indexKeyIndexes = new HashMap<>();
+        for (String indexKeyStr : conf.get(ConfigOptions.TABLE_INDEX_KEY).split(";")) {
+            String[] indexNameAndFields = indexKeyStr.split("=");
+            String indexKeyName = indexNameAndFields[0];
+            List<Integer> indexKeyList = new ArrayList<>();
+            for (String field : indexNameAndFields[1].split(",")) {
+                indexKeyList.add(columnNames.indexOf(field));
+            }
+            indexKeyIndexes.put(
+                    indexKeyName, indexKeyList.stream().mapToInt(Integer::intValue).toArray());
+        }
+        return indexKeyIndexes;
     }
 
     /** Whether the data lake is enabled. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metrics/MetricNames.java
@@ -76,6 +76,10 @@ public class MetricNames {
     public static final String FAILED_PUT_KV_REQUESTS_RATE = "failedPutKvRequestsPerSecond";
     public static final String TOTAL_LIMIT_SCAN_REQUESTS_RATE = "totalLimitScanRequestsPerSecond";
     public static final String FAILED_LIMIT_SCAN_REQUESTS_RATE = "failedLimitScanRequestsPerSecond";
+    public static final String TOTAL_INDEX_LOOKUP_REQUESTS_RATE =
+            "totalIndexLookupRequestsPerSecond";
+    public static final String FAILED_INDEX_LOOKUP_REQUESTS_RATE =
+            "failedIndexLookupRequestsPerSecond";
 
     // --------------------------------------------------------------------------------------------
     // metrics for table bucket

--- a/fluss-common/src/main/java/com/alibaba/fluss/row/encode/KeyEncoder.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/row/encode/KeyEncoder.java
@@ -54,7 +54,7 @@ public class KeyEncoder {
         return new KeyEncoder(rowType, encodeColIndexes);
     }
 
-    protected KeyEncoder(RowType rowType) {
+    public KeyEncoder(RowType rowType) {
         this(rowType, IntStream.range(0, rowType.getFieldCount()).toArray());
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/BytesUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/BytesUtils.java
@@ -58,4 +58,20 @@ public final class BytesUtils {
         }
         return dest;
     }
+
+    /**
+     * Check if the given two byte arrays have the same prefix.
+     *
+     * @param bytes1 The first byte array
+     * @param bytes2 The second byte array
+     * @return true if the given two byte arrays have the same prefix, false otherwise
+     */
+    public static boolean isPrefixEquals(byte[] bytes1, byte[] bytes2) {
+        for (int i = 0; i < bytes1.length; i++) {
+            if (bytes1[i] != bytes2[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
@@ -69,6 +69,18 @@ public class FlinkConnectorOptions {
                     .defaultValue(true)
                     .withDescription("Whether to set async lookup. Default is true.");
 
+    public static final ConfigOption<String> INDEX_LOOKUP_KEY =
+            ConfigOptions.key("index.key")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The index key is used to build non-key secondary indexes on a pk table, "
+                                    + "enabling fast data queries. You can define multiple index keys, separated by ';'."
+                                    + " Each index key can specify a index name, like indexName=indexKeyFields. "
+                                    + " indexKeyFields support multiple fields, which can be nullable filed,"
+                                    + " and fields within a key are separated by ','."
+                                    + " For example: 'index1=num_orders;index2=num_orders,total_amount'");
+
     // --------------------------------------------------------------------------------------------
     // Scan specific options
     // --------------------------------------------------------------------------------------------

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtil.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConnectorOptionsUtil.java
@@ -22,11 +22,19 @@ import com.alibaba.fluss.connector.flink.FlinkConnectorOptions.ScanStartupMode;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.table.types.logical.RowType;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.INDEX_LOOKUP_KEY;
 import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.SCAN_STARTUP_MODE;
 import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.SCAN_STARTUP_TIMESTAMP;
 import static com.alibaba.fluss.connector.flink.FlinkConnectorOptions.ScanStartupMode.TIMESTAMP;
@@ -43,8 +51,10 @@ public class FlinkConnectorOptionsUtil {
                 : ZoneId.of(timeZone);
     }
 
-    public static void validateTableSourceOptions(ReadableConfig tableOptions) {
+    public static void validateTableSourceOptions(
+            ReadableConfig tableOptions, RowType tableOutputType) {
         validateScanStartupMode(tableOptions);
+        validateIndexKeys(tableOptions, tableOutputType);
     }
 
     public static StartupOptions getStartupOptions(ReadableConfig tableOptions, ZoneId timeZone) {
@@ -71,6 +81,81 @@ public class FlinkConnectorOptionsUtil {
                                 SCAN_STARTUP_TIMESTAMP.key(), TIMESTAMP));
             }
         }
+    }
+
+    private static void validateIndexKeys(ReadableConfig tableOptions, RowType tableOutputType) {
+        if (!tableOptions.getOptional(INDEX_LOOKUP_KEY).isPresent()) {
+            return;
+        }
+
+        List<String> columnNames = tableOutputType.getFieldNames();
+
+        String indexKeysString = tableOptions.get(INDEX_LOOKUP_KEY);
+        String indexKeysError = detectInvalidIndexKeys(indexKeysString, columnNames);
+        if (indexKeysError != null) {
+            throw new ValidationException(
+                    "Option 'index.key' = '" + indexKeysString + "' is invalid: " + indexKeysError);
+        }
+    }
+
+    private static String detectInvalidIndexKeys(String indexKeysString, List<String> columnNames) {
+        String[] indexKeyStringList = indexKeysString.split(";");
+        if (indexKeyStringList.length <= 0) {
+            return "Index key is empty or index key doesn't split by ';'.";
+        }
+
+        List<int[]> orderedIndexKey = new ArrayList<>();
+        for (String indexKeyFieldsStr : indexKeyStringList) {
+            String[] indexNameAndFields = indexKeyFieldsStr.split("=");
+            if (indexNameAndFields.length != 2) {
+                return "There is an index key not follow the format 'indexKeyName=indexKeyFields'.";
+            }
+
+            String[] fieldStrings = indexNameAndFields[1].split(",");
+            if (fieldStrings.length <= 0) {
+                return "There is an index key is empty or column field in index key doesn't split by ','.";
+            }
+
+            List<Integer> indexKeyPosList = new ArrayList<>();
+            for (String field : fieldStrings) {
+                int fieldIndex = columnNames.indexOf(field);
+                if (fieldIndex < 0) {
+                    return "Index key '" + field + "' does not exist in the schema.";
+                }
+                indexKeyPosList.add(fieldIndex);
+            }
+
+            Collections.sort(indexKeyPosList);
+            if (orderedIndexKey.stream()
+                    .anyMatch(
+                            f ->
+                                    Arrays.equals(
+                                            f,
+                                            indexKeyPosList.stream()
+                                                    .mapToInt(Integer::intValue)
+                                                    .toArray()))) {
+                return "There is an index key is duplicate.";
+            }
+            orderedIndexKey.add(indexKeyPosList.stream().mapToInt(Integer::intValue).toArray());
+        }
+
+        return null;
+    }
+
+    public static Map<String, int[]> getIndexKeys(String indexKeyString, RowType rowType) {
+        List<String> columnNames = rowType.getFieldNames();
+        Map<String, int[]> indexKeyIndexes = new HashMap<>();
+        for (String indexKeyStr : indexKeyString.split(";")) {
+            String[] indexNameAndFields = indexKeyStr.split("=");
+            String indexKeyName = indexNameAndFields[0];
+            List<Integer> indexKeyList = new ArrayList<>();
+            for (String field : indexNameAndFields[1].split(",")) {
+                indexKeyList.add(columnNames.indexOf(field));
+            }
+            indexKeyIndexes.put(
+                    indexKeyName, indexKeyList.stream().mapToInt(Integer::intValue).toArray());
+        }
+        return indexKeyIndexes;
     }
 
     /**

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/TabletServerGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/TabletServerGateway.java
@@ -19,6 +19,8 @@ package com.alibaba.fluss.rpc.gateway;
 import com.alibaba.fluss.rpc.RpcGateway;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.messages.FetchLogResponse;
+import com.alibaba.fluss.rpc.messages.IndexLookupRequest;
+import com.alibaba.fluss.rpc.messages.IndexLookupResponse;
 import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanRequest;
@@ -98,6 +100,14 @@ public interface TabletServerGateway extends RpcGateway, AdminReadOnlyGateway {
      */
     @RPC(api = ApiKeys.LOOKUP)
     CompletableFuture<LookupResponse> lookup(LookupRequest request);
+
+    /**
+     * Index lookup to get value by index key.
+     *
+     * @return Index lookup response.
+     */
+    @RPC(api = ApiKeys.INDEX_LOOKUP)
+    CompletableFuture<IndexLookupResponse> indexLookup(IndexLookupRequest request);
 
     /**
      * Get limit number of values from the specified table bucket.

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -61,7 +61,8 @@ public enum ApiKeys {
     NOTIFY_LAKE_TABLE_OFFSET(1031, 0, 0, PRIVATE),
     DESCRIBE_LAKE_STORAGE(1032, 0, 0, PUBLIC),
     GET_LAKE_TABLE_SNAPSHOT(1033, 0, 0, PUBLIC),
-    LIMIT_SCAN(1034, 0, 0, PUBLIC);
+    LIMIT_SCAN(1034, 0, 0, PUBLIC),
+    INDEX_LOOKUP(1035, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -28,6 +28,7 @@ import com.alibaba.fluss.exception.InvalidColumnProjectionException;
 import com.alibaba.fluss.exception.InvalidConfigException;
 import com.alibaba.fluss.exception.InvalidCoordinatorException;
 import com.alibaba.fluss.exception.InvalidDatabaseException;
+import com.alibaba.fluss.exception.InvalidIndexKeysException;
 import com.alibaba.fluss.exception.InvalidReplicationFactorException;
 import com.alibaba.fluss.exception.InvalidRequiredAcksException;
 import com.alibaba.fluss.exception.InvalidTableException;
@@ -174,8 +175,8 @@ public enum Errors {
     INVALID_TIMESTAMP_EXCEPTION(38, "The timestamp is invalid.", InvalidTimestampException::new),
     INVALID_CONFIG_EXCEPTION(39, "The config is invalid.", InvalidConfigException::new),
     LAKE_STORAGE_NOT_CONFIGURED_EXCEPTION(
-            40, "The lake storage is not configured.", LakeStorageNotConfiguredException::new);
-    ;
+            40, "The lake storage is not configured.", LakeStorageNotConfiguredException::new),
+    INVALID_INDEX_KEYS_EXCEPTION(40, "The index keys is invalid", InvalidIndexKeysException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -202,6 +202,16 @@ message LookupResponse {
   repeated PbLookupRespForBucket buckets_resp = 1;
 }
 
+// Index Lookup request and response
+message IndexLookupRequest {
+  required int64 table_id = 1;
+  repeated PbIndexLookupReqForBucket buckets_req = 2;
+}
+
+message IndexLookupResponse {
+  repeated PbIndexLookupRespForBucket buckets_resp = 1;
+}
+
 
 // limit scan request and response
 message LimitScanRequest {
@@ -548,6 +558,27 @@ message PbLookupRespForBucket {
 message PbValue {
   // optional, if empty, means no value
   optional bytes values = 1;
+}
+
+message PbIndexLookupReqForBucket {
+  optional int64 partition_id = 1;
+  required int32 bucket_id = 2;
+  repeated bytes keys = 3;
+}
+
+message PbIndexData {
+  required string index_name = 1;
+  required bytes index_key = 2;
+}
+
+message PbIndexLookupRespForBucket {
+  optional int64 partition_id = 1;
+  required int32 bucket_id = 2;
+  repeated PbIndexLookupRespForKey keys_resp = 3;
+}
+
+message PbIndexLookupRespForKey {
+  repeated bytes values = 1;
 }
 
 message PbTableBucket {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -20,6 +20,7 @@ import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidDatabaseException;
+import com.alibaba.fluss.exception.InvalidIndexKeysException;
 import com.alibaba.fluss.exception.InvalidTableException;
 import com.alibaba.fluss.fs.FileSystem;
 import com.alibaba.fluss.metadata.Schema;
@@ -133,6 +134,11 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         }
 
         TableDescriptor tableDescriptor = TableDescriptor.fromJsonBytes(request.getTableJson());
+        try {
+            tableDescriptor.validate();
+        } catch (InvalidIndexKeysException e) {
+            return FutureUtils.failedFuture(e);
+        }
 
         int bucketCount = defaultBucketNumber;
         // not set distribution

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
@@ -470,6 +470,15 @@ public final class KvTablet {
                 });
     }
 
+    public List<byte[]> indexLookup(byte[] indexKey) throws IOException {
+        return inReadLock(
+                kvLock,
+                () -> {
+                    rocksDBKv.checkIfRocksDBClosed();
+                    return rocksDBKv.indexLookup(indexKey);
+                });
+    }
+
     public List<byte[]> limitScan(int limit) throws IOException {
         return inReadLock(
                 kvLock,

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBKv.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/rocksdb/RocksDBKv.java
@@ -35,6 +35,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.alibaba.fluss.utils.BytesUtils.isPrefixEquals;
+
 /** A wrapper for the operation of {@link org.rocksdb.RocksDB}. */
 public class RocksDBKv implements AutoCloseable {
 
@@ -56,7 +58,7 @@ public class RocksDBKv implements AutoCloseable {
      * {@link RocksDB#open(String)} is different from that by {@link
      * RocksDB#getDefaultColumnFamily()}, probably it's a bug of RocksDB java API.
      */
-    private final ColumnFamilyHandle defaultColumnFamily;
+    private final ColumnFamilyHandle defaultColumnFamilyHandle;
 
     /** Our RocksDB database. Currently, one kv tablet, one RocksDB instance. */
     protected final RocksDB db;
@@ -73,7 +75,7 @@ public class RocksDBKv implements AutoCloseable {
         this.db = db;
         this.rocksDBResourceGuard = rocksDBResourceGuard;
         this.writeOptions = optionsContainer.getWriteOptions();
-        this.defaultColumnFamily = defaultColumnFamilyHandle;
+        this.defaultColumnFamilyHandle = defaultColumnFamilyHandle;
     }
 
     public ResourceGuard getResourceGuard() {
@@ -100,10 +102,28 @@ public class RocksDBKv implements AutoCloseable {
         }
     }
 
+    public List<byte[]> indexLookup(byte[] indexKey) throws IOException {
+        List<byte[]> pkList = new ArrayList<>();
+        ReadOptions readOptions = new ReadOptions();
+        RocksIterator iterator = db.newIterator(defaultColumnFamilyHandle, readOptions);
+        try {
+            iterator.seek(indexKey);
+            while (iterator.isValid() && isPrefixEquals(indexKey, iterator.key())) {
+                pkList.add(iterator.value());
+                iterator.next();
+            }
+        } finally {
+            readOptions.close();
+            iterator.close();
+        }
+
+        return pkList;
+    }
+
     public List<byte[]> limitScan(Integer limit) {
         List<byte[]> pkList = new ArrayList<>();
         ReadOptions readOptions = new ReadOptions();
-        RocksIterator iterator = db.newIterator(defaultColumnFamily, readOptions);
+        RocksIterator iterator = db.newIterator(defaultColumnFamilyHandle, readOptions);
 
         int count = 0;
         iterator.seekToFirst();
@@ -165,8 +185,8 @@ public class RocksDBKv implements AutoCloseable {
             // Start with default CF ...
             List<ColumnFamilyOptions> columnFamilyOptions = new ArrayList<>();
             RocksDBOperationUtils.addColumnFamilyOptionsToCloseLater(
-                    columnFamilyOptions, defaultColumnFamily);
-            IOUtils.closeQuietly(defaultColumnFamily);
+                    columnFamilyOptions, defaultColumnFamilyHandle);
+            IOUtils.closeQuietly(defaultColumnFamilyHandle);
 
             // ... and finally close the DB instance ...
             IOUtils.closeQuietly(db);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
@@ -201,6 +201,22 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
         }
     }
 
+    public Counter totalIndexLookupRequests() {
+        if (kvMetrics == null) {
+            return NoOpCounter.INSTANCE;
+        } else {
+            return kvMetrics.totalIndexLookupRequests;
+        }
+    }
+
+    public Counter failedIndexLookupRequests() {
+        if (kvMetrics == null) {
+            return NoOpCounter.INSTANCE;
+        } else {
+            return kvMetrics.failedIndexLookupRequests;
+        }
+    }
+
     // ------------------------------------------------------------------------
     //  bucket groups
     // ------------------------------------------------------------------------
@@ -326,6 +342,8 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
         private final Counter failedPutKvRequests;
         private final Counter totalLimitScanRequests;
         private final Counter failedLimitScanRequests;
+        private final Counter totalIndexLookupRequests;
+        private final Counter failedIndexLookupRequests;
 
         public KvMetricGroup(PhysicalTableMetricGroup physicalTableMetricGroup) {
             super(physicalTableMetricGroup, TabletType.KV);
@@ -349,6 +367,16 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
             meter(
                     MetricNames.FAILED_LIMIT_SCAN_REQUESTS_RATE,
                     new MeterView(failedLimitScanRequests));
+
+            // for index lookup request
+            totalIndexLookupRequests = new ThreadSafeSimpleCounter();
+            meter(
+                    MetricNames.TOTAL_INDEX_LOOKUP_REQUESTS_RATE,
+                    new MeterView(totalIndexLookupRequests));
+            failedIndexLookupRequests = new ThreadSafeSimpleCounter();
+            meter(
+                    MetricNames.FAILED_INDEX_LOOKUP_REQUESTS_RATE,
+                    new MeterView(failedIndexLookupRequests));
         }
 
         @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -50,9 +50,12 @@ import com.alibaba.fluss.rpc.entity.ProduceLogResultForBucket;
 import com.alibaba.fluss.rpc.entity.PutKvResultForBucket;
 import com.alibaba.fluss.rpc.entity.WriteResultForBucket;
 import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
+import com.alibaba.fluss.rpc.messages.IndexLookupResponse;
 import com.alibaba.fluss.rpc.messages.NotifyKvSnapshotOffsetResponse;
 import com.alibaba.fluss.rpc.messages.NotifyLakeTableOffsetResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.PbIndexLookupRespForBucket;
+import com.alibaba.fluss.rpc.messages.PbIndexLookupRespForKey;
 import com.alibaba.fluss.rpc.protocol.ApiError;
 import com.alibaba.fluss.rpc.protocol.Errors;
 import com.alibaba.fluss.server.coordinator.CoordinatorContext;
@@ -454,6 +457,45 @@ public class ReplicaManager {
         }
         LOG.debug("Lookup from local kv in {}ms", System.currentTimeMillis() - startTime);
         responseCallback.accept(lookupResultForBucketMap);
+    }
+
+    /** Lookup by index name and index keys on kv store. */
+    public void indexLookup(
+            Map<TableBucket, List<byte[]>> entriesPerBucket,
+            Consumer<IndexLookupResponse> responseCallback) {
+        IndexLookupResponse response = new IndexLookupResponse();
+        PhysicalTableMetricGroup tableMetrics = null;
+        List<PbIndexLookupRespForBucket> resultForAll = new ArrayList<>();
+        for (Map.Entry<TableBucket, List<byte[]>> entry : entriesPerBucket.entrySet()) {
+            TableBucket tb = entry.getKey();
+            PbIndexLookupRespForBucket respForBucket = new PbIndexLookupRespForBucket();
+            respForBucket.setBucketId(tb.getBucket());
+            try {
+                Replica replica = getReplicaOrException(tb);
+                tableMetrics = replica.tableMetrics();
+                tableMetrics.totalIndexLookupRequests().inc();
+                List<PbIndexLookupRespForKey> keyResultList = new ArrayList<>();
+                for (byte[] indexKey : entry.getValue()) {
+                    PbIndexLookupRespForKey pbIndexLookupRespForKey = new PbIndexLookupRespForKey();
+                    for (byte[] result : replica.indexLookup(indexKey)) {
+                        pbIndexLookupRespForKey.addValue(result);
+                    }
+                    keyResultList.add(pbIndexLookupRespForKey);
+                }
+                respForBucket.addAllKeysResps(keyResultList);
+            } catch (Exception e) {
+                LOG.error("Error processing index lookup operation on replica {}", tb, e);
+                if (tableMetrics != null) {
+                    tableMetrics.failedIndexLookupRequests().inc();
+                }
+                throw e;
+            }
+
+            resultForAll.add(respForBucket);
+        }
+
+        response.addAllBucketsResps(resultForAll);
+        responseCallback.accept(response);
     }
 
     public void listOffsets(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
@@ -25,6 +25,8 @@ import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.messages.FetchLogResponse;
+import com.alibaba.fluss.rpc.messages.IndexLookupRequest;
+import com.alibaba.fluss.rpc.messages.IndexLookupResponse;
 import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanRequest;
@@ -62,6 +64,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.fluss.server.utils.RpcMessageUtils.makeLookupResponse;
+import static com.alibaba.fluss.server.utils.RpcMessageUtils.toIndexLookupData;
 import static com.alibaba.fluss.server.utils.RpcMessageUtils.toLookupData;
 
 /** An RPC Gateway service for tablet server. */
@@ -139,6 +142,13 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         Map<TableBucket, List<byte[]>> lookupData = toLookupData(request);
         replicaManager.multiLookupValues(
                 lookupData, value -> response.complete(makeLookupResponse(value)));
+        return response;
+    }
+
+    @Override
+    public CompletableFuture<IndexLookupResponse> indexLookup(IndexLookupRequest request) {
+        CompletableFuture<IndexLookupResponse> response = new CompletableFuture<>();
+        replicaManager.indexLookup(toIndexLookupData(request), response::complete);
         return response;
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/RpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/RpcMessageUtils.java
@@ -52,6 +52,7 @@ import com.alibaba.fluss.rpc.messages.GetFileSystemSecurityTokenResponse;
 import com.alibaba.fluss.rpc.messages.GetKvSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.GetLakeTableSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.GetPartitionSnapshotResponse;
+import com.alibaba.fluss.rpc.messages.IndexLookupRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
@@ -72,6 +73,7 @@ import com.alibaba.fluss.rpc.messages.PbFetchLogReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbFetchLogReqForTable;
 import com.alibaba.fluss.rpc.messages.PbFetchLogRespForBucket;
 import com.alibaba.fluss.rpc.messages.PbFetchLogRespForTable;
+import com.alibaba.fluss.rpc.messages.PbIndexLookupReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbKeyValue;
 import com.alibaba.fluss.rpc.messages.PbLakeSnapshotForBucket;
 import com.alibaba.fluss.rpc.messages.PbLakeStorageInfo;
@@ -581,6 +583,28 @@ public class RpcMessageUtils {
         long tableId = lookupRequest.getTableId();
         Map<TableBucket, List<byte[]>> lookupEntryData = new HashMap<>();
         for (PbLookupReqForBucket lookupReqForBucket : lookupRequest.getBucketsReqsList()) {
+            TableBucket tb =
+                    new TableBucket(
+                            tableId,
+                            lookupReqForBucket.hasPartitionId()
+                                    ? lookupReqForBucket.getPartitionId()
+                                    : null,
+                            lookupReqForBucket.getBucketId());
+            List<byte[]> keys = new ArrayList<>(lookupReqForBucket.getKeysCount());
+            for (int i = 0; i < lookupReqForBucket.getKeysCount(); i++) {
+                keys.add(lookupReqForBucket.getKeyAt(i));
+            }
+            lookupEntryData.put(tb, keys);
+        }
+        return lookupEntryData;
+    }
+
+    public static Map<TableBucket, List<byte[]>> toIndexLookupData(
+            IndexLookupRequest indexLookupRequest) {
+        long tableId = indexLookupRequest.getTableId();
+        Map<TableBucket, List<byte[]>> lookupEntryData = new HashMap<>();
+        for (PbIndexLookupReqForBucket lookupReqForBucket :
+                indexLookupRequest.getBucketsReqsList()) {
             TableBucket tb =
                     new TableBucket(
                             tableId,

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
@@ -41,6 +41,8 @@ import com.alibaba.fluss.rpc.messages.GetTableRequest;
 import com.alibaba.fluss.rpc.messages.GetTableResponse;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaResponse;
+import com.alibaba.fluss.rpc.messages.IndexLookupRequest;
+import com.alibaba.fluss.rpc.messages.IndexLookupResponse;
 import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanRequest;
@@ -181,6 +183,11 @@ public class TestTabletServerGateway implements TabletServerGateway {
     @Override
     public CompletableFuture<LookupResponse> lookup(LookupRequest request) {
         return null;
+    }
+
+    @Override
+    public CompletableFuture<IndexLookupResponse> indexLookup(IndexLookupRequest request) {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
Index lookup is a feature that exposes lookup capabilities built on top of secondary indexes. By using secondary indexes, the required data can be located quickly, which can be utilized in conjunction with Flink to implement delta joins. 
The purpose of this PR is to provide index lookup for kv tables. The implementation approach is to define the primary key of the kv storage as "secondary keys + primary key", and set the bucket key to the secondary keys. This way, when looking up data through the secondary keys, the corresponding bucket and server can be quickly identified, providing efficient point query capabilities.