### PR TITLE
[client] Indexed row support projection

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/FlussLogScanner.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/FlussLogScanner.java
@@ -22,7 +22,6 @@ import com.alibaba.fluss.client.metrics.ScannerMetricGroup;
 import com.alibaba.fluss.client.scanner.RemoteFileDownloader;
 import com.alibaba.fluss.client.scanner.ScanRecord;
 import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
@@ -113,13 +112,6 @@ public class FlussLogScanner implements LogScanner {
     private Projection sanityProjection(@Nullable int[] projectedFields, TableInfo tableInfo) {
         RowType tableRowType = tableInfo.getTableDescriptor().getSchema().toRowType();
         if (projectedFields != null) {
-            LogFormat logFormat = tableInfo.getTableDescriptor().getLogFormat();
-            if (logFormat != LogFormat.ARROW) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "Only ARROW log format supports column projection, but the log format of table '%s' is %s",
-                                tableInfo.getTablePath(), logFormat));
-            }
             for (int projectedField : projectedFields) {
                 if (projectedField < 0 || projectedField >= tableRowType.getFieldCount()) {
                     throw new IllegalArgumentException(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/LogFetcher.java
@@ -27,7 +27,6 @@ import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidMetadataException;
 import com.alibaba.fluss.fs.FsPath;
-import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableInfo;
@@ -85,8 +84,8 @@ public class LogFetcher implements Closeable {
     private final boolean isPartitioned;
     private final LogRecordReadContext readContext;
     // TODO this context can be merge with readContext. Introduce it only because log remote read
-    // currently can only do project when generate scanRecord instead of doing project while read
-    // bytes from remote file.
+    //  currently can only do project when generate scanRecord instead of doing project while read
+    //  bytes from remote file.
     private final LogRecordReadContext remoteReadContext;
     @Nullable private final Projection projection;
     private final RpcClient rpcClient;
@@ -97,7 +96,6 @@ public class LogFetcher implements Closeable {
     private final LogFetchBuffer logFetchBuffer;
     private final LogFetchCollector logFetchCollector;
     private final RemoteLogDownloader remoteLogDownloader;
-    private final LogFormat logFormat;
 
     @GuardedBy("this")
     private final Set<Integer> nodesWithPendingFetchRequests;
@@ -119,7 +117,6 @@ public class LogFetcher implements Closeable {
             RemoteFileDownloader remoteFileDownloader) {
         this.tablePath = tableInfo.getTablePath();
         this.isPartitioned = tableInfo.getTableDescriptor().isPartitioned();
-        this.logFormat = tableInfo.getTableDescriptor().getLogFormat();
         this.readContext = LogRecordReadContext.createReadContext(tableInfo, false, projection);
         this.remoteReadContext =
                 LogRecordReadContext.createReadContext(tableInfo, true, projection);
@@ -317,6 +314,8 @@ public class LogFetcher implements Closeable {
                                                 fetchResultForBucket,
                                                 readContext,
                                                 logScannerStatus,
+                                                // skipping CRC check if projection push downed as
+                                                // the data is pruned
                                                 isCheckCrcs,
                                                 fetchOffset);
                                 logFetchBuffer.add(completedFetch);
@@ -423,7 +422,8 @@ public class LogFetcher implements Closeable {
                                         .setMaxBytes(maxFetchBytes);
                         PbFetchLogReqForTable reqForTable =
                                 new PbFetchLogReqForTable().setTableId(finalTableId);
-                        if (projectionPushDownEnable()) {
+                        if (readContext.isProjectionPushDowned()) {
+                            assert projection != null;
                             reqForTable
                                     .setProjectionPushdownEnabled(true)
                                     .setProjectedFields(projection.getProjectionInOrder());
@@ -447,13 +447,6 @@ public class LogFetcher implements Closeable {
         }
 
         return logScannerStatus.fetchableBuckets(tableBucket -> !exclude.contains(tableBucket));
-    }
-
-    private boolean projectionPushDownEnable() {
-        // Currently, only ARROW log format supports projection push down to server. Other log
-        // formats will do project in client, see DefaultCompletedFetch#toScanRecord() for more
-        // details.
-        return projection != null && logFormat == LogFormat.ARROW;
     }
 
     private Integer getTableBucketLeader(TableBucket tableBucket) {

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/RemotePendingFetch.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/RemotePendingFetch.java
@@ -20,9 +20,6 @@ import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.record.FileLogRecords;
 import com.alibaba.fluss.record.LogRecordReadContext;
 import com.alibaba.fluss.remote.RemoteLogSegment;
-import com.alibaba.fluss.utils.Projection;
-
-import javax.annotation.Nullable;
 
 /**
  * {@link RemotePendingFetch} is a {@link PendingFetch} that represents a pending fetch that waiting
@@ -39,7 +36,6 @@ class RemotePendingFetch implements PendingFetch {
     private final LogRecordReadContext readContext;
     private final LogScannerStatus logScannerStatus;
     private final boolean isCheckCrc;
-    private final @Nullable Projection projection;
 
     RemotePendingFetch(
             RemoteLogSegment remoteLogSegment,
@@ -49,8 +45,7 @@ class RemotePendingFetch implements PendingFetch {
             long highWatermark,
             LogRecordReadContext readContext,
             LogScannerStatus logScannerStatus,
-            boolean isCheckCrc,
-            @Nullable Projection projection) {
+            boolean isCheckCrc) {
         this.remoteLogSegment = remoteLogSegment;
         this.downloadFuture = downloadFuture;
         this.posInLogSegment = posInLogSegment;
@@ -59,7 +54,6 @@ class RemotePendingFetch implements PendingFetch {
         this.readContext = readContext;
         this.logScannerStatus = logScannerStatus;
         this.isCheckCrc = isCheckCrc;
-        this.projection = projection;
     }
 
     @Override
@@ -83,7 +77,6 @@ class RemotePendingFetch implements PendingFetch {
                 logScannerStatus,
                 isCheckCrc,
                 fetchOffset,
-                projection,
                 downloadFuture.getRecycleCallback());
     }
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/FlussTable.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/FlussTable.java
@@ -279,7 +279,7 @@ public class FlussTable implements Table {
             }
         } else {
             LogRecordReadContext readContext =
-                    LogRecordReadContext.createReadContext(tableInfo, null);
+                    LogRecordReadContext.createReadContext(tableInfo, false, null);
             LogRecords records = MemoryLogRecords.pointToByteBuffer(recordsBuffer);
             for (LogRecordBatch logRecordBatch : records.batches()) {
                 // A batch of log record maybe little more than limit, thus we need slice the

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/log/LogFetchBufferTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/log/LogFetchBufferTest.java
@@ -250,8 +250,7 @@ public class LogFetchBufferTest {
                 readContext,
                 logScannerStatus,
                 true,
-                0L,
-                null);
+                0L);
     }
 
     private PendingFetch makePendingFetch(TableBucket tableBucket) throws Exception {

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/log/LogFetchCollectorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/scanner/log/LogFetchCollectorTest.java
@@ -157,6 +157,6 @@ public class LogFetchCollectorTest {
     private DefaultCompletedFetch makeCompletedFetch(
             TableBucket tableBucket, FetchLogResultForBucket resultForBucket, long offset) {
         return new DefaultCompletedFetch(
-                tableBucket, resultForBucket, readContext, logScannerStatus, true, offset, null);
+                tableBucket, resultForBucket, readContext, logScannerStatus, true, offset);
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/types/RowType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/types/RowType.java
@@ -84,10 +84,6 @@ public final class RowType extends DataType {
     }
 
     public RowType project(int[] projectFields) {
-        if (projectFields.length == 0) {
-            return this;
-        }
-
         List<DataField> projectedFields = new ArrayList<>();
         for (int projectField : projectFields) {
             projectedFields.add(this.fields.get(projectField));

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/Projection.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/Projection.java
@@ -70,7 +70,7 @@ public class Projection {
         return rowType.project(projectionInOrder);
     }
 
-    public int[] projection() {
+    public int[] getProjection() {
         return projection;
     }
 

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/FileLogProjectionTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/FileLogProjectionTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.record;
 
 import com.alibaba.fluss.exception.InvalidColumnProjectionException;
+import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.types.RowType;
 import com.alibaba.fluss.utils.CloseableIterator;
@@ -209,7 +210,8 @@ class FileLogProjectionTest {
                             DEFAULT_SCHEMA_ID,
                             offsetBase,
                             System.currentTimeMillis(),
-                            input));
+                            input,
+                            LogFormat.ARROW));
             offsetBase += input.size();
         }
         fileLogRecords.flush();

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
@@ -556,7 +556,8 @@ class KvTabletTest {
                 NO_WRITER_ID,
                 NO_BATCH_SEQUENCE,
                 rowKinds,
-                values);
+                values,
+                LogFormat.ARROW);
     }
 
     private MemoryLogRecords logRecords(
@@ -570,7 +571,8 @@ class KvTabletTest {
                 NO_WRITER_ID,
                 NO_BATCH_SEQUENCE,
                 rowKinds,
-                values);
+                values,
+                LogFormat.ARROW);
     }
 
     private void checkEqual(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.replica;
 
 import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.metadata.LogFormat;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
@@ -527,7 +528,8 @@ final class ReplicaTest extends ReplicaTestBase {
                 NO_WRITER_ID,
                 NO_BATCH_SEQUENCE,
                 rowKinds,
-                values);
+                values,
+                LogFormat.ARROW);
     }
 
     private LogAppendInfo putRecordsToLeader(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue:  https://github.com/alibaba/fluss/issues/150

<!-- What is the purpose of the change -->

Even if Fluss only support projection push down to server for log format as ARROW. However, INDEXED format also need to support projection push down in client side. This pr is aims to fix this bug.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
