### PR TITLE
[connector] Fluss support scan.startup.timestamp is larger than max timestamp of bucket.

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceITCase.java
@@ -32,8 +32,6 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.RowTypeInfo;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.configuration.RestartStrategyOptions;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.table.api.DataTypes;
@@ -86,14 +84,7 @@ class FlinkTableSourceITCase extends FlinkTestBase {
         FlinkTestBase.beforeAll();
 
         String bootstrapServers = String.join(",", clientConf.get(ConfigOptions.BOOTSTRAP_SERVERS));
-        execEnv =
-                StreamExecutionEnvironment.getExecutionEnvironment(
-                        new Configuration()
-                                .set(
-                                        RestartStrategyOptions.RESTART_STRATEGY,
-                                        RestartStrategyOptions.RestartStrategyType
-                                                .NO_RESTART_STRATEGY
-                                                .getMainValue()));
+        execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         // create table environment
         tEnv = StreamTableEnvironment.create(execEnv, EnvironmentSettings.inStreamingMode());
         // crate catalog using sql

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/ListOffsetsResultForBucket.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/ListOffsetsResultForBucket.java
@@ -62,4 +62,16 @@ public class ListOffsetsResultForBucket extends ResultForBucket {
         ListOffsetsResultForBucket that = (ListOffsetsResultForBucket) o;
         return offset == that.offset;
     }
+
+    @Override
+    public String toString() {
+        return "ListOffsetsResultForBucket{"
+                + "offset="
+                + offset
+                + ", tableBucket="
+                + tableBucket
+                + ", error="
+                + error
+                + '}';
+    }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/ResultForBucket.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/ResultForBucket.java
@@ -31,7 +31,7 @@ import java.util.Objects;
 @Internal
 public abstract class ResultForBucket {
     protected final TableBucket tableBucket;
-    private final ApiError error;
+    protected final ApiError error;
 
     public ResultForBucket(TableBucket tableBucket) {
         this(tableBucket, ApiError.NONE);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
@@ -156,8 +156,8 @@ public class TabletServer extends ServerBase {
             this.scheduler = new FlussScheduler(conf.get(BACKGROUND_THREADS));
             scheduler.startup();
 
-            this.logManager =
-                    LogManager.create(conf, zkClient, scheduler, SystemClock.getInstance());
+            SystemClock systemClock = SystemClock.getInstance();
+            this.logManager = LogManager.create(conf, zkClient, scheduler, systemClock);
             logManager.startup();
 
             this.kvManager = KvManager.create(conf, zkClient, logManager);
@@ -188,7 +188,8 @@ public class TabletServer extends ServerBase {
                             coordinatorGateway,
                             DefaultCompletedKvSnapshotCommitter.create(rpcClient, metadataCache),
                             this,
-                            tabletServerMetricGroup);
+                            tabletServerMetricGroup,
+                            systemClock);
             replicaManager.startup();
 
             this.tabletService =

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaManagerTest.java
@@ -58,8 +58,6 @@ import com.alibaba.fluss.utils.types.Tuple2;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -102,8 +100,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link ReplicaManager}. */
 class ReplicaManagerTest extends ReplicaTestBase {
-
-    private static final Logger log = LoggerFactory.getLogger(ReplicaManagerTest.class);
 
     @Test
     void testProduceLog() throws Exception {
@@ -884,13 +880,6 @@ class ReplicaManagerTest extends ReplicaTestBase {
                             -1, ListOffsetsParam.TIMESTAMP_OFFSET_TYPE, commitTimestamp),
                     Collections.singleton(tb),
                     future1::complete);
-            List<ListOffsetsResultForBucket> listOffsetsResultForBuckets = future1.get();
-            for (ListOffsetsResultForBucket result : listOffsetsResultForBuckets) {
-                if (result.getErrorCode() != 0) {
-                    log.warn(result.getErrorMessage() + "," + result.getErrorCode());
-                }
-            }
-
             assertThat(future1.get()).containsOnly(new ListOffsetsResultForBucket(tb, baseOffset));
         }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -265,7 +265,8 @@ public class ReplicaTestBase {
                 snapshotReporter,
                 NOPErrorHandler.INSTANCE,
                 TestingMetricGroups.TABLET_SERVER_METRICS,
-                remoteLogManager);
+                remoteLogManager,
+                manualClock);
     }
 
     @AfterEach
@@ -294,6 +295,10 @@ public class ReplicaTestBase {
 
         if (rpcClient != null) {
             rpcClient.close();
+        }
+
+        if (scheduler != null) {
+            scheduler.shutdown();
         }
 
         // clear zk environment.
@@ -433,7 +438,8 @@ public class ReplicaTestBase {
                 serverMetadataCache,
                 NOPErrorHandler.INSTANCE,
                 metricGroup,
-                TableDescriptor.builder().schema(DATA1_SCHEMA).distributedBy(3).build());
+                TableDescriptor.builder().schema(DATA1_SCHEMA).distributedBy(3).build(),
+                manualClock);
     }
 
     private void initRemoteLogEnv() throws Exception {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -44,6 +44,7 @@ import com.alibaba.fluss.server.zk.ZooKeeperExtension;
 import com.alibaba.fluss.server.zk.data.LeaderAndIsr;
 import com.alibaba.fluss.server.zk.data.TableRegistration;
 import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
+import com.alibaba.fluss.utils.clock.Clock;
 import com.alibaba.fluss.utils.clock.SystemClock;
 import com.alibaba.fluss.utils.concurrent.FlussScheduler;
 import com.alibaba.fluss.utils.concurrent.Scheduler;
@@ -219,7 +220,8 @@ public class ReplicaFetcherThreadTest {
                         serverId,
                         new ServerMetadataCacheImpl(),
                         RpcClient.create(conf, TestingClientMetricGroup.newInstance()),
-                        TestingMetricGroups.TABLET_SERVER_METRICS);
+                        TestingMetricGroups.TABLET_SERVER_METRICS,
+                        SystemClock.getInstance());
         replicaManager.startup();
         return replicaManager;
     }
@@ -238,7 +240,8 @@ public class ReplicaFetcherThreadTest {
                 int serverId,
                 ServerMetadataCache metadataCache,
                 RpcClient rpcClient,
-                TabletServerMetricGroup serverMetricGroup)
+                TabletServerMetricGroup serverMetricGroup,
+                Clock clock)
                 throws IOException {
             super(
                     conf,
@@ -252,7 +255,8 @@ public class ReplicaFetcherThreadTest {
                     new TestCoordinatorGateway(),
                     new TestingCompletedKvSnapshotCommitter(),
                     NOPErrorHandler.INSTANCE,
-                    serverMetricGroup);
+                    serverMetricGroup,
+                    clock);
         }
 
         @Override


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #274 

