### PR TITLE
[client][admin] Admin provide interface to get cluster information.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -20,6 +20,7 @@ import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.client.table.lake.LakeTableSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.KvSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.PartitionSnapshotInfo;
+import com.alibaba.fluss.cluster.Cluster;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
 import com.alibaba.fluss.exception.DatabaseNotEmptyException;
 import com.alibaba.fluss.exception.DatabaseNotExistException;
@@ -39,8 +40,11 @@ import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 
+import javax.annotation.Nullable;
+
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -51,6 +55,19 @@ import java.util.concurrent.CompletableFuture;
  */
 @PublicEvolving
 public interface Admin extends AutoCloseable {
+
+    /**
+     * Get the current cluster information. asynchronously.
+     *
+     * @param tablePaths table paths to be included in the metadata.
+     * @param tablePartitions table partitions to be included in the metadata.
+     * @param tablePartitionIds table partition ids to be included in the metadata.
+     */
+    CompletableFuture<Cluster> getCluster(
+            @Nullable Set<TablePath> tablePaths,
+            @Nullable Collection<PhysicalTablePath> tablePartitions,
+            @Nullable Collection<Long> tablePartitionIds);
+
     /**
      * Get the latest table schema of the given table asynchronously.
      *

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -20,7 +20,7 @@ import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.client.table.lake.LakeTableSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.KvSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.PartitionSnapshotInfo;
-import com.alibaba.fluss.cluster.Cluster;
+import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
 import com.alibaba.fluss.exception.DatabaseNotEmptyException;
 import com.alibaba.fluss.exception.DatabaseNotExistException;
@@ -40,11 +40,8 @@ import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 
-import javax.annotation.Nullable;
-
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -56,17 +53,8 @@ import java.util.concurrent.CompletableFuture;
 @PublicEvolving
 public interface Admin extends AutoCloseable {
 
-    /**
-     * Get the current cluster information. asynchronously.
-     *
-     * @param tablePaths table paths to be included in the metadata.
-     * @param tablePartitions table partitions to be included in the metadata.
-     * @param tablePartitionIds table partition ids to be included in the metadata.
-     */
-    CompletableFuture<Cluster> getCluster(
-            @Nullable Set<TablePath> tablePaths,
-            @Nullable Collection<PhysicalTablePath> tablePartitions,
-            @Nullable Collection<Long> tablePartitionIds);
+    /** Get the current server node information. asynchronously. */
+    CompletableFuture<List<ServerNode>> getServerNodes();
 
     /**
      * Get the latest table schema of the given table asynchronously.

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -430,7 +430,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
     }
 
     @Test
-    void testGetCluster() throws Exception {
+    void testGetServerNodes() throws Exception {
         List<ServerNode> serverNodes = admin.getServerNodes().get();
         List<ServerNode> expectedNodes = new ArrayList<>();
         expectedNodes.add(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -435,7 +435,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         List<ServerNode> expectedNodes = new ArrayList<>();
         expectedNodes.add(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
         expectedNodes.addAll(FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
-        assertThat(serverNodes).isEqualTo(expectedNodes);
+        assertThat(serverNodes).containsExactlyInAnyOrderElementsOf(expectedNodes);
     }
 
     private void assertHasTabletServerNumber(int tabletServerNumber) {

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -21,7 +21,7 @@ import com.alibaba.fluss.client.table.snapshot.BucketSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.BucketsSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.KvSnapshotInfo;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
-import com.alibaba.fluss.cluster.Cluster;
+import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.config.AutoPartitionTimeUnit;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Collections;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -431,27 +431,11 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
 
     @Test
     void testGetCluster() throws Exception {
-        Cluster cluster = admin.getCluster(null, null, null).get();
-        assertThat(cluster.getCoordinatorServer())
-                .isEqualTo(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
-        assertThat(cluster.getAliveTabletServerList())
-                .containsExactlyInAnyOrderElementsOf(
-                        FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
-        assertThat(cluster.getTable(DEFAULT_TABLE_PATH)).isNotPresent();
-
-        cluster = admin.getCluster(Collections.singleton(DEFAULT_TABLE_PATH), null, null).get();
-        assertThat(cluster.getCoordinatorServer())
-                .isEqualTo(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
-        assertThat(cluster.getAliveTabletServerList())
-                .containsExactlyInAnyOrderElementsOf(
-                        FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
-        assertThat(cluster.getTable(DEFAULT_TABLE_PATH)).isPresent();
-        assertThat(cluster.getBucketCount(DEFAULT_TABLE_PATH))
-                .isEqualTo(
-                        DEFAULT_TABLE_DESCRIPTOR
-                                .getTableDistribution()
-                                .flatMap(TableDescriptor.TableDistribution::getBucketCount)
-                                .orElse(0));
+        List<ServerNode> serverNodes = admin.getServerNodes().get();
+        List<ServerNode> expectedNodes = new ArrayList<>();
+        expectedNodes.add(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
+        expectedNodes.addAll(FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
+        assertThat(serverNodes).isEqualTo(expectedNodes);
     }
 
     private void assertHasTabletServerNumber(int tabletServerNumber) {

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -21,6 +21,7 @@ import com.alibaba.fluss.client.table.snapshot.BucketSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.BucketsSnapshotInfo;
 import com.alibaba.fluss.client.table.snapshot.KvSnapshotInfo;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
+import com.alibaba.fluss.cluster.Cluster;
 import com.alibaba.fluss.config.AutoPartitionTimeUnit;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
@@ -51,6 +52,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -425,6 +427,31 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
             kvSnapshotInfo = admin.getKvSnapshot(tablePath1).get();
             assertTableSnapshot(kvSnapshotInfo, bucketNum, expectedSnapshots);
         }
+    }
+
+    @Test
+    void testGetCluster() throws Exception {
+        Cluster cluster = admin.getCluster(null, null, null).get();
+        assertThat(cluster.getCoordinatorServer())
+                .isEqualTo(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
+        assertThat(cluster.getAliveTabletServerList())
+                .containsExactlyInAnyOrderElementsOf(
+                        FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
+        assertThat(cluster.getTable(DEFAULT_TABLE_PATH)).isNotPresent();
+
+        cluster = admin.getCluster(Collections.singleton(DEFAULT_TABLE_PATH), null, null).get();
+        assertThat(cluster.getCoordinatorServer())
+                .isEqualTo(FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode());
+        assertThat(cluster.getAliveTabletServerList())
+                .containsExactlyInAnyOrderElementsOf(
+                        FLUSS_CLUSTER_EXTENSION.getTabletServerNodes());
+        assertThat(cluster.getTable(DEFAULT_TABLE_PATH)).isPresent();
+        assertThat(cluster.getBucketCount(DEFAULT_TABLE_PATH))
+                .isEqualTo(
+                        DEFAULT_TABLE_DESCRIPTOR
+                                .getTableDistribution()
+                                .flatMap(TableDescriptor.TableDistribution::getBucketCount)
+                                .orElse(0));
     }
 
     private void assertHasTabletServerNumber(int tabletServerNumber) {

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/ServerNode.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/ServerNode.java
@@ -16,9 +16,16 @@
 
 package com.alibaba.fluss.cluster;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 import java.util.Objects;
 
-/** Information about a Fluss server node. */
+/**
+ * Information about a Fluss server node.
+ *
+ * @since 0.6
+ */
+@PublicEvolving
 public class ServerNode {
     private final int id;
     private final String uid;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #282 

<!-- What is the purpose of the change -->

### Tests

com.alibaba.fluss.client.admin.FlussAdminITCase#testGetCluster

### API and Format


```java
public interface Admin extends AutoCloseable {

    /**
     * Get the current cluster information. asynchronously.
     *
     * @param tablePaths table paths to be included in the metadata.
     * @param tablePartitions table partitions to be included in the metadata.
     * @param tablePartitionIds table partition ids to be included in the metadata.
     */
    CompletableFuture<Cluster> getCluster(
            @Nullable Set<TablePath> tablePaths,
            @Nullable Collection<PhysicalTablePath> tablePartitions,
            @Nullable Collection<Long> tablePartitionIds);


```

### Documentation

<!-- Does this change introduce a new feature -->
