### PR TITLE
[conf][server] Make the size of the threads pool in tablet server scheduler configurable.

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -210,6 +210,13 @@ public class ConfigOptions {
                             "This configuration controls the directory where fluss will store its data. "
                                     + "The default value is /tmp/fluss-data");
 
+    public static final ConfigOption<Integer> SCHEDULER_THREADS =
+            key("scheduler.threads")
+                    .intType()
+                    .defaultValue(10)
+                    .withDescription(
+                            "This configuration item to set the core threads for the fluss scheduler in tablet servers.");
+
     public static final ConfigOption<Duration> WRITER_ID_EXPIRATION_TIME =
             key("server.writer-id.expiration-time")
                     .durationType()

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
@@ -59,6 +59,8 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.alibaba.fluss.config.ConfigOptions.SCHEDULER_THREADS;
+
 /**
  * Tablet server implementation. The tablet server is responsible to manage the log tablet and kv
  * tablet.
@@ -151,8 +153,7 @@ public class TabletServer extends ServerBase {
 
             this.metadataCache = new ServerMetadataCacheImpl();
 
-            // TODO set scheduler thread number.
-            this.scheduler = new FlussScheduler(10);
+            this.scheduler = new FlussScheduler(conf.get(SCHEDULER_THREADS));
             scheduler.startup();
 
             this.logManager =

--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -58,6 +58,7 @@ during the Fluss cluster working.
 | data.dir                                   | String   | /tmp/fluss-data | This configuration controls the directory where fluss will store its data. The default value is /tmp/fluss-data                                                                                                                               |
 | server.writer-id.expiration-time           | Duration | 7d              | The time that the tablet server will wait without receiving any write request from a client before expiring the related status. The default value is 7 days.                                                                                  |
 | server.writer-id.expiration-check-interval | Duration | 10min           | The interval at which to remove writer ids that have expired due to 'server.writer-id.expiration-time passing. The default value is 10 minutes.                                                                                               |
+| scheduler.threads                          | Integer  | 10              | This configuration item to set the core threads for the fluss scheduler in tablet servers. The default value is 10.                                                                                                                           |
 
 ### Zookeeper
 


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #125 

<!-- What is the purpose of the change -->

### Tests

N.A

### API and Format

N.A

### Documentation
N.A
<!-- Does this change introduce a new feature -->
