### PR TITLE
[kv] Support first row merge engine

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
@@ -890,13 +890,13 @@ class FlussTableITCase extends ClientToServerITCaseBase {
         RowType rowType = DATA1_SCHEMA_PK.toRowType();
         createTable(DATA1_TABLE_PATH_PK, tableDescriptor, false);
         int rows = 5;
-        int rowNum = 3;
+        int duplicateNum = 3;
         try (Table table = conn.getTable(DATA1_TABLE_PATH_PK)) {
             // first, put rows
             UpsertWriter upsertWriter = table.getUpsertWriter();
             List<InternalRow> expectedRows = new ArrayList<>(rows);
             for (int row = 0; row < rows; row++) {
-                for (int num = 0; num < rowNum; num++) {
+                for (int num = 0; num < duplicateNum; num++) {
                     upsertWriter.upsert(compactedRow(rowType, new Object[] {row, "value_" + num}));
                 }
                 expectedRows.add(compactedRow(rowType, new Object[] {row, "value_0"}));

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -20,6 +20,7 @@ import com.alibaba.fluss.annotation.Internal;
 import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.utils.ArrayUtils;
 
 import java.time.Duration;
@@ -1320,21 +1321,5 @@ public class ConfigOptions {
         SNAPPY,
         LZ4,
         ZSTD
-    }
-
-    /** The merge engine for primary key table. */
-    public enum MergeEngine {
-        FIRST_ROW("first_row");
-
-        private final String value;
-
-        MergeEngine(String value) {
-            this.value = value;
-        }
-
-        @Override
-        public String toString() {
-            return value;
-        }
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -968,6 +968,12 @@ public class ConfigOptions {
                                     + "When this option is set to ture and the datalake tiering service is up,"
                                     + " the table will be tiered and compacted into datalake format stored on lakehouse storage.");
 
+    public static final ConfigOption<MergeEngine> TABLE_MERGE_ENGINE =
+            key("table.merge-engine")
+                    .enumType(MergeEngine.class)
+                    .noDefaultValue()
+                    .withDescription("The merge engine for the primary key table.");
+
     // ------------------------------------------------------------------------
     //  ConfigOptions for Kv
     // ------------------------------------------------------------------------
@@ -1314,5 +1320,21 @@ public class ConfigOptions {
         SNAPPY,
         LZ4,
         ZSTD
+    }
+
+    /** The merge engine for primary key table. */
+    public enum MergeEngine {
+        FIRST_ROW("first_row");
+
+        private final String value;
+
+        MergeEngine(String value) {
+            this.value = value;
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/MergeEngine.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/MergeEngine.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.metadata;
+
+/**
+ * The merge engine for primary key table.
+ *
+ * @since 0.6
+ */
+public enum MergeEngine {
+    FIRST_ROW("first_row");
+
+    private final String value;
+
+    MergeEngine(String value) {
+        this.value = value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
@@ -134,6 +134,11 @@ public final class TableDescriptor implements Serializable {
             throw new IllegalArgumentException(
                     "For Primary Key Table, if kv format is compacted, log format must be arrow.");
         }
+
+        if (!hasPrimaryKey() && getMergeEngine() != null) {
+            throw new IllegalArgumentException(
+                    "Merge-engine is only supported in primary key table.");
+        }
     }
 
     /** Creates a builder for building table descriptor. */
@@ -273,6 +278,10 @@ public final class TableDescriptor implements Serializable {
     /** Whether the data lake is enabled. */
     public boolean isDataLakeEnabled() {
         return configuration().get(ConfigOptions.TABLE_DATALAKE_ENABLED);
+    }
+
+    public @Nullable ConfigOptions.MergeEngine getMergeEngine() {
+        return configuration().get(ConfigOptions.TABLE_MERGE_ENGINE);
     }
 
     public TableDescriptor copy(Map<String, String> newProperties) {

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableDescriptor.java
@@ -280,7 +280,7 @@ public final class TableDescriptor implements Serializable {
         return configuration().get(ConfigOptions.TABLE_DATALAKE_ENABLED);
     }
 
-    public @Nullable ConfigOptions.MergeEngine getMergeEngine() {
+    public @Nullable MergeEngine getMergeEngine() {
         return configuration().get(ConfigOptions.TABLE_MERGE_ENGINE);
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -52,15 +52,10 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.alibaba.fluss.connector.flink.catalog.FlinkCatalog.LAKE_TABLE_SPLITTER;
-import static org.apache.flink.configuration.ConfigOptions.key;
+import static com.alibaba.fluss.connector.flink.utils.FlinkConversions.toFlinkOption;
 
 /** Factory to create table source and table sink for Fluss. */
 public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
-
-    private static final ConfigOption<ConfigOptions.MergeEngine> MERGE_ENGINE_OPTION =
-            key(ConfigOptions.TABLE_MERGE_ENGINE.key())
-                    .enumType(ConfigOptions.MergeEngine.class)
-                    .noDefaultValue();
 
     private volatile LakeTableFactory lakeTableFactory;
 
@@ -119,15 +114,10 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                 tableOptions
                         .get(FlinkConnectorOptions.SCAN_PARTITION_DISCOVERY_INTERVAL)
                         .toMillis();
-        boolean isDatalakeEnabled =
-                tableOptions.get(
-                        key(ConfigOptions.TABLE_DATALAKE_ENABLED.key())
-                                .booleanType()
-                                .defaultValue(false));
 
         return new FlinkTableSource(
                 toFlussTablePath(context.getObjectIdentifier()),
-                toFlussClientConfig(helper.getOptions(), context.getConfiguration()),
+                toFlussClientConfig(tableOptions, context.getConfiguration()),
                 tableOutputType,
                 primaryKeyIndexes,
                 bucketKeyIndexes,
@@ -138,7 +128,8 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                 tableOptions.get(FlinkConnectorOptions.LOOKUP_ASYNC),
                 cache,
                 partitionDiscoveryIntervalMs,
-                isDatalakeEnabled);
+                tableOptions.get(toFlinkOption(ConfigOptions.TABLE_DATALAKE_ENABLED)),
+                tableOptions.get(toFlinkOption(ConfigOptions.TABLE_MERGE_ENGINE)));
     }
 
     @Override
@@ -151,14 +142,15 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                         == RuntimeExecutionMode.STREAMING;
 
         RowType rowType = (RowType) context.getPhysicalRowDataType().getLogicalType();
+        final ReadableConfig tableOptions = helper.getOptions();
 
         return new FlinkTableSink(
                 toFlussTablePath(context.getObjectIdentifier()),
-                toFlussClientConfig(helper.getOptions(), context.getConfiguration()),
+                toFlussClientConfig(tableOptions, context.getConfiguration()),
                 rowType,
                 context.getPrimaryKeyIndexes(),
                 isStreamingMode,
-                helper.getOptions().get(MERGE_ENGINE_OPTION));
+                tableOptions.get(toFlinkOption(ConfigOptions.TABLE_MERGE_ENGINE)));
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -57,6 +57,11 @@ import static org.apache.flink.configuration.ConfigOptions.key;
 /** Factory to create table source and table sink for Fluss. */
 public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTableSinkFactory {
 
+    private static final ConfigOption<ConfigOptions.MergeEngine> MERGE_ENGINE_OPTION =
+            key(ConfigOptions.TABLE_MERGE_ENGINE.key())
+                    .enumType(ConfigOptions.MergeEngine.class)
+                    .noDefaultValue();
+
     private volatile LakeTableFactory lakeTableFactory;
 
     @Override
@@ -146,12 +151,6 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                         == RuntimeExecutionMode.STREAMING;
 
         RowType rowType = (RowType) context.getPhysicalRowDataType().getLogicalType();
-        ConfigOptions.MergeEngine mergeEngine =
-                helper.getOptions()
-                        .get(
-                                key(ConfigOptions.TABLE_MERGE_ENGINE.key())
-                                        .enumType(ConfigOptions.MergeEngine.class)
-                                        .noDefaultValue());
 
         return new FlinkTableSink(
                 toFlussTablePath(context.getObjectIdentifier()),
@@ -159,7 +158,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                 rowType,
                 context.getPrimaryKeyIndexes(),
                 isStreamingMode,
-                mergeEngine);
+                helper.getOptions().get(MERGE_ENGINE_OPTION));
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -146,13 +146,20 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                         == RuntimeExecutionMode.STREAMING;
 
         RowType rowType = (RowType) context.getPhysicalRowDataType().getLogicalType();
+        ConfigOptions.MergeEngine mergeEngine =
+                helper.getOptions()
+                        .get(
+                                key(ConfigOptions.TABLE_MERGE_ENGINE.key())
+                                        .enumType(ConfigOptions.MergeEngine.class)
+                                        .noDefaultValue());
 
         return new FlinkTableSink(
                 toFlussTablePath(context.getObjectIdentifier()),
                 toFlussClientConfig(helper.getOptions(), context.getConfiguration()),
                 rowType,
                 context.getPrimaryKeyIndexes(),
-                isStreamingMode);
+                isStreamingMode,
+                mergeEngine);
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSink.java
@@ -16,11 +16,11 @@
 
 package com.alibaba.fluss.connector.flink.sink;
 
-import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.FieldEqual;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.ValueConversion;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.row.GenericRow;
 
@@ -64,7 +64,7 @@ public class FlinkTableSink
     private final RowType tableRowType;
     private final int[] primaryKeyIndexes;
     private final boolean streaming;
-    @Nullable private final ConfigOptions.MergeEngine mergeEngine;
+    @Nullable private final MergeEngine mergeEngine;
 
     private boolean appliedUpdates = false;
     @Nullable private GenericRow deleteRow;
@@ -75,7 +75,7 @@ public class FlinkTableSink
             RowType tableRowType,
             int[] primaryKeyIndexes,
             boolean streaming,
-            @Nullable ConfigOptions.MergeEngine mergeEngine) {
+            @Nullable MergeEngine mergeEngine) {
         this.tablePath = tablePath;
         this.flussConfig = flussConfig;
         this.tableRowType = tableRowType;
@@ -123,12 +123,12 @@ public class FlinkTableSink
                     throw new ValidationException(
                             "Fluss table sink does not support partial updates for table without primary key. Please make sure the "
                                     + "number of specified columns in INSERT INTO matches columns of the Fluss table.");
-                } else if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+                } else if (mergeEngine == MergeEngine.FIRST_ROW) {
                     throw new ValidationException(
                             String.format(
                                     "Table %s uses the '%s' merge engine which does not support partial updates. Please make sure the "
                                             + "number of specified columns in INSERT INTO matches columns of the Fluss table.",
-                                    tablePath, ConfigOptions.MergeEngine.FIRST_ROW));
+                                    tablePath, MergeEngine.FIRST_ROW));
                 }
             }
             int[][] targetColumns = context.getTargetColumns().get();
@@ -299,11 +299,11 @@ public class FlinkTableSink
                             tablePath));
         }
 
-        if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+        if (mergeEngine == MergeEngine.FIRST_ROW) {
             throw new UnsupportedOperationException(
                     String.format(
                             "Table %s uses the '%s' merge engine which does not support DELETE or UPDATE statements.",
-                            tablePath, ConfigOptions.MergeEngine.FIRST_ROW));
+                            tablePath, MergeEngine.FIRST_ROW));
         }
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.fluss.connector.flink.source;
 
-import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.connector.flink.FlinkConnectorOptions;
 import com.alibaba.fluss.connector.flink.source.enumerator.initializer.OffsetsInitializer;
@@ -27,6 +26,7 @@ import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.connector.flink.utils.FlinkConversions;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils;
 import com.alibaba.fluss.connector.flink.utils.PushdownUtils.ValueConversion;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.RowType;
 
@@ -105,7 +105,7 @@ public class FlinkTableSource
 
     private final long scanPartitionDiscoveryIntervalMs;
     private final boolean isDataLakeEnabled;
-    @Nullable private final ConfigOptions.MergeEngine mergeEngine;
+    @Nullable private final MergeEngine mergeEngine;
 
     // output type after projection pushdown
     private LogicalType producedDataType;
@@ -137,7 +137,7 @@ public class FlinkTableSource
             @Nullable LookupCache cache,
             long scanPartitionDiscoveryIntervalMs,
             boolean isDataLakeEnabled,
-            @Nullable ConfigOptions.MergeEngine mergeEngine) {
+            @Nullable MergeEngine mergeEngine) {
         this.tablePath = tablePath;
         this.flussConfig = flussConfig;
         this.tableOutputType = tableOutputType;
@@ -164,7 +164,7 @@ public class FlinkTableSource
         } else {
             if (hasPrimaryKey()) {
                 // pk table
-                if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+                if (mergeEngine == MergeEngine.FIRST_ROW) {
                     return ChangelogMode.insertOnly();
                 } else {
                     return ChangelogMode.all();

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -418,12 +418,6 @@ public class FlinkTableSource
             RowLevelModificationType rowLevelModificationType,
             @Nullable RowLevelModificationScanContext rowLevelModificationScanContext) {
         modificationScanType = rowLevelModificationType;
-        if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
-            throw new UnsupportedOperationException(
-                    String.format(
-                            "%s is not supported for merge engine %s",
-                            rowLevelModificationType, mergeEngine));
-        }
         return null;
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.connector.flink.source;
 
+import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.connector.flink.FlinkConnectorOptions;
 import com.alibaba.fluss.connector.flink.source.enumerator.initializer.OffsetsInitializer;
@@ -104,6 +105,7 @@ public class FlinkTableSource
 
     private final long scanPartitionDiscoveryIntervalMs;
     private final boolean isDataLakeEnabled;
+    @Nullable private final ConfigOptions.MergeEngine mergeEngine;
 
     // output type after projection pushdown
     private LogicalType producedDataType;
@@ -134,7 +136,8 @@ public class FlinkTableSource
             boolean lookupAsync,
             @Nullable LookupCache cache,
             long scanPartitionDiscoveryIntervalMs,
-            boolean isDataLakeEnabled) {
+            boolean isDataLakeEnabled,
+            @Nullable ConfigOptions.MergeEngine mergeEngine) {
         this.tablePath = tablePath;
         this.flussConfig = flussConfig;
         this.tableOutputType = tableOutputType;
@@ -151,6 +154,7 @@ public class FlinkTableSource
 
         this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
         this.isDataLakeEnabled = isDataLakeEnabled;
+        this.mergeEngine = mergeEngine;
     }
 
     @Override
@@ -160,7 +164,11 @@ public class FlinkTableSource
         } else {
             if (hasPrimaryKey()) {
                 // pk table
-                return ChangelogMode.all();
+                if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+                    return ChangelogMode.insertOnly();
+                } else {
+                    return ChangelogMode.all();
+                }
             } else {
                 // append only
                 return ChangelogMode.insertOnly();
@@ -341,7 +349,8 @@ public class FlinkTableSource
                         lookupAsync,
                         cache,
                         scanPartitionDiscoveryIntervalMs,
-                        isDataLakeEnabled);
+                        isDataLakeEnabled,
+                        mergeEngine);
         source.producedDataType = producedDataType;
         source.projectedFields = projectedFields;
         source.singleRowFilter = singleRowFilter;
@@ -409,6 +418,12 @@ public class FlinkTableSource
             RowLevelModificationType rowLevelModificationType,
             @Nullable RowLevelModificationScanContext rowLevelModificationScanContext) {
         modificationScanType = rowLevelModificationType;
+        if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+            throw new UnsupportedOperationException(
+                    String.format(
+                            "%s is not supported for merge engine %s",
+                            rowLevelModificationType, mergeEngine));
+        }
         return null;
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
@@ -251,8 +251,9 @@ public class FlinkConversions {
     }
 
     /** Convert Fluss's ConfigOption to Flink's ConfigOption. */
-    public static org.apache.flink.configuration.ConfigOption<?> toFlinkOption(
-            ConfigOption<?> flussOption) {
+    @SuppressWarnings("unchecked")
+    public static <T> org.apache.flink.configuration.ConfigOption<T> toFlinkOption(
+            ConfigOption<T> flussOption) {
         org.apache.flink.configuration.ConfigOptions.OptionBuilder builder =
                 org.apache.flink.configuration.ConfigOptions.key(flussOption.key());
         org.apache.flink.configuration.ConfigOption<?> option;
@@ -301,7 +302,7 @@ public class FlinkConversions {
         }
         option.withDescription(flussOption.description());
         // TODO: support fallback keys in the future.
-        return option;
+        return (org.apache.flink.configuration.ConfigOption<T>) option;
     }
 
     private static Map<String, String> convertFlinkOptionsToFlussTableProperties(

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
@@ -33,6 +33,7 @@ import com.alibaba.fluss.server.testutils.FlussClusterExtension;
 
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
@@ -354,6 +355,39 @@ class FlinkTableSinkITCase {
         tEnv.executeSql("INSERT INTO sink_test(a, c) SELECT f0, f2 FROM changeLog").await();
         expectedRows = Arrays.asList("-U[1, null, c1]", "+U[1, null, c11]", "-D[1, null, c11]");
         assertResultsIgnoreOrder(rowIter, expectedRows, true);
+    }
+
+    @Test
+    void testFirstRowMergeEngine() throws Exception {
+        tEnv.executeSql(
+                "create table first_row_source (a int not null primary key not enforced,"
+                        + " b string) with('table.merge-engine' = 'first_row')");
+        tEnv.executeSql("create table first_row_sink (a int, b string)");
+
+        // insert from first_row_source to first_row_sink
+        JobClient insertJobClient =
+                tEnv.executeSql("insert into first_row_sink select * from first_row_source")
+                        .getJobClient()
+                        .get();
+
+        // insert once
+        tEnv.executeSql(
+                        "insert into first_row_source(a, b) VALUES (1, 'v1'), (2, 'v2'), (1, 'v11'), (3, 'v3')")
+                .await();
+
+        CloseableIterator<Row> rowIter =
+                tEnv.executeSql("select * from first_row_source").collect();
+
+        List<String> expectedRows = Arrays.asList("+I[1, v1]", "+I[2, v2]", "+I[3, v3]");
+
+        assertResultsIgnoreOrder(rowIter, expectedRows, false);
+
+        // insert again
+        tEnv.executeSql("insert into first_row_source(a, b) VALUES (3, 'v33'), ('4', 'v44')")
+                .await();
+        expectedRows = Collections.singletonList("+I[4, v44]");
+        assertResultsIgnoreOrder(rowIter, expectedRows, true);
+        insertJobClient.cancel().get();
     }
 
     @Test

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/testutils/TestingDatabaseSyncSink.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/testutils/TestingDatabaseSyncSink.java
@@ -87,7 +87,8 @@ public class TestingDatabaseSyncSink extends RichSinkFunction<MultiplexCdcRecord
                             flussConfig,
                             FlinkConversions.toFlinkRowType(rowType),
                             tableDescriptor.getSchema().getPrimaryKeyIndexes(),
-                            true);
+                            true,
+                            null);
 
             sinkFunction =
                     ((SinkFunctionProvider)

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
@@ -41,6 +41,7 @@ import com.alibaba.fluss.utils.types.Tuple2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 import java.io.File;
@@ -141,12 +142,14 @@ public final class KvManager extends TabletManagerBase {
      * @param tableBucket the table bucket
      * @param logTablet the cdc log tablet of the kv tablet
      * @param kvFormat the kv format
+     * @param mergeEngine the merge engine
      */
     public KvTablet getOrCreateKv(
             PhysicalTablePath tablePath,
             TableBucket tableBucket,
             LogTablet logTablet,
-            KvFormat kvFormat)
+            KvFormat kvFormat,
+            @Nullable ConfigOptions.MergeEngine mergeEngine)
             throws Exception {
         return inLock(
                 tabletCreationOrDeletionLock,
@@ -164,7 +167,8 @@ public final class KvManager extends TabletManagerBase {
                                     conf,
                                     arrowBufferAllocator,
                                     memorySegmentPool,
-                                    kvFormat);
+                                    kvFormat,
+                                    mergeEngine);
                     currentKvs.put(tableBucket, tablet);
 
                     LOG.info(
@@ -265,7 +269,8 @@ public final class KvManager extends TabletManagerBase {
                         conf,
                         arrowBufferAllocator,
                         memorySegmentPool,
-                        tableDescriptor.getKvFormat());
+                        tableDescriptor.getKvFormat(),
+                        tableDescriptor.getMergeEngine());
         if (this.currentKvs.containsKey(tableBucket)) {
             throw new IllegalStateException(
                     String.format(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
@@ -24,6 +24,7 @@ import com.alibaba.fluss.fs.FsPath;
 import com.alibaba.fluss.memory.LazyMemorySegmentPool;
 import com.alibaba.fluss.memory.MemorySegmentPool;
 import com.alibaba.fluss.metadata.KvFormat;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -149,7 +150,7 @@ public final class KvManager extends TabletManagerBase {
             TableBucket tableBucket,
             LogTablet logTablet,
             KvFormat kvFormat,
-            @Nullable ConfigOptions.MergeEngine mergeEngine)
+            @Nullable MergeEngine mergeEngine)
             throws Exception {
         return inLock(
                 tabletCreationOrDeletionLock,

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
@@ -24,6 +24,7 @@ import com.alibaba.fluss.memory.ManagedPagedOutputView;
 import com.alibaba.fluss.memory.MemorySegmentPool;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -102,7 +103,7 @@ public final class KvTablet {
     private final ReadWriteLock kvLock = new ReentrantReadWriteLock();
     private final LogFormat logFormat;
     private final KvFormat kvFormat;
-    private final @Nullable ConfigOptions.MergeEngine mergeEngine;
+    private final @Nullable MergeEngine mergeEngine;
 
     /**
      * The kv data in pre-write buffer whose log offset is less than the flushedLogOffset has been
@@ -124,7 +125,7 @@ public final class KvTablet {
             BufferAllocator arrowBufferAllocator,
             MemorySegmentPool memorySegmentPool,
             KvFormat kvFormat,
-            @Nullable ConfigOptions.MergeEngine mergeEngine) {
+            @Nullable MergeEngine mergeEngine) {
         this.physicalPath = physicalPath;
         this.tableBucket = tableBucket;
         this.logTablet = logTablet;
@@ -148,7 +149,7 @@ public final class KvTablet {
             BufferAllocator arrowBufferAllocator,
             MemorySegmentPool memorySegmentPool,
             KvFormat kvFormat,
-            @Nullable ConfigOptions.MergeEngine mergeEngine)
+            @Nullable MergeEngine mergeEngine)
             throws IOException {
         Tuple2<PhysicalTablePath, TableBucket> tablePathAndBucket =
                 FlussPaths.parseTabletDir(kvTabletDir);
@@ -173,7 +174,7 @@ public final class KvTablet {
             BufferAllocator arrowBufferAllocator,
             MemorySegmentPool memorySegmentPool,
             KvFormat kvFormat,
-            @Nullable ConfigOptions.MergeEngine mergeEngine)
+            @Nullable MergeEngine mergeEngine)
             throws IOException {
         RocksDBKv kv = buildRocksDBKv(conf, kvTabletDir);
         return new KvTablet(
@@ -280,7 +281,7 @@ public final class KvTablet {
                                             "The specific key can't be found in kv tablet although the kv record is for deletion, "
                                                     + "ignore it directly as it doesn't exist in the kv tablet yet.");
                                 } else {
-                                    if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+                                    if (mergeEngine == MergeEngine.FIRST_ROW) {
                                         // if the merge engine is first row, skip the deletion
                                         continue;
                                     }
@@ -308,7 +309,7 @@ public final class KvTablet {
                                 byte[] oldValue = getFromBufferOrKv(key);
                                 // it's update
                                 if (oldValue != null) {
-                                    if (mergeEngine == ConfigOptions.MergeEngine.FIRST_ROW) {
+                                    if (mergeEngine == MergeEngine.FIRST_ROW) {
                                         // if the merge engine is first row, skip the update
                                         continue;
                                     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -30,6 +30,7 @@ import com.alibaba.fluss.exception.NotLeaderOrFollowerException;
 import com.alibaba.fluss.fs.FsPath;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -167,7 +168,7 @@ public final class Replica {
     private final Schema schema;
     private final LogFormat logFormat;
     private final KvFormat kvFormat;
-    private final @Nullable ConfigOptions.MergeEngine mergeEngine;
+    private final @Nullable MergeEngine mergeEngine;
     private final long logTTLMs;
     private final boolean dataLakeEnabled;
     private final int tieredLogLocalSegments;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -167,6 +167,7 @@ public final class Replica {
     private final Schema schema;
     private final LogFormat logFormat;
     private final KvFormat kvFormat;
+    private final @Nullable ConfigOptions.MergeEngine mergeEngine;
     private final long logTTLMs;
     private final boolean dataLakeEnabled;
     private final int tieredLogLocalSegments;
@@ -232,6 +233,7 @@ public final class Replica {
         this.logTTLMs = tableDescriptor.getLogTTLMs();
         this.dataLakeEnabled = tableDescriptor.isDataLakeEnabled();
         this.tieredLogLocalSegments = tableDescriptor.getTieredLogLocalSegments();
+        this.mergeEngine = tableDescriptor.getMergeEngine();
         this.partitionKeys = tableDescriptor.getPartitionKeys();
         this.snapshotContext = snapshotContext;
         // create a closeable registry for the replica
@@ -602,7 +604,9 @@ public final class Replica {
                 LOG.info("No snapshot found, restore from log.");
                 // actually, kv manager always create a kv tablet since we will drop the kv
                 // if it exists before init kv tablet
-                kvTablet = kvManager.getOrCreateKv(physicalPath, tableBucket, logTablet, kvFormat);
+                kvTablet =
+                        kvManager.getOrCreateKv(
+                                physicalPath, tableBucket, logTablet, kvFormat, mergeEngine);
             }
             logTablet.updateMinRetainOffset(restoreStartOffset);
             recoverKvTablet(restoreStartOffset);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvManagerTest.java
@@ -260,7 +260,7 @@ final class KvManagerTest {
         LogTablet logTablet =
                 logManager.getOrCreateLog(physicalTablePath, tableBucket, LogFormat.ARROW, 1, true);
         return kvManager.getOrCreateKv(
-                physicalTablePath, tableBucket, logTablet, KvFormat.COMPACTED);
+                physicalTablePath, tableBucket, logTablet, KvFormat.COMPACTED, null);
     }
 
     private byte[] valueOf(KvRecord kvRecord) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.server.kv;
 
+import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidTargetColumnException;
 import com.alibaba.fluss.exception.OutOfOrderSequenceException;
@@ -99,32 +100,9 @@ class KvTabletTest {
     @BeforeEach
     void beforeEach() throws Exception {
         PhysicalTablePath tablePath = PhysicalTablePath.of(TablePath.of("testDb", "t1"));
-        long tableId = 0L;
-        File logTabletDir =
-                LogTestUtils.makeRandomLogTabletDir(
-                        tempLogDir, tablePath.getDatabaseName(), tableId, tablePath.getTableName());
-        logTablet =
-                LogTablet.create(
-                        tablePath,
-                        logTabletDir,
-                        conf,
-                        0,
-                        new FlussScheduler(1),
-                        LogFormat.ARROW,
-                        1,
-                        true,
-                        SystemClock.getInstance());
+        logTablet = createLogTablet(tempLogDir, 0L, tablePath);
         TableBucket tableBucket = logTablet.getTableBucket();
-        kvTablet =
-                KvTablet.create(
-                        tablePath,
-                        tableBucket,
-                        logTablet,
-                        tmpKvDir,
-                        conf,
-                        new RootAllocator(Long.MAX_VALUE),
-                        new TestingMemorySegmentPool(10 * 1024),
-                        KvFormat.COMPACTED);
+        kvTablet = createKvTablet(tablePath, tableBucket, logTablet, tmpKvDir, null);
         executor = Executors.newFixedThreadPool(2);
     }
 
@@ -133,6 +111,42 @@ class KvTabletTest {
         if (executor != null) {
             executor.shutdown();
         }
+    }
+
+    private LogTablet createLogTablet(File tempLogDir, long tableId, PhysicalTablePath tablePath)
+            throws Exception {
+        File logTabletDir =
+                LogTestUtils.makeRandomLogTabletDir(
+                        tempLogDir, tablePath.getDatabaseName(), tableId, tablePath.getTableName());
+        return LogTablet.create(
+                tablePath,
+                logTabletDir,
+                conf,
+                0,
+                new FlussScheduler(1),
+                LogFormat.ARROW,
+                1,
+                true,
+                SystemClock.getInstance());
+    }
+
+    private KvTablet createKvTablet(
+            PhysicalTablePath tablePath,
+            TableBucket tableBucket,
+            LogTablet logTablet,
+            File tmpKvDir,
+            ConfigOptions.MergeEngine mergeEngine)
+            throws Exception {
+        return KvTablet.create(
+                tablePath,
+                tableBucket,
+                logTablet,
+                tmpKvDir,
+                conf,
+                new RootAllocator(Long.MAX_VALUE),
+                new TestingMemorySegmentPool(10 * 1024),
+                KvFormat.COMPACTED,
+                mergeEngine);
     }
 
     @Test
@@ -536,11 +550,74 @@ class KvTabletTest {
         assertThat(kvTablet.getKvPreWriteBuffer().getMaxLSN()).isEqualTo(3);
     }
 
+    @Test
+    void testFirstRowMergeEngine(@TempDir File tempLogDir, @TempDir File tmpKvDir)
+            throws Exception {
+        PhysicalTablePath tablePath =
+                PhysicalTablePath.of(TablePath.of("testDb", "test_first_row"));
+
+        LogTablet logTablet = createLogTablet(tempLogDir, 1L, tablePath);
+        TableBucket tableBucket = logTablet.getTableBucket();
+        KvTablet kvTablet =
+                createKvTablet(
+                        tablePath,
+                        tableBucket,
+                        logTablet,
+                        tmpKvDir,
+                        ConfigOptions.MergeEngine.FIRST_ROW);
+
+        List<KvRecord> kvData1 =
+                Arrays.asList(
+                        kvRecordFactory.ofRecord("k1".getBytes(), new Object[] {1, "v11"}),
+                        kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v21"}),
+                        kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v23"}));
+        KvRecordBatch kvRecordBatch1 = kvRecordBatchFactory.ofRecords(kvData1);
+        kvTablet.putAsLeader(kvRecordBatch1, null, DATA1_SCHEMA_PK);
+
+        long endOffset = logTablet.localLogEndOffset();
+        LogRecords actualLogRecords = readLogRecords(logTablet);
+        List<MemoryLogRecords> expectedLogs =
+                Collections.singletonList(
+                        logRecords(
+                                DATA1_SCHEMA_PK.toRowType(),
+                                0,
+                                Arrays.asList(RowKind.INSERT, RowKind.INSERT),
+                                Arrays.asList(new Object[] {1, "v11"}, new Object[] {2, "v21"})));
+        checkEqual(actualLogRecords, expectedLogs);
+
+        List<KvRecord> kvData2 =
+                Arrays.asList(
+                        kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v22"}),
+                        kvRecordFactory.ofRecord("k1".getBytes(), new Object[] {1, "v21"}),
+                        kvRecordFactory.ofRecord("k1".getBytes(), null),
+                        kvRecordFactory.ofRecord("k3".getBytes(), new Object[] {3, "v31"}));
+        KvRecordBatch kvRecordBatch2 = kvRecordBatchFactory.ofRecords(kvData2);
+        kvTablet.putAsLeader(kvRecordBatch2, null, DATA1_SCHEMA_PK);
+
+        expectedLogs =
+                Collections.singletonList(
+                        logRecords(
+                                DATA1_SCHEMA_PK.toRowType(),
+                                endOffset,
+                                Collections.singletonList(RowKind.INSERT),
+                                Collections.singletonList(new Object[] {3, "v31"})));
+        actualLogRecords = readLogRecords(logTablet, endOffset);
+        checkEqual(actualLogRecords, expectedLogs);
+    }
+
     private LogRecords readLogRecords() throws Exception {
         return readLogRecords(0L);
     }
 
     private LogRecords readLogRecords(long startOffset) throws Exception {
+        return readLogRecords(logTablet, startOffset);
+    }
+
+    private LogRecords readLogRecords(LogTablet logTablet) throws Exception {
+        return readLogRecords(logTablet, 0L);
+    }
+
+    private LogRecords readLogRecords(LogTablet logTablet, long startOffset) throws Exception {
         return logTablet
                 .read(startOffset, Integer.MAX_VALUE, FetchIsolation.LOG_END, false, null)
                 .getRecords();

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
@@ -16,13 +16,13 @@
 
 package com.alibaba.fluss.server.kv;
 
-import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidTargetColumnException;
 import com.alibaba.fluss.exception.OutOfOrderSequenceException;
 import com.alibaba.fluss.memory.TestingMemorySegmentPool;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.metadata.LogFormat;
+import com.alibaba.fluss.metadata.MergeEngine;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -135,7 +135,7 @@ class KvTabletTest {
             TableBucket tableBucket,
             LogTablet logTablet,
             File tmpKvDir,
-            ConfigOptions.MergeEngine mergeEngine)
+            MergeEngine mergeEngine)
             throws Exception {
         return KvTablet.create(
                 tablePath,
@@ -559,12 +559,7 @@ class KvTabletTest {
         LogTablet logTablet = createLogTablet(tempLogDir, 1L, tablePath);
         TableBucket tableBucket = logTablet.getTableBucket();
         KvTablet kvTablet =
-                createKvTablet(
-                        tablePath,
-                        tableBucket,
-                        logTablet,
-                        tmpKvDir,
-                        ConfigOptions.MergeEngine.FIRST_ROW);
+                createKvTablet(tablePath, tableBucket, logTablet, tmpKvDir, MergeEngine.FIRST_ROW);
 
         List<KvRecord> kvData1 =
                 Arrays.asList(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #133

<!-- What is the purpose of the change -->
Introduce first row merge engine for primary key table

### Tests
FlussTableITCase#testFirstRowMergeEngine
FlinkTableSinkITCase#testFirstRowMergeEngine


### API and Format

<!-- Does this change affect API or storage format -->
N/A

### Documentation
I'd like to complete the document in another pr #241  since after introduce merge engine, we may need to refactor the document struture about primary key table.
