### PR TITLE
[hotfix][connector] Fix sink not stop when exception is occurs.

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkFunction.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkFunction.java
@@ -121,7 +121,7 @@ abstract class FlinkSinkFunction extends RichSinkFunction<RowData>
         CompletableFuture<Void> writeFuture = writeRow(value.getRowKind(), internalRow);
         writeFuture.exceptionally(
                 exception -> {
-                    if (this.asyncWriterException != null) {
+                    if (this.asyncWriterException == null) {
                         this.asyncWriterException = exception;
                     }
                     return null;


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
in https://github.com/alibaba/fluss/issues/283, there is also an abnormal log for multiple times:
```java
WARN  com.alibaba.fluss.client.write.Sender                        [] - Get error write response on table bucket TableBucket{tableId=2, bucket=152}, fail. Error: UNKNOWN_SERVER_ERROR. Error Message: java.lang.IllegalArgumentException: The log sequence number must be non-decreasing. The current log sequence number is 600582, but the new log sequence number is 600581
	at com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer.update(KvPreWriteBuffer.java:126)
```

the coresponing code is com.alibaba.fluss.client.write.Sender#handleWriteBatchException.
```java
    private Set<PhysicalTablePath> handleWriteBatchException(
            WriteBatch writeBatch, ApiError error) {
        Set<PhysicalTablePath> invalidMetadataTables = new HashSet<>();
        if (canRetry(writeBatch, error.error())) {
            // ....ignore
        } else if (error.error() == Errors.DUPLICATE_SEQUENCE_EXCEPTION) {
          // ...
        } else {
            LOG.warn(
                    "Get error write response on table bucket {}, fail. Error: {}",
                    writeBatch.tableBucket(),
                    error.formatErrMsg());
            // tell the user the result of their request. We only adjust batch sequence if the
            // batch didn't exhaust its retries -- if it did, we don't know whether the batch
            // sequence was accepted or not, and thus it is not safe to reassign the sequence.
            failBatch(writeBatch, error.exception(), writeBatch.attempts() < this.retries);
        }
        return invalidMetadataTables;
    }
```

It means that  IllegalArgumentException is not a triable exception, which will be thrown out of the client. However, the flink job didn't stop but stuck to allocate memory.

Then, I find some thing wrong in sinkfunction:  asyncWriterException can never be set.
```java
 @Override
    public void invoke(RowData value, SinkFunction.Context context) throws IOException {
        checkAsyncException();
        InternalRow internalRow = dataConverter.toInternalRow(value);
        CompletableFuture<Void> writeFuture = writeRow(value.getRowKind(), internalRow);
        writeFuture.exceptionally(
                exception -> {
                    if (this.asyncWriterException != null) {
                        this.asyncWriterException = exception;
                    }
                    return null;
                });

        numRecordsOutCounter.inc();
    }
```


