### PR TITLE
[bug] update checkstyle-plugin version and doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,13 +884,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.6.0</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- Note: match version with docs/dev/ide-setup.md -->
-                            <version>8.14</version>
+                            <version>9.3</version>
                         </dependency>
                     </dependencies>
                     <executions>

--- a/tools/maven/checkstyle.xml
+++ b/tools/maven/checkstyle.xml
@@ -15,8 +15,8 @@
  limitations under the License.
 -->
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <!--
 This is a checkstyle configuration file. For descriptions of
@@ -28,10 +28,6 @@ This file is based on the checkstyle file of Apache Beam.
 
 <module name="Checker">
 
-    <module name="NewlineAtEndOfFile">
-        <!-- windows can use \r\n vs \n, so enforce the most used one ie UNIx style -->
-        <property name="lineSeparator" value="lf"/>
-    </module>
 
     <module name="RegexpSingleline">
         <!-- Checks that TODOs don't have stuff in parenthesis, e.g., username. -->
@@ -264,16 +260,16 @@ This file is based on the checkstyle file of Apache Beam.
         <!-- Checks for Javadoc comments.                     -->
         <!-- See http://checkstyle.sf.net/config_javadoc.html -->
         <module name="JavadocMethod">
-            <property name="scope" value="protected"/>
+            <property name="accessModifiers" value="protected"/>
             <property name="severity" value="error"/>
-            <property name="allowMissingJavadoc" value="true"/>
+            <!--            <property name="allowMissingJavadoc" value="true"/>-->
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
-            <property name="allowMissingThrowsTags" value="true"/>
-            <property name="allowThrowsTagsForSubclasses" value="true"/>
-            <property name="allowUndeclaredRTE" value="true"/>
+            <!--            <property name="allowMissingThrowsTags" value="true"/>-->
+            <!--            <property name="allowThrowsTagsForSubclasses" value="true"/>-->
+            <!--            <property name="allowUndeclaredRTE" value="true"/>-->
             <!-- This check sometimes failed for with "Unable to get class information for @throws tag" for custom exceptions -->
-            <property name="suppressLoadErrors" value="true"/>
+            <!--            <property name="suppressLoadErrors" value="true"/>-->
         </module>
 
         <!-- Check that paragraph tags are used correctly in Javadoc. -->

--- a/website/docs/dev/ide-setup.md
+++ b/website/docs/dev/ide-setup.md
@@ -119,7 +119,7 @@ You can also format the whole project via Maven by using `mvn spotless:apply`.
 
 1. Go to "Settings" → "Tools" → "Checkstyle".
 2. Set "Scan Scope" to "Only Java sources (including tests)".
-3. For "Checkstyle Version" select "10.18.2".
+3. For "Checkstyle Version" select "9.6".
 4. Under "Configuration File" click the "+" icon to add a new configuration.
 5. Set "Description" to "Fluss".
 6. Select "Use a local Checkstyle file" and point it to `tools/maven/checkstyle.xml` located within

--- a/website/docs/dev/ide-setup.md
+++ b/website/docs/dev/ide-setup.md
@@ -119,7 +119,7 @@ You can also format the whole project via Maven by using `mvn spotless:apply`.
 
 1. Go to "Settings" → "Tools" → "Checkstyle".
 2. Set "Scan Scope" to "Only Java sources (including tests)".
-3. For "Checkstyle Version" select "9.6".
+3. For "Checkstyle Version" select "9.3".
 4. Under "Configuration File" click the "+" icon to add a new configuration.
 5. Set "Description" to "Fluss".
 6. Select "Use a local Checkstyle file" and point it to `tools/maven/checkstyle.xml` located within


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: fix #220 


Here are the changes I made:
1. Upgraded to version 3.6.0 according to the information on the [official website](https://maven.apache.org/plugins/maven-checkstyle-plugin/history.html) (since Fluss is still compiled with JDK 8).
2. Removed invalid Checkstyle options.
3. Removed the NewlineAtEndOfFile check because it causes a significant number of Checkstyle errors when compiling on Windows (approximately 1,400 files fail to comply).

我做了如下改动：
1. 根据[官方网站](https://maven.apache.org/plugins/maven-checkstyle-plugin/history.html)提供的信息，升级到了3.6.0版本（因为fluss目前仍然是JDK8编译的）;
2. 删除无效的checkstyle选项;
3. 删除NewlineAtEndOfFile的检查。因为在windows上进行编译，会产生大量的checkstyle错误（大概1400多个文件不符合要求）。


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
