### PR TITLE
[flink] Upgrade sink connector to new API version

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.connector.flink.sink;
+
+import com.alibaba.fluss.annotation.Internal;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.connector.flink.sink.writer.AppendSinkWriter;
+import com.alibaba.fluss.connector.flink.sink.writer.FlinkSinkWriter;
+import com.alibaba.fluss.connector.flink.sink.writer.UpsertSinkWriter;
+import com.alibaba.fluss.metadata.TablePath;
+
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+
+import javax.annotation.Nullable;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/** Flink sink for Fluss. */
+public class FlinkSink implements Sink<RowData> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final SinkWriterBuilder<? extends FlinkSinkWriter> builder;
+
+    public FlinkSink(SinkWriterBuilder<? extends FlinkSinkWriter> builder) {
+        this.builder = builder;
+    }
+
+    @Deprecated
+    @Override
+    public SinkWriter<RowData> createWriter(InitContext context) throws IOException {
+        throw new UnsupportedOperationException(
+                "Not supported. Use FlinkSink#createWriter(WriterInitContext context)");
+    }
+
+    @Override
+    public SinkWriter<RowData> createWriter(WriterInitContext context) throws IOException {
+        FlinkSinkWriter flinkSinkWriter = builder.createWriter();
+        flinkSinkWriter.initialize(context);
+        return flinkSinkWriter;
+    }
+
+    @Internal
+    interface SinkWriterBuilder<W extends FlinkSinkWriter> extends Serializable {
+        W createWriter();
+    }
+
+    @Internal
+    static class AppendSinkSinkWriterBuilder implements SinkWriterBuilder<AppendSinkWriter> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final TablePath tablePath;
+        private final Configuration flussConfig;
+        private final RowType tableRowType;
+
+        public AppendSinkSinkWriterBuilder(
+                TablePath tablePath, Configuration flussConfig, RowType tableRowType) {
+            this.tablePath = tablePath;
+            this.flussConfig = flussConfig;
+            this.tableRowType = tableRowType;
+        }
+
+        @Override
+        public AppendSinkWriter createWriter() {
+            return new AppendSinkWriter(tablePath, flussConfig, tableRowType);
+        }
+    }
+
+    @Internal
+    static class UpsertSinkWriterBuilder implements SinkWriterBuilder<UpsertSinkWriter> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final TablePath tablePath;
+        private final Configuration flussConfig;
+        private final RowType tableRowType;
+        private final @Nullable int[] targetColumnIndexes;
+
+        UpsertSinkWriterBuilder(
+                TablePath tablePath,
+                Configuration flussConfig,
+                RowType tableRowType,
+                @Nullable int[] targetColumnIndexes) {
+            this.tablePath = tablePath;
+            this.flussConfig = flussConfig;
+            this.tableRowType = tableRowType;
+            this.targetColumnIndexes = targetColumnIndexes;
+        }
+
+        @Override
+        public UpsertSinkWriter createWriter() {
+            return new UpsertSinkWriter(tablePath, flussConfig, tableRowType, targetColumnIndexes);
+        }
+    }
+}

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
@@ -35,13 +35,13 @@ import java.io.IOException;
 import java.io.Serializable;
 
 /** Flink sink for Fluss. */
-public class FlinkSink implements Sink<RowData> {
+class FlinkSink implements Sink<RowData> {
 
     private static final long serialVersionUID = 1L;
 
     private final SinkWriterBuilder<? extends FlinkSinkWriter> builder;
 
-    public FlinkSink(SinkWriterBuilder<? extends FlinkSinkWriter> builder) {
+    FlinkSink(SinkWriterBuilder<? extends FlinkSinkWriter> builder) {
         this.builder = builder;
     }
 
@@ -65,7 +65,7 @@ public class FlinkSink implements Sink<RowData> {
     }
 
     @Internal
-    static class AppendSinkSinkWriterBuilder implements SinkWriterBuilder<AppendSinkWriter> {
+    static class AppendSinkWriterBuilder implements SinkWriterBuilder<AppendSinkWriter> {
 
         private static final long serialVersionUID = 1L;
 
@@ -73,7 +73,7 @@ public class FlinkSink implements Sink<RowData> {
         private final Configuration flussConfig;
         private final RowType tableRowType;
 
-        public AppendSinkSinkWriterBuilder(
+        public AppendSinkWriterBuilder(
                 TablePath tablePath, Configuration flussConfig, RowType tableRowType) {
             this.tablePath = tablePath;
             this.flussConfig = flussConfig;

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
@@ -164,9 +164,9 @@ public class FlinkTableSink
         FlinkSink.SinkWriterBuilder<? extends FlinkSinkWriter> flinkSinkWriterBuilder =
                 (primaryKeyIndexes.length > 0)
                         ? new FlinkSink.UpsertSinkWriterBuilder(
-                                tablePath, flussConfig, tableRowType, targetColumnIndexes, ignoreDelete)
-                        : new FlinkSink.AppendSinkSinkWriterBuilder(
-                                tablePath, flussConfig, tableRowType, ignoreDelete);
+                        tablePath, flussConfig, tableRowType, targetColumnIndexes, ignoreDelete)
+                        : new FlinkSink.AppendSinkWriterBuilder(
+                        tablePath, flussConfig, tableRowType, ignoreDelete);
 
         FlinkSink flinkSink = new FlinkSink(flinkSinkWriterBuilder);
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
@@ -164,9 +164,13 @@ public class FlinkTableSink
         FlinkSink.SinkWriterBuilder<? extends FlinkSinkWriter> flinkSinkWriterBuilder =
                 (primaryKeyIndexes.length > 0)
                         ? new FlinkSink.UpsertSinkWriterBuilder(
-                        tablePath, flussConfig, tableRowType, targetColumnIndexes, ignoreDelete)
+                                tablePath,
+                                flussConfig,
+                                tableRowType,
+                                targetColumnIndexes,
+                                ignoreDelete)
                         : new FlinkSink.AppendSinkWriterBuilder(
-                        tablePath, flussConfig, tableRowType, ignoreDelete);
+                                tablePath, flussConfig, tableRowType, ignoreDelete);
 
         FlinkSink flinkSink = new FlinkSink(flinkSinkWriterBuilder);
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.connector.flink.sink;
 
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.connector.flink.sink.writer.FlinkSinkWriter;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.FieldEqual;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.ValueConversion;
@@ -29,7 +30,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.RowLevelModificationScanContext;
 import org.apache.flink.table.connector.sink.DynamicTableSink;
-import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.connector.sink.abilities.SupportsDeletePushDown;
 import org.apache.flink.table.connector.sink.abilities.SupportsPartitioning;
 import org.apache.flink.table.connector.sink.abilities.SupportsRowLevelDelete;
@@ -160,18 +161,16 @@ public class FlinkTableSink
             // else, it's full update, ignore the given target columns as we don't care the order
         }
 
-        FlinkSinkFunction sinkFunction =
-                primaryKeyIndexes.length > 0
-                        ? new UpsertSinkFunction(
-                                tablePath,
-                                flussConfig,
-                                tableRowType,
-                                targetColumnIndexes,
-                                ignoreDelete)
-                        : new AppendSinkFunction(
+        FlinkSink.SinkWriterBuilder<? extends FlinkSinkWriter> flinkSinkWriterBuilder =
+                (primaryKeyIndexes.length > 0)
+                        ? new FlinkSink.UpsertSinkWriterBuilder(
+                                tablePath, flussConfig, tableRowType, targetColumnIndexes, ignoreDelete)
+                        : new FlinkSink.AppendSinkSinkWriterBuilder(
                                 tablePath, flussConfig, tableRowType, ignoreDelete);
 
-        return SinkFunctionProvider.of(sinkFunction);
+        FlinkSink flinkSink = new FlinkSink(flinkSinkWriterBuilder);
+
+        return SinkV2Provider.of(flinkSink);
     }
 
     private List<String> columns(int[] columnIndexes) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/AppendSinkWriter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/AppendSinkWriter.java
@@ -21,7 +21,7 @@ import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.row.InternalRow;
 
-import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -33,13 +33,17 @@ public class AppendSinkWriter extends FlinkSinkWriter {
 
     private transient AppendWriter appendWriter;
 
-    public AppendWriter(TablePath tablePath, Configuration flussConfig, RowType tableRowType, boolean ignoreDelete) {
+    public AppendSinkWriter(
+            TablePath tablePath,
+            Configuration flussConfig,
+            RowType tableRowType,
+            boolean ignoreDelete) {
         super(tablePath, flussConfig, tableRowType, ignoreDelete);
     }
 
     @Override
-    public void initialize(WriterInitContext context) {
-        super.initialize(context);
+    public void initialize(SinkWriterMetricGroup metricGroup) {
+        super.initialize(metricGroup);
         appendWriter = table.newAppend().createWriter();
         LOG.info("Finished opening Fluss {}.", this.getClass().getSimpleName());
     }
@@ -47,11 +51,6 @@ public class AppendSinkWriter extends FlinkSinkWriter {
     @Override
     CompletableFuture<?> writeRow(RowKind rowKind, InternalRow internalRow) {
         return appendWriter.append(internalRow);
-    }
-
-    @Override
-    FlinkRowToFlussRowConverter createFlinkRowToFlussRowConverter() {
-        return FlinkRowToFlussRowConverter.create(tableRowType);
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/FlinkSinkWriter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/FlinkSinkWriter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.connector.flink.sink;
+package com.alibaba.fluss.connector.flink.sink.writer;
 
 import com.alibaba.fluss.client.Connection;
 import com.alibaba.fluss.client.ConnectionFactory;
@@ -30,14 +30,11 @@ import com.alibaba.fluss.metrics.Metric;
 import com.alibaba.fluss.metrics.MetricNames;
 import com.alibaba.fluss.row.InternalRow;
 
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -48,16 +45,13 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
-/** Flink's {@link SinkFunction} implementation for Fluss. */
-abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
-        implements CheckpointedFunction, Serializable {
+/** Base class for Flink {@link SinkWriter} implementations in Fluss. */
+public abstract class FlinkSinkWriter implements SinkWriter<RowData> {
 
-    private static final long serialVersionUID = 1L;
-    protected static final Logger LOG = LoggerFactory.getLogger(FlinkSinkFunction.class);
+    protected static final Logger LOG = LoggerFactory.getLogger(FlinkSinkWriter.class);
 
     private final TablePath tablePath;
     private final Configuration flussConfig;
@@ -76,15 +70,14 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
     private transient Counter numRecordsOutErrorsCounter;
     private volatile Throwable asyncWriterException;
 
-    public FlinkSinkFunction(
+    public FlinkSinkWriter(
             TablePath tablePath,
             Configuration flussConfig,
-            RowType tableRowType,
-            boolean ignoreDelete) {
+            RowType tableRowType) {
         this(tablePath, flussConfig, tableRowType, null, ignoreDelete);
     }
 
-    public FlinkSinkFunction(
+    public FlinkSinkWriter(
             TablePath tablePath,
             Configuration flussConfig,
             RowType tableRowType,
@@ -97,14 +90,13 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
         this.ignoreDelete = ignoreDelete;
     }
 
-    @Override
-    public void open(org.apache.flink.configuration.Configuration config) {
+    public void initialize(WriterInitContext context) {
         LOG.info(
                 "Opening Fluss {}, database: {} and table: {}",
                 this.getClass().getSimpleName(),
                 tablePath.getDatabaseName(),
                 tablePath.getTableName());
-        metricGroup = InternalSinkWriterMetricGroup.wrap(getRuntimeContext().getMetricGroup());
+        metricGroup = InternalSinkWriterMetricGroup.wrap(context.metricGroup());
         flinkMetricRegistry =
                 new FlinkMetricRegistry(
                         metricGroup, Collections.singleton(MetricNames.WRITER_SEND_LATENCY_MS));
@@ -122,7 +114,7 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
     }
 
     @Override
-    public void invoke(RowData value, SinkFunction.Context context) throws IOException {
+    public void write(RowData value, Context context) throws IOException, InterruptedException {
         checkAsyncException();
         if (ignoreDelete
                 && (value.getRowKind() == RowKind.UPDATE_BEFORE
@@ -144,19 +136,7 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
     }
 
     @Override
-    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws IOException {
-        flush();
-    }
-
-    @Override
-    public void initializeState(FunctionInitializationContext functionInitializationContext) {}
-
-    @Override
-    public void finish() throws IOException {
-        flush();
-    }
-
-    abstract void flush() throws IOException;
+    public abstract void flush(boolean endOfInput) throws IOException, InterruptedException;
 
     abstract CompletableFuture<?> writeRow(RowKind rowKind, InternalRow internalRow);
 
@@ -195,7 +175,7 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
 
     private void sanityCheck(TableInfo flussTableInfo) {
         // when it's UpsertSinkFunction, it means it has primary key got from Flink's metadata
-        boolean hasPrimaryKey = this instanceof UpsertSinkFunction;
+        boolean hasPrimaryKey = this instanceof UpsertSinkWriter;
         if (flussTableInfo.hasPrimaryKey() != hasPrimaryKey) {
             throw new ValidationException(
                     String.format(

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/UpsertSinkWriter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/writer/UpsertSinkWriter.java
@@ -16,14 +16,13 @@
 
 package com.alibaba.fluss.connector.flink.sink.writer;
 
-import com.alibaba.fluss.client.table.writer.UpsertWrite;
+import com.alibaba.fluss.client.table.writer.Upsert;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
 import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.connector.flink.utils.FlinkRowToFlussRowConverter;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.row.InternalRow;
 
-import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.types.RowKind;
 
@@ -47,8 +46,8 @@ public class UpsertSinkWriter extends FlinkSinkWriter {
     }
 
     @Override
-    public void initialize(WriterInitContext context) {
-        super.initialize(context);
+    public void initialize(SinkWriterMetricGroup metricGroup) {
+        super.initialize(metricGroup);
         Upsert upsert = table.newUpsert();
         if (targetColumnIndexes != null) {
             upsert = upsert.partialUpdate(targetColumnIndexes);

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
@@ -18,33 +18,47 @@ package com.alibaba.fluss.connector.flink.sink;
 
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.connector.flink.sink.writer.AppendSinkWriter;
+import com.alibaba.fluss.connector.flink.sink.writer.FlinkSinkWriter;
 import com.alibaba.fluss.connector.flink.source.testutils.FlinkTestBase;
 import com.alibaba.fluss.metadata.DatabaseDescriptor;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TablePath;
 
+import org.apache.flink.api.common.JobInfo;
+import org.apache.flink.api.common.TaskInfo;
+import org.apache.flink.api.common.operators.MailboxExecutor;
+import org.apache.flink.api.common.operators.ProcessingTimeService;
+import org.apache.flink.api.common.serialization.SerializationSchema;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.metrics.Counter;
 import org.apache.flink.metrics.Gauge;
 import org.apache.flink.metrics.Metric;
 import org.apache.flink.metrics.groups.OperatorMetricGroup;
+import org.apache.flink.metrics.groups.SinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.MetricNames;
+import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.runtime.metrics.util.InterceptingOperatorMetricGroup;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
 import org.apache.flink.streaming.util.MockStreamingRuntimeContext;
 import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.util.UserCodeClassLoader;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
+import java.util.OptionalLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
-/** Test for {@link FlinkSinkFunction}. */
-public class FlinkSinkFunctionTest extends FlinkTestBase {
+/** Test for {@link com.alibaba.fluss.connector.flink.sink.writer.FlinkSinkWriter}. */
+public class FlinkSinkWriterTest extends FlinkTestBase {
 
     @ParameterizedTest
     @ValueSource(strings = {"", "1"})
@@ -62,6 +76,7 @@ public class FlinkSinkFunctionTest extends FlinkTestBase {
         createTable(tablePath, tableDescriptor);
         Configuration flussConf = FLUSS_CLUSTER_EXTENSION.getClientConfig();
         flussConf.set(ConfigOptions.CLIENT_ID, clientId);
+
         RowType rowType =
                 new RowType(
                         true,
@@ -79,11 +94,13 @@ public class FlinkSinkFunctionTest extends FlinkTestBase {
                         return interceptingOperatorMetricGroup;
                     }
                 };
-        flinkSinkFunction.setRuntimeContext(mockStreamingRuntimeContext);
-        flinkSinkFunction.open(new org.apache.flink.configuration.Configuration());
-        flinkSinkFunction.invoke(
-                GenericRowData.of(1, StringData.fromString("a")), new MockSinkContext());
-        flinkSinkFunction.flush();
+        MockWriterInitContext mockWriterInitContext =
+                new MockWriterInitContext(mockStreamingRuntimeContext);
+
+        flinkSinkFunction.initialize(mockWriterInitContext);
+        flinkSinkFunction.write(
+                GenericRowData.of(1, StringData.fromString("a")), new MockSinkWriterContext());
+        flinkSinkFunction.flush(false);
 
         Metric currentSendTime = interceptingOperatorMetricGroup.get(MetricNames.CURRENT_SEND_TIME);
         assertThat(currentSendTime).isInstanceOf(Gauge.class);
@@ -96,12 +113,7 @@ public class FlinkSinkFunctionTest extends FlinkTestBase {
         flinkSinkFunction.close();
     }
 
-    static class MockSinkContext implements SinkFunction.Context {
-        @Override
-        public long currentProcessingTime() {
-            return 0;
-        }
-
+    static class MockSinkWriterContext implements SinkWriter.Context {
         @Override
         public long currentWatermark() {
             return 0;
@@ -110,6 +122,78 @@ public class FlinkSinkFunctionTest extends FlinkTestBase {
         @Override
         public Long timestamp() {
             return 0L;
+        }
+    }
+
+    static class MockWriterInitContext implements WriterInitContext {
+
+        private static final String UNEXPECTED_METHOD_CALL_MESSAGE =
+                "Unexpected method call. Expected that this method will never be called by a test case.";
+
+        private final MockStreamingRuntimeContext mockStreamingRuntimeContext;
+
+        public MockWriterInitContext(MockStreamingRuntimeContext mockStreamingRuntimeContext) {
+            this.mockStreamingRuntimeContext = mockStreamingRuntimeContext;
+        }
+
+        @Override
+        public UserCodeClassLoader getUserCodeClassLoader() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public MailboxExecutor getMailboxExecutor() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public ProcessingTimeService getProcessingTimeService() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public SinkWriterMetricGroup metricGroup() {
+            return InternalSinkWriterMetricGroup.wrap(mockStreamingRuntimeContext.getMetricGroup());
+        }
+
+        @Override
+        public SerializationSchema.InitializationContext
+                asSerializationSchemaInitializationContext() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public boolean isObjectReuseEnabled() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return false;
+        }
+
+        @Override
+        public <IN> TypeSerializer<IN> createInputSerializer() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public OptionalLong getRestoredCheckpointId() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return OptionalLong.empty();
+        }
+
+        @Override
+        public JobInfo getJobInfo() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        @Override
+        public TaskInfo getTaskInfo() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
         }
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
@@ -83,8 +83,9 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
                         Arrays.asList(
                                 new RowType.RowField("id", DataTypes.INT().getLogicalType()),
                                 new RowType.RowField("name", DataTypes.STRING().getLogicalType())));
-        FlinkSinkFunction flinkSinkFunction =
-                new AppendSinkFunction(tablePath, flussConf, rowType, false);
+        FlinkSinkWriter flinkSinkWriter =
+                new AppendSinkWriter(tablePath, flussConf, rowType, false);
+
         InterceptingOperatorMetricGroup interceptingOperatorMetricGroup =
                 new InterceptingOperatorMetricGroup();
         MockStreamingRuntimeContext mockStreamingRuntimeContext =
@@ -97,10 +98,10 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
         MockWriterInitContext mockWriterInitContext =
                 new MockWriterInitContext(mockStreamingRuntimeContext);
 
-        flinkSinkFunction.initialize(mockWriterInitContext);
-        flinkSinkFunction.write(
+        flinkSinkWriter.initialize(mockWriterInitContext.metricGroup());
+        flinkSinkWriter.write(
                 GenericRowData.of(1, StringData.fromString("a")), new MockSinkWriterContext());
-        flinkSinkFunction.flush(false);
+        flinkSinkWriter.flush(false);
 
         Metric currentSendTime = interceptingOperatorMetricGroup.get(MetricNames.CURRENT_SEND_TIME);
         assertThat(currentSendTime).isInstanceOf(Gauge.class);
@@ -110,7 +111,7 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
         assertThat(numRecordSend).isInstanceOf(Counter.class);
         assertThat(((Counter) numRecordSend).getCount()).isGreaterThan(0);
 
-        flinkSinkFunction.close();
+        flinkSinkWriter.close();
     }
 
     static class MockSinkWriterContext implements SinkWriter.Context {

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/source/FlussDatabaseSyncSourceITCase.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/source/FlussDatabaseSyncSourceITCase.java
@@ -97,7 +97,7 @@ class FlussDatabaseSyncSourceITCase extends FlinkTestBase {
                         syncDatabaseFlussSource,
                         WatermarkStrategy.noWatermarks(),
                         "flinkSyncDatabaseSource");
-        input.addSink(new TestingDatabaseSyncSink(sinkDataBase, clientConf));
+        input.sinkTo(new TestingDatabaseSyncSink(sinkDataBase, clientConf));
 
         JobClient jobClient = execEnv.executeAsync();
         // check the records are synced to target database
@@ -210,7 +210,7 @@ class FlussDatabaseSyncSourceITCase extends FlinkTestBase {
                         syncDatabaseFlussSource,
                         WatermarkStrategy.noWatermarks(),
                         "flinkSyncDatabaseSource");
-        input.addSink(new TestingDatabaseSyncSink(sinkDataBase, clientConf));
+        input.sinkTo(new TestingDatabaseSyncSink(sinkDataBase, clientConf));
 
         // execute the sync job
         JobClient jobClient = execEnv.executeAsync();

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/testutils/TestingDatabaseSyncSink.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/testutils/TestingDatabaseSyncSink.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *  Copyright (c) 2024 Alibaba Group Holding Ltd.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 
 package com.alibaba.fluss.lakehouse.paimon.testutils;
@@ -26,32 +26,25 @@ import com.alibaba.fluss.lakehouse.paimon.record.MultiplexCdcRecord;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
-import org.apache.flink.streaming.api.functions.sink.SinkFunction;
-import org.apache.flink.table.connector.sink.SinkFunctionProvider;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.runtime.connector.sink.SinkRuntimeProviderContext;
 
-import java.io.Serializable;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 /** A sink to write {@link MultiplexCdcRecord} to fluss for testing purpose. */
-public class TestingDatabaseSyncSink extends RichSinkFunction<MultiplexCdcRecord>
-        implements CheckpointedFunction, Serializable {
+public class TestingDatabaseSyncSink implements Sink<MultiplexCdcRecord> {
 
     private static final long serialVersionUID = 1L;
 
-    private final Configuration flussConfig;
     private final String sinkDataBase;
-    private org.apache.flink.configuration.Configuration flinkConfig;
-
-    private transient Connection connection;
-    private transient Admin admin;
-    private transient Map<TablePath, SinkFunction<RowData>> sinkByTablePath;
+    private final Configuration flussConfig;
 
     public TestingDatabaseSyncSink(String sinkDataBase, Configuration flussConfig) {
         this.sinkDataBase = sinkDataBase;
@@ -59,77 +52,121 @@ public class TestingDatabaseSyncSink extends RichSinkFunction<MultiplexCdcRecord
     }
 
     @Override
-    public void open(org.apache.flink.configuration.Configuration config) {
-        this.connection = ConnectionFactory.createConnection(flussConfig);
-        this.admin = connection.getAdmin();
-        this.flinkConfig = config;
-        this.sinkByTablePath = new HashMap<>();
+    public SinkWriter<MultiplexCdcRecord> createWriter(WriterInitContext context)
+            throws IOException {
+        return new TestingDatabaseSyncSinkWriter(sinkDataBase, flussConfig, context);
     }
 
+    @Deprecated
     @Override
-    public void initializeState(FunctionInitializationContext functionInitializationContext) {
-        // do nothing
+    public SinkWriter<MultiplexCdcRecord> createWriter(InitContext context) throws IOException {
+        return new TestingDatabaseSyncSinkWriter(sinkDataBase, flussConfig, context);
     }
 
-    @Override
-    public void invoke(MultiplexCdcRecord record, SinkFunction.Context context) throws Exception {
-        TablePath tablePath = record.getTablePath();
-        SinkFunction<RowData> sinkFunction = sinkByTablePath.get(tablePath);
-        if (sinkFunction == null) {
-            TableInfo tableInfo = admin.getTableInfo(tablePath).get();
+    /** A sink writer to write {@link MultiplexCdcRecord} to fluss for testing purpose. */
+    public static class TestingDatabaseSyncSinkWriter implements SinkWriter<MultiplexCdcRecord> {
 
-            FlinkTableSink flinkTableSink =
-                    new FlinkTableSink(
-                            // write to the sink database
-                            new TablePath(sinkDataBase, tablePath.getTableName()),
-                            flussConfig,
-                            FlinkConversions.toFlinkRowType(tableInfo.getRowType()),
-                            tableInfo.getSchema().getPrimaryKeyIndexes(),
-                            true,
-                            null,
-                            false);
+        private final String sinkDataBase;
+        private final Configuration flussConfig;
 
-            sinkFunction =
-                    ((SinkFunctionProvider)
-                                    flinkTableSink.getSinkRuntimeProvider(
-                                            new SinkRuntimeProviderContext(false)))
-                            .createSinkFunction();
+        private WriterInitContext writerInitContext;
+        @Deprecated private InitContext initContext;
 
-            if (sinkFunction instanceof RichSinkFunction) {
-                RichSinkFunction<RowData> richSinkFunction =
-                        (RichSinkFunction<RowData>) sinkFunction;
-                richSinkFunction.setRuntimeContext(getRuntimeContext());
-                richSinkFunction.open(flinkConfig);
+        private transient Connection connection;
+        private transient Admin admin;
+        private transient Map<TablePath, SinkWriter<RowData>> sinkWriterByTablePath;
+
+        private TestingDatabaseSyncSinkWriter(String sinkDataBase, Configuration flussConfig) {
+            this.sinkDataBase = sinkDataBase;
+            this.flussConfig = flussConfig;
+            this.connection = ConnectionFactory.createConnection(flussConfig);
+            this.admin = connection.getAdmin();
+            this.sinkWriterByTablePath = new HashMap<>();
+        }
+
+        public TestingDatabaseSyncSinkWriter(
+                String sinkDataBase, Configuration flussConfig, WriterInitContext writerInitContext)
+                throws IOException {
+            this(sinkDataBase, flussConfig);
+            this.writerInitContext = writerInitContext;
+            this.initContext = null;
+        }
+
+        @Deprecated
+        public TestingDatabaseSyncSinkWriter(
+                String sinkDataBase, Configuration flussConfig, InitContext context)
+                throws IOException {
+            this(sinkDataBase, flussConfig);
+            this.writerInitContext = null;
+            this.initContext = context;
+        }
+
+        @Override
+        public void write(MultiplexCdcRecord record, Context context)
+                throws IOException, InterruptedException {
+            TablePath tablePath = record.getTablePath();
+            SinkWriter<RowData> sinkWriter = sinkWriterByTablePath.get(tablePath);
+
+            if (sinkWriter == null) {
+                TableInfo tableInfo;
+                try {
+                    tableInfo = admin.getTableInfo(tablePath).get();
+                } catch (ExecutionException e) {
+                    throw new RuntimeException(e);
+                }
+
+                FlinkTableSink flinkTableSink =
+                        new FlinkTableSink(
+                                // write to the sink database
+                                new TablePath(sinkDataBase, tablePath.getTableName()),
+                                flussConfig,
+                                FlinkConversions.toFlinkRowType(tableInfo.getRowType()),
+                                tableInfo.getSchema().getPrimaryKeyIndexes(),
+                                true,
+                                null,
+                                false);
+
+                Sink<RowData> sink =
+                        ((SinkV2Provider)
+                                        flinkTableSink.getSinkRuntimeProvider(
+                                                new SinkRuntimeProviderContext(false)))
+                                .createSink();
+
+                if (writerInitContext != null) {
+                    sinkWriter = sink.createWriter(writerInitContext);
+                } else if (initContext != null) {
+                    sinkWriter = sink.createWriter(initContext);
+                } else {
+                    throw new IllegalStateException(
+                            "Neither writer init context nor init context was set.");
+                }
+
+                sinkWriterByTablePath.put(tablePath, sinkWriter);
             }
-            sinkByTablePath.put(tablePath, sinkFunction);
+
+            sinkWriter.write(record.getCdcRecord().getRowData(), context);
         }
 
-        sinkFunction.invoke(record.getCdcRecord().getRowData(), context);
-    }
-
-    @Override
-    public void snapshotState(FunctionSnapshotContext functionSnapshotContext) throws Exception {
-        for (SinkFunction<RowData> sinkFunction : sinkByTablePath.values()) {
-            if (sinkFunction instanceof CheckpointedFunction) {
-                ((CheckpointedFunction) sinkFunction).snapshotState(functionSnapshotContext);
+        @Override
+        public void flush(boolean endOfInput) throws IOException, InterruptedException {
+            for (SinkWriter<RowData> sinkWriter : sinkWriterByTablePath.values()) {
+                sinkWriter.flush(endOfInput);
             }
         }
-    }
 
-    @Override
-    public void close() throws Exception {
-        super.close();
-        if (admin != null) {
-            admin.close();
-        }
-        if (connection != null) {
-            connection.close();
-        }
+        @Override
+        public void close() throws Exception {
+            if (admin != null) {
+                admin.close();
+            }
 
-        if (sinkByTablePath != null) {
-            for (SinkFunction<RowData> sinkFunction : sinkByTablePath.values()) {
-                if (sinkFunction instanceof RichSinkFunction) {
-                    ((RichSinkFunction<RowData>) sinkFunction).close();
+            if (connection != null) {
+                connection.close();
+            }
+
+            if (sinkWriterByTablePath != null) {
+                for (SinkWriter<RowData> sinkWriter : sinkWriterByTablePath.values()) {
+                    sinkWriter.close();
                 }
             }
         }

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -247,6 +247,7 @@
                                         <exlucde>
                                             com.alibaba.fluss.connector.flink.source.reader.RecordAndPos
                                         </exlucde>
+                                        <exclude>com.alibaba.fluss.connector.flink.sink.FlinkSink</exclude>
                                         <exclude>
                                             com.alibaba.fluss.connector.flink.metrics.*
                                         </exclude>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #132

Upgrade sink connector from deprecated RichSinkFunction (will be removed in Flink 2.0) to new Sink interface

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

- UT (adapted to new implementation, test case logic unchanged): `com.alibaba.fluss.connector.flink.sink.FlinkSinkWriterTest.java`
- IT (_unchanged_, because external interface did not change): `com.alibaba.fluss.connector.flink.sink.FlinkTableSinkITCase.java`

### API and Format

<!-- Does this change affect API or storage format -->
n/a

### Documentation

<!-- Does this change introduce a new feature -->
n/a