### PR TITLE
[rpc] Fix detecting bind failure in case of Netty EPOLL transport

### DIFF
--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/NettyUtils.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/NettyUtils.java
@@ -27,6 +27,7 @@ import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.ServerSocketChann
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.nio.NioServerSocketChannel;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.nio.NioSocketChannel;
+import com.alibaba.fluss.shaded.netty4.io.netty.channel.unix.Errors;
 import com.alibaba.fluss.shaded.netty4.io.netty.util.concurrent.DefaultThreadFactory;
 
 import java.util.concurrent.CompletableFuture;
@@ -100,5 +101,20 @@ public class NettyUtils {
             shutdownFuture.complete(null);
         }
         return shutdownFuture;
+    }
+
+    /**
+     * check whether the provided {@link Throwable} represents a bind failure.
+     *
+     * @param t The {@link Throwable} object to be checked for bind failure.
+     * @return {@code true} if the provided {@link Throwable} represents a bind failure, {@code
+     *     false} otherwise.
+     */
+    public static boolean isBindFailure(Throwable t) {
+        return t instanceof java.net.BindException
+                || (t instanceof Errors.NativeIoException
+                        && t.getMessage() != null
+                        && t.getMessage().matches("^bind\\(.*\\) failed:.*"))
+                || (t.getCause() != null && isBindFailure(t.getCause()));
     }
 }

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/client/NettyClientTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/client/NettyClientTest.java
@@ -28,6 +28,7 @@ import com.alibaba.fluss.rpc.messages.GetTableRequest;
 import com.alibaba.fluss.rpc.messages.LookupRequest;
 import com.alibaba.fluss.rpc.messages.PbLookupReqForBucket;
 import com.alibaba.fluss.rpc.metrics.TestingClientMetricGroup;
+import com.alibaba.fluss.rpc.netty.NettyUtils;
 import com.alibaba.fluss.rpc.netty.server.NettyServer;
 import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
@@ -162,6 +163,21 @@ final class NettyClientTest {
         assertThat(nettyClient.connections().size()).isEqualTo(1);
         assertThat(nettyClient.connections().get(serverNode.uid()).getServerNode())
                 .isEqualTo(serverNode);
+    }
+
+    @Test
+    void testBindFailureDetection() {
+        Throwable ex = new java.net.BindException();
+        assertThat(NettyUtils.isBindFailure(ex)).isTrue();
+
+        ex = new Exception(new java.net.BindException());
+        assertThat(NettyUtils.isBindFailure(ex)).isTrue();
+
+        ex = new Exception();
+        assertThat(NettyUtils.isBindFailure(ex)).isFalse();
+
+        ex = new RuntimeException();
+        assertThat(NettyUtils.isBindFailure(ex)).isFalse();
     }
 
     private void buildNettyServer(int serverId) throws Exception {


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #278 

<!-- What is the purpose of the change -->
Temporary bind-port error should not shutdown server

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
