### PR TITLE
[Doc] Fix wrong lakehouse storage key name in documentation

### DIFF
--- a/website/docs/maintenance/tiered-storage/lakehouse-storage.md
+++ b/website/docs/maintenance/tiered-storage/lakehouse-storage.md
@@ -23,7 +23,7 @@ Lakehouse Storage disabled by default, you must enable it manually.
 First, you must configure the lakehouse storage in `server.yaml`. Take Paimon
 as an example, you must configure the following configurations:
 ```yaml
-datalake.tiered.storage: paimon
+lakehouse.storage: paimon
 
 # the catalog config about Paimon, assuming using Filesystem catalog
 paimon.catalog.type: filesystem


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #190

<!-- What is the purpose of the change -->

Fixed error in documentation

### Tests

n/a

### API and Format

n/a

### Documentation

n/a
