### PR TITLE
[conf][server] Add a parameter which is the size of the thread pool in the tablet manager

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -227,6 +227,13 @@ public class ConfigOptions {
                                     + WRITER_ID_EXPIRATION_TIME.key()
                                     + " passing. The default value is 10 minutes.");
 
+    public static final ConfigOption<Integer> TABLET_MANAGER_POOL_THREADS_NUM =
+            key("tablet-manager.pool.threads.num")
+                    .intType()
+                    .defaultValue(8)
+                    .withDescription(
+                            "Number of threads used for recovery per data dir or close operations. The default value is 8.");
+
     // ------------------------------------------------------------------
     // ZooKeeper Settings
     // ------------------------------------------------------------------

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/TabletManagerBase.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/TabletManagerBase.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.server;
 
+import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.KvStorageException;
 import com.alibaba.fluss.exception.LogStorageException;
@@ -75,18 +76,16 @@ public abstract class TabletManagerBase {
 
     protected final Lock tabletCreationOrDeletionLock = new ReentrantLock();
 
-    // TODO make this parameter configurable.
-    private final int recoveryThreads;
+    private final int poolThreadsNum;
     private final TabletType tabletType;
     private final String tabletDirPrefix;
 
-    public TabletManagerBase(
-            TabletType tabletType, File dataDir, Configuration conf, int recoveryThreads) {
+    public TabletManagerBase(TabletType tabletType, File dataDir, Configuration conf) {
         this.tabletType = tabletType;
         this.tabletDirPrefix = getTabletDirPrefix(tabletType);
         this.dataDir = dataDir;
         this.conf = conf;
-        this.recoveryThreads = recoveryThreads;
+        this.poolThreadsNum = conf.getInt(ConfigOptions.TABLET_MANAGER_POOL_THREADS_NUM);
     }
 
     /**
@@ -135,7 +134,7 @@ public abstract class TabletManagerBase {
     }
 
     protected ExecutorService createThreadPool(String poolName) {
-        return Executors.newFixedThreadPool(recoveryThreads, new ExecutorThreadFactory(poolName));
+        return Executors.newFixedThreadPool(poolThreadsNum, new ExecutorThreadFactory(poolName));
     }
 
     /** Running a series of jobs in a thread pool, and return the count of the successful job. */

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
@@ -75,12 +75,8 @@ public final class KvManager extends TabletManagerBase {
     private final MemorySegmentPool memorySegmentPool;
 
     private KvManager(
-            File dataDir,
-            Configuration conf,
-            ZooKeeperClient zkClient,
-            int recoveryThreadsPerDataDir,
-            LogManager logManager) {
-        super(TabletType.KV, dataDir, conf, recoveryThreadsPerDataDir);
+            File dataDir, Configuration conf, ZooKeeperClient zkClient, LogManager logManager) {
+        super(TabletType.KV, dataDir, conf);
         this.logManager = logManager;
         this.arrowBufferAllocator = new RootAllocator(Long.MAX_VALUE);
         this.memorySegmentPool = LazyMemorySegmentPool.create(conf);
@@ -91,12 +87,7 @@ public final class KvManager extends TabletManagerBase {
             Configuration conf, ZooKeeperClient zkClient, LogManager logManager) {
         String dataDirString = conf.getString(ConfigOptions.DATA_DIR);
         File dataDir = new File(dataDirString).getAbsoluteFile();
-        return new KvManager(
-                dataDir,
-                conf,
-                zkClient,
-                conf.getInt(ConfigOptions.NETTY_SERVER_NUM_WORKER_THREADS),
-                logManager);
+        return new KvManager(dataDir, conf, zkClient, logManager);
     }
 
     public void startup() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogManager.java
@@ -85,11 +85,10 @@ public final class LogManager extends TabletManagerBase {
             File dataDir,
             Configuration conf,
             ZooKeeperClient zkClient,
-            int recoveryThreadsPerDataDir,
             Scheduler scheduler,
             Clock clock)
             throws Exception {
-        super(TabletType.LOG, dataDir, conf, recoveryThreadsPerDataDir);
+        super(TabletType.LOG, dataDir, conf);
         this.zkClient = zkClient;
         this.scheduler = scheduler;
         this.clock = clock;
@@ -103,13 +102,7 @@ public final class LogManager extends TabletManagerBase {
             throws Exception {
         String dataDirString = conf.getString(ConfigOptions.DATA_DIR);
         File dataDir = new File(dataDirString).getAbsoluteFile();
-        return new LogManager(
-                dataDir,
-                conf,
-                zkClient,
-                conf.getInt(ConfigOptions.NETTY_SERVER_NUM_WORKER_THREADS),
-                scheduler,
-                clock);
+        return new LogManager(dataDir, conf, zkClient, scheduler, clock);
     }
 
     public void startup() {

--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -58,6 +58,7 @@ during the Fluss cluster working.
 | data.dir                                   | String   | /tmp/fluss-data | This configuration controls the directory where fluss will store its data. The default value is /tmp/fluss-data                                                                                                                               |
 | server.writer-id.expiration-time           | Duration | 7d              | The time that the tablet server will wait without receiving any write request from a client before expiring the related status. The default value is 7 days.                                                                                  |
 | server.writer-id.expiration-check-interval | Duration | 10min           | The interval at which to remove writer ids that have expired due to 'server.writer-id.expiration-time passing. The default value is 10 minutes.                                                                                               |
+| tablet-manager.pool.threads.num            | Integer  | 8               | Number of threads used for recovery per data dir or close operations. The default value is 8.                                                                                                                                                 |           
 
 ### Zookeeper
 


### PR DESCRIPTION
Add a parameter which is the size of the thread pool in the tablet manager.

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
