### PR TITLE
[fix] Fix round-robin strategy name typo

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/RoundRobinBucketAssigner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/RoundRobinBucketAssigner.java
@@ -28,13 +28,13 @@ import java.util.List;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 
-/** The bucket assigner use round-rabin strategy. */
+/** The bucket assigner use round-robin strategy. */
 @Internal
-public class RoundRabinBucketAssigner implements BucketAssigner {
+public class RoundRobinBucketAssigner implements BucketAssigner {
     private final PhysicalTablePath physicalTablePath;
     private final AtomicInteger counter = new AtomicInteger(new Random().nextInt());
 
-    public RoundRabinBucketAssigner(PhysicalTablePath physicalTablePath) {
+    public RoundRobinBucketAssigner(PhysicalTablePath physicalTablePath) {
         this.physicalTablePath = physicalTablePath;
     }
 

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/WriterClient.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/WriterClient.java
@@ -333,7 +333,7 @@ public class WriterClient {
             ConfigOptions.NoKeyAssigner noKeyAssigner =
                     conf.get(ConfigOptions.CLIENT_WRITER_BUCKET_NO_KEY_ASSIGNER);
             if (noKeyAssigner == ROUND_ROBIN) {
-                return new RoundRabinBucketAssigner(physicalTablePath);
+                return new RoundRobinBucketAssigner(physicalTablePath);
             } else if (noKeyAssigner == STICKY) {
                 return new StickyBucketAssigner(physicalTablePath);
             } else {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Fix round-robin strategy name typo.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
