### PR TITLE
[connector] FlinkRowToFlussRowConverter pass byte[] rather than string From Flink StringData to Fluss BinaryString.

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverter.java
@@ -142,7 +142,7 @@ public class FlinkRowToFlussRowConverter implements AutoCloseable {
             case VARCHAR:
                 return (flinkField) -> {
                     StringData stringData = (StringData) flinkField;
-                    return BinaryString.fromString(stringData.toString());
+                    return BinaryString.fromBytes(stringData.toBytes());
                 };
             case DECIMAL:
                 return (flinkField) -> {


### PR DESCRIPTION


### Purpose
fix [#255](https://github.com/alibaba/fluss/issues/225)

