### PR TITLE
[server] Revert the queue in RequestChannel from PriorityBlockingQueue back to ArrayBlockingQueue to fix config 'netty.server.max-queued-requests' error

### DIFF
--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RequestChannel.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RequestChannel.java
@@ -21,8 +21,8 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.ThreadSafe;
 
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 /** A blocking queue channel that can receive requests and send responses. */
@@ -33,18 +33,7 @@ public final class RequestChannel {
     private final BlockingQueue<RpcRequest> requestQueue;
 
     public RequestChannel(int queueCapacity) {
-        this.requestQueue =
-                new PriorityBlockingQueue<>(
-                        queueCapacity,
-                        (req1, req2) -> {
-                            // less value will be popped first
-                            int res = Integer.compare(req2.getPriority(), req1.getPriority());
-                            // if priority is same, we want to keep FIFO
-                            if (res == 0 && req1 != req2) {
-                                res = (req1.getRequestId() < req2.getRequestId() ? -1 : 1);
-                            }
-                            return res;
-                        });
+        this.requestQueue = new ArrayBlockingQueue<>(queueCapacity);
     }
 
     /**

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RpcRequest.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RpcRequest.java
@@ -17,8 +17,6 @@
 package com.alibaba.fluss.rpc.netty.server;
 
 import com.alibaba.fluss.rpc.messages.ApiMessage;
-import com.alibaba.fluss.rpc.messages.FetchLogRequest;
-import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.ApiMethod;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelHandlerContext;
@@ -106,23 +104,6 @@ public final class RpcRequest {
 
     public long getStartTimeMs() {
         return startTimeMs;
-    }
-
-    /**
-     * Get the request priority in {@link RequestChannel}. The higher priority of this request, the
-     * higher the result will be.
-     *
-     * <p>Currently, we only consider the FetchLogRequest from follower as high priority in order to
-     * make sure the data is replicated to the follower as soon as possible, which can maintain the
-     * stability of the cluster when the network load is high.
-     */
-    public int getPriority() {
-        if (apiKey == ApiKeys.FETCH_LOG.id
-                && ((FetchLogRequest) message).getFollowerServerId() >= 0) {
-            return 1;
-        }
-
-        return 0;
     }
 
     @Override

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/RequestChannelTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/RequestChannelTest.java
@@ -34,10 +34,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RequestChannelTest {
 
     @Test
-    void testRequestPriority() throws Exception {
+    void testRequestsFIFO() throws Exception {
         RequestChannel channel = new RequestChannel(100);
 
-        // 1. request with same priority score. Use FIFO.
+        // 1. Same request type, Use FIFO.
         List<RpcRequest> rpcRequests = new ArrayList<>();
         // push rpc requests
         for (int i = 0; i < 100; i++) {
@@ -59,7 +59,7 @@ public class RequestChannelTest {
             assertThat(gotRequest).isEqualTo(rpcRequests.get(i));
         }
 
-        // 2. request with different priority score. Should be ordered by priority score.
+        // 2. Different request type, Use FIFO.
         RpcRequest rpcRequest1 =
                 new RpcRequest(
                         ApiKeys.GET_TABLE.id,
@@ -81,8 +81,8 @@ public class RequestChannelTest {
         channel.putRequest(rpcRequest1);
         channel.putRequest(rpcRequest2);
         RpcRequest rpcRequest = channel.pollRequest(100);
-        assertThat(rpcRequest).isEqualTo(rpcRequest2);
-        rpcRequest = channel.pollRequest(100);
         assertThat(rpcRequest).isEqualTo(rpcRequest1);
+        rpcRequest = channel.pollRequest(100);
+        assertThat(rpcRequest).isEqualTo(rpcRequest2);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/268

<!-- What is the purpose of the change -->

This pr is aims to fix the error that the server will receive unlimited requests even if we config the `netty.server.max-queued-requests` to a specify number. 
This issue arose because we introduced a `PriorityBlockingQueue` in the `RequestChannel` to replace the `ArrayBlockingQueue`. The `PriorityBlockingQueue`, unlike the `ArrayBlockingQueue`, is an unbounded queue. 

Therefore, in this PR, we will revert the queue in `RequestChannel` from `PriorityBlockingQueue` back to `ArrayBlockingQueue` to fix config 'netty.server.max-queued-requests' error. The reason we can roll back here is that the `PriorityBlockingQueue` has become unnecessary after introducing https://github.com/alibaba/fluss/pull/233 . In this pr, we significantly reduce the number of fetch requests during follower synchronization, which makes our server more stable even without the priority queue.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
