### PR TITLE
[server] Support alter table to update properties and custom properties

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/FlussConnection.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/FlussConnection.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.client;
 
+import com.alibaba.fluss.annotation.VisibleForTesting;
 import com.alibaba.fluss.client.admin.Admin;
 import com.alibaba.fluss.client.admin.FlussAdmin;
 import com.alibaba.fluss.client.lookup.LookupClient;
@@ -33,7 +34,8 @@ import com.alibaba.fluss.rpc.metrics.ClientMetricGroup;
 import java.time.Duration;
 import java.util.List;
 
-final class FlussConnection implements Connection {
+/** A default implement of {@link Connection}. */
+public final class FlussConnection implements Connection {
     private final Configuration conf;
     private final RpcClient rpcClient;
     private final MetadataUpdater metadataUpdater;
@@ -129,5 +131,10 @@ final class FlussConnection implements Connection {
         clientMetricGroup.close();
         rpcClient.close();
         metricRegistry.closeAsync().get();
+    }
+
+    @VisibleForTesting
+    public MetadataUpdater getMetadataUpdater() {
+        return metadataUpdater;
     }
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/Table.java
@@ -26,8 +26,11 @@ import com.alibaba.fluss.client.scanner.snapshot.SnapshotScanner;
 import com.alibaba.fluss.client.table.writer.AppendWriter;
 import com.alibaba.fluss.client.table.writer.UpsertWrite;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
+import com.alibaba.fluss.exception.InvalidAlterTableException;
+import com.alibaba.fluss.exception.TableNotExistException;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.UpdateProperties;
 import com.alibaba.fluss.row.InternalRow;
 
 import javax.annotation.Nullable;
@@ -112,4 +115,18 @@ public interface Table extends AutoCloseable {
      * @return the {@link SnapshotScanner} to scan data from this table.
      */
     SnapshotScanner getSnapshotScanner(SnapshotScan snapshotScan);
+
+    /**
+     * Update the table properties with this table.
+     *
+     * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
+     *
+     * <ul>
+     *   <li>{@link TableNotExistException} if the table does not exist.
+     *   <li>{@link InvalidAlterTableException} if the update properties is invalid.
+     * </ul>
+     *
+     * @param updateProperties the update properties.
+     */
+    CompletableFuture<Void> updateProperties(UpdateProperties updateProperties);
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
@@ -20,8 +20,12 @@ import com.alibaba.fluss.annotation.Internal;
 import com.alibaba.fluss.exception.InvalidConfigException;
 
 import java.lang.reflect.Field;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+
+import static com.alibaba.fluss.config.ConfigOptions.TABLE_DATALAKE_ENABLED;
 
 /** Utilities of Fluss {@link ConfigOptions}. */
 @Internal
@@ -29,6 +33,10 @@ public class FlussConfigUtils {
 
     public static final Map<String, ConfigOption<?>> TABLE_OPTIONS;
     public static final Map<String, ConfigOption<?>> CLIENT_OPTIONS;
+
+    // table properties that support alter.
+    public static final List<String> TABLE_OPTIONS_SUPPORT_ALTER =
+            Collections.singletonList(TABLE_DATALAKE_ENABLED.key());
 
     static {
         TABLE_OPTIONS = extractConfigOptions("table.");

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidAlterTableException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidAlterTableException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/** Exception for invalid alter table. */
+public class InvalidAlterTableException extends ApiException {
+    public InvalidAlterTableException(String message) {
+        super(message);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/UpdateProperties.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/UpdateProperties.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.metadata;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Updating properties for updating properties. */
+public class UpdateProperties {
+    private final List<String> resetProperties;
+    private final Map<String, String> setProperties;
+    private final List<String> resetCustomProperties;
+    private final Map<String, String> setCustomProperties;
+
+    private UpdateProperties(
+            List<String> resetProperties,
+            Map<String, String> setProperties,
+            List<String> resetCustomProperties,
+            Map<String, String> setCustomProperties) {
+        this.resetProperties = resetProperties;
+        this.setProperties = setProperties;
+        this.resetCustomProperties = resetCustomProperties;
+        this.setCustomProperties = setCustomProperties;
+    }
+
+    /** Creates a builder for building update property data. */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public List<String> getResetProperties() {
+        return resetProperties;
+    }
+
+    public Map<String, String> getSetProperties() {
+        return setProperties;
+    }
+
+    public List<String> getResetCustomProperties() {
+        return resetCustomProperties;
+    }
+
+    public Map<String, String> getSetCustomProperties() {
+        return setCustomProperties;
+    }
+
+    /** Builder for {@link TableDescriptor}. */
+    public static class Builder {
+        private final List<String> resetProperties;
+        private final Map<String, String> setProperties;
+        private final List<String> resetCustomProperties;
+        private final Map<String, String> setCustomProperties;
+
+        protected Builder() {
+            this.resetProperties = new ArrayList<>();
+            this.setProperties = new HashMap<>();
+            this.resetCustomProperties = new ArrayList<>();
+            this.setCustomProperties = new HashMap<>();
+        }
+
+        public Builder resetProperty(String property) {
+            this.resetProperties.add(property);
+            return this;
+        }
+
+        public Builder setProperty(String property, String value) {
+            this.setProperties.put(property, value);
+            return this;
+        }
+
+        public Builder resetCustomProperty(String property) {
+            this.resetCustomProperties.add(property);
+            return this;
+        }
+
+        public Builder setCustomProperty(String property, String value) {
+            this.setCustomProperties.put(property, value);
+            return this;
+        }
+
+        public UpdateProperties build() {
+            return new UpdateProperties(
+                    resetProperties, setProperties, resetCustomProperties, setCustomProperties);
+        }
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.rpc.gateway;
 
+import com.alibaba.fluss.rpc.messages.AlterTableRequest;
+import com.alibaba.fluss.rpc.messages.AlterTableResponse;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.CreateTableRequest;
@@ -63,5 +65,13 @@ public interface AdminGateway extends AdminReadOnlyGateway {
     @RPC(api = ApiKeys.DROP_TABLE)
     CompletableFuture<DropTableResponse> dropTable(DropTableRequest request);
 
-    // todo: rename table & alter table
+    /**
+     * Alter table, like alter table properties and customProperties.
+     *
+     * @param request Alter table request
+     */
+    @RPC(api = ApiKeys.ALTER_TABLE)
+    CompletableFuture<AlterTableResponse> alterTable(AlterTableRequest request);
+
+    // todo: rename table
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -61,7 +61,8 @@ public enum ApiKeys {
     NOTIFY_LAKE_TABLE_OFFSET(1031, 0, 0, PRIVATE),
     DESCRIBE_LAKE_STORAGE(1032, 0, 0, PUBLIC),
     GET_LAKE_TABLE_SNAPSHOT(1033, 0, 0, PUBLIC),
-    LIMIT_SCAN(1034, 0, 0, PUBLIC);
+    LIMIT_SCAN(1034, 0, 0, PUBLIC),
+    ALTER_TABLE(1035, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -24,6 +24,7 @@ import com.alibaba.fluss.exception.DatabaseNotEmptyException;
 import com.alibaba.fluss.exception.DatabaseNotExistException;
 import com.alibaba.fluss.exception.DuplicateSequenceException;
 import com.alibaba.fluss.exception.FencedLeaderEpochException;
+import com.alibaba.fluss.exception.InvalidAlterTableException;
 import com.alibaba.fluss.exception.InvalidColumnProjectionException;
 import com.alibaba.fluss.exception.InvalidConfigException;
 import com.alibaba.fluss.exception.InvalidCoordinatorException;
@@ -174,8 +175,9 @@ public enum Errors {
     INVALID_TIMESTAMP_EXCEPTION(38, "The timestamp is invalid.", InvalidTimestampException::new),
     INVALID_CONFIG_EXCEPTION(39, "The config is invalid.", InvalidConfigException::new),
     LAKE_STORAGE_NOT_CONFIGURED_EXCEPTION(
-            40, "The lake storage is not configured.", LakeStorageNotConfiguredException::new);
-    ;
+            40, "The lake storage is not configured.", LakeStorageNotConfiguredException::new),
+    INVALID_ALTER_TABLE_EXCEPTION(
+            41, "The alter table is invalid.", InvalidAlterTableException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -99,6 +99,18 @@ message GetTableResponse {
   required bytes table_json = 3;
 }
 
+// alter table request and response.
+message AlterTableRequest {
+  required PbTablePath table_path = 1;
+  optional PbUpdateProperties update_properties = 2;
+  // TODO extend in the future, like:
+  // optional PbUpdateSchema update_schema = 3;
+  // optional PbUpdatePartitionSpec update_partition_spec = 4;
+}
+
+message AlterTableResponse {
+}
+
 // list tables request and response
 message ListTablesRequest {
   required string database_name = 1;
@@ -436,6 +448,13 @@ message PbApiVersion {
 message PbTablePath {
   required string database_name = 1;
   required string table_name = 2;
+}
+
+message PbUpdateProperties {
+  repeated PbKeyValue set_properties = 1;
+  repeated string reset_properties = 2;
+  repeated PbKeyValue set_custom_properties = 3;
+  repeated string reset_custom_properties = 4;
 }
 
 message PbPhysicalTablePath {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -28,6 +28,8 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
 import com.alibaba.fluss.rpc.messages.AdjustIsrRequest;
 import com.alibaba.fluss.rpc.messages.AdjustIsrResponse;
+import com.alibaba.fluss.rpc.messages.AlterTableRequest;
+import com.alibaba.fluss.rpc.messages.AlterTableResponse;
 import com.alibaba.fluss.rpc.messages.CommitKvSnapshotRequest;
 import com.alibaba.fluss.rpc.messages.CommitKvSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
@@ -68,6 +70,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static com.alibaba.fluss.server.utils.RpcMessageUtils.getAlterTableData;
 import static com.alibaba.fluss.server.utils.RpcMessageUtils.getCommitLakeTableSnapshotData;
 import static com.alibaba.fluss.server.utils.RpcMessageUtils.toTablePath;
 
@@ -205,6 +208,13 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         DropTableResponse response = new DropTableResponse();
         metadataManager.dropTable(
                 toTablePath(request.getTablePath()), request.isIgnoreIfNotExists());
+        return CompletableFuture.completedFuture(response);
+    }
+
+    @Override
+    public CompletableFuture<AlterTableResponse> alterTable(AlterTableRequest request) {
+        AlterTableResponse response = new AlterTableResponse();
+        metadataManager.alterTable(getAlterTableData(request));
         return CompletableFuture.completedFuture(response);
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/entity/AlterTableData.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/entity/AlterTableData.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.entity;
+
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.metadata.UpdateProperties;
+import com.alibaba.fluss.rpc.messages.AlterTableRequest;
+
+/** The data for request {@link AlterTableRequest}. */
+public class AlterTableData {
+    private final TablePath tablePath;
+    private final UpdateProperties updateProperties;
+
+    // TODO add more alter table type like add column, change schema etc.
+
+    public AlterTableData(TablePath tablePath, UpdateProperties updateProperties) {
+        this.tablePath = tablePath;
+        this.updateProperties = updateProperties;
+    }
+
+    public TablePath getTablePath() {
+        return tablePath;
+    }
+
+    public UpdateProperties getUpdatePropertiesData() {
+        return updateProperties;
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
@@ -84,6 +84,17 @@ public class TableRegistration {
                 tableDescriptor.getCustomProperties());
     }
 
+    public TableRegistration copy(
+            Map<String, String> newProperties, Map<String, String> newCustomProperties) {
+        return new TableRegistration(
+                tableId,
+                comment,
+                partitionKeys,
+                tableDistribution,
+                newProperties,
+                newCustomProperties);
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
@@ -20,6 +20,8 @@ import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
 import com.alibaba.fluss.rpc.messages.AdjustIsrRequest;
 import com.alibaba.fluss.rpc.messages.AdjustIsrResponse;
+import com.alibaba.fluss.rpc.messages.AlterTableRequest;
+import com.alibaba.fluss.rpc.messages.AlterTableResponse;
 import com.alibaba.fluss.rpc.messages.ApiVersionsRequest;
 import com.alibaba.fluss.rpc.messages.ApiVersionsResponse;
 import com.alibaba.fluss.rpc.messages.CommitKvSnapshotRequest;
@@ -119,6 +121,11 @@ public class TestCoordinatorGateway implements CoordinatorGateway {
 
     @Override
     public CompletableFuture<DropTableResponse> dropTable(DropTableRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<AlterTableResponse> alterTable(AlterTableRequest request) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
This pr is aims to support  alter table to update properties and custom properties. In this pr I introduce a new api named `alter table`, it currently only support update properties and update custom properties, but it support extends if we want add more alter table operations like `add columns`.