### PR TITLE
[flink](lookup) convert to Fluss GenericRow to avoid unnecessary deserialization

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/lookup/FlinkLookupFunction.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/lookup/FlinkLookupFunction.java
@@ -84,12 +84,10 @@ public class FlinkLookupFunction extends LookupFunction {
         LOG.info("start open ...");
         connection = ConnectionFactory.createConnection(flussConfig);
         table = connection.getTable(tablePath);
-        // TODO: convert to Fluss GenericRow to avoid unnecessary deserialization
         int[] lookupKeyIndexes = lookupNormalizer.getLookupKeyIndexes();
         flinkRowToFlussRowConverter =
                 FlinkRowToFlussRowConverter.create(
-                        FlinkUtils.projectRowType(flinkRowType, lookupKeyIndexes),
-                        table.getDescriptor().getKvFormat());
+                        FlinkUtils.projectRowType(flinkRowType, lookupKeyIndexes));
 
         final RowType outputRowType;
         if (projection == null) {
@@ -121,7 +119,7 @@ public class FlinkLookupFunction extends LookupFunction {
         // first is converting from flink row to fluss row,
         // second is extracting key from the fluss row when calling method table.get(flussKeyRow)
         // todo: may be reduce to one data conversion when it's a bottle neck
-        InternalRow flussKeyRow = flinkRowToFlussRowConverter.toInternalRow(normalizedKeyRow);
+        InternalRow flussKeyRow = flinkRowToFlussRowConverter.toGenericRow(normalizedKeyRow);
         for (int retry = 0; retry <= maxRetryTimes; retry++) {
             try {
                 if (flussLookupType == LookupType.LOOKUP) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverter.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.connector.flink.utils;
 import com.alibaba.fluss.metadata.KvFormat;
 import com.alibaba.fluss.row.BinaryString;
 import com.alibaba.fluss.row.Decimal;
+import com.alibaba.fluss.row.GenericRow;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
@@ -87,6 +88,16 @@ public class FlinkRowToFlussRowConverter implements AutoCloseable {
                     toFlussFieldConverters[i].serialize(fieldGetters[i].getFieldOrNull(rowData)));
         }
         return rowEncoder.finishRow();
+    }
+
+    public InternalRow toGenericRow(RowData rowData) {
+        GenericRow genericRow = new GenericRow(fieldLength);
+        for (int i = 0; i < fieldLength; i++) {
+            genericRow.setField(
+                    i,
+                    toFlussFieldConverters[i].serialize(fieldGetters[i].getFieldOrNull(rowData)));
+        }
+        return genericRow;
     }
 
     private FlussSerializationConverter createNullableInternalConverter(LogicalType flinkField) {

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverterTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkRowToFlussRowConverterTest.java
@@ -61,6 +61,14 @@ public class FlinkRowToFlussRowConverterTest {
             assertThat(internalRow.getFieldCount()).isEqualTo(19);
             assertAllTypeEquals(internalRow);
         }
+
+        // test GenericRow row converter
+        try (FlinkRowToFlussRowConverter converter =
+                FlinkRowToFlussRowConverter.create(toFlinkRowType(flussRowType))) {
+            InternalRow internalRow = converter.toGenericRow(genRowDataForAllType());
+            assertThat(internalRow.getFieldCount()).isEqualTo(19);
+            assertAllTypeEquals(internalRow);
+        }
     }
 
     private static RowData genRowDataForAllType() {


### PR DESCRIPTION
### Purpose
convert to Fluss GenericRow to avoid unnecessary deserialization

