### PR TITLE
[ci] Fix CI unstable for TableManagerITCase#testPartitionedTableManagement

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -80,7 +80,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
             TableDescriptor.builder()
                     .schema(DEFAULT_SCHEMA)
                     .comment("test table")
-                    .distributedBy(10, "id")
+                    .distributedBy(3, "id")
                     .property(ConfigOptions.TABLE_LOG_TTL, Duration.ofDays(1))
                     .customProperty("connector", "fluss")
                     .build();
@@ -350,7 +350,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                                         .column("pt", DataTypes.STRING())
                                         .build())
                         .comment("test table")
-                        .distributedBy(10, "id")
+                        .distributedBy(3, "id")
                         .partitionedBy("pt")
                         .property(ConfigOptions.TABLE_AUTO_PARTITION_ENABLED, true)
                         .property(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
@@ -649,7 +649,7 @@ class TableManagerITCase {
         return TableDescriptor.builder()
                 .schema(builder.build())
                 .comment("partitioned table")
-                .distributedBy(16)
+                .distributedBy(3)
                 .partitionedBy("dt")
                 .property(ConfigOptions.TABLE_AUTO_PARTITION_ENABLED.key(), "true")
                 .property(
@@ -662,7 +662,7 @@ class TableManagerITCase {
         return TableDescriptor.builder()
                 .schema(newSchema())
                 .comment("first table")
-                .distributedBy(16, "a")
+                .distributedBy(3, "a")
                 .build();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/175

<!-- What is the purpose of the change -->

Currently, `TableManagerITCase#testPartitionedTableManagement`, I suspect that the bucket count is set too large, which may introduce instability for the IT case.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
