### PR TITLE
[hotfix] Report empty string as value for partition label for non-partitioned table

### DIFF
--- a/fluss-metrics/fluss-metrics-jmx/src/test/java/com/alibaba/fluss/metrics/jmx/JMXReporterTest.java
+++ b/fluss-metrics/fluss-metrics-jmx/src/test/java/com/alibaba/fluss/metrics/jmx/JMXReporterTest.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.metrics.reporter.MetricReporter;
 import com.alibaba.fluss.metrics.util.TestHistogram;
 import com.alibaba.fluss.metrics.util.TestMeter;
 import com.alibaba.fluss.metrics.util.TestMetricGroup;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -34,6 +35,7 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
+
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;

--- a/fluss-metrics/fluss-metrics-jmx/src/test/java/com/alibaba/fluss/metrics/jmx/JMXReporterTest.java
+++ b/fluss-metrics/fluss-metrics-jmx/src/test/java/com/alibaba/fluss/metrics/jmx/JMXReporterTest.java
@@ -23,7 +23,6 @@ import com.alibaba.fluss.metrics.reporter.MetricReporter;
 import com.alibaba.fluss.metrics.util.TestHistogram;
 import com.alibaba.fluss.metrics.util.TestMeter;
 import com.alibaba.fluss.metrics.util.TestMetricGroup;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +34,6 @@ import javax.management.ObjectName;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.util.HashMap;
@@ -54,6 +52,8 @@ class JMXReporterTest {
     static {
         variables = new HashMap<>();
         variables.put("<host>", "localhost");
+        variables.put("key1", "value1");
+        variables.put("key2", "");
 
         metricGroup =
                 TestMetricGroup.newBuilder()
@@ -91,6 +91,7 @@ class JMXReporterTest {
         vars.put("key0", "value0");
         vars.put("key1", "value1");
         vars.put("\"key2,=;:?'", "\"value2 (test),=;:?'");
+        vars.put("key3", "");
 
         Hashtable<String, String> jmxTable = JMXReporter.generateJmxTable(vars);
 
@@ -98,6 +99,7 @@ class JMXReporterTest {
         assertThat(jmxTable).containsEntry("key0", "value0");
         assertThat(jmxTable).containsEntry("key1", "value1");
         assertThat(jmxTable).containsEntry("key2------", "value2_(test)------");
+        assertThat(jmxTable).containsEntry("key3", "");
     }
 
     /**

--- a/fluss-metrics/fluss-metrics-prometheus/src/test/java/com/alibaba/fluss/metrics/prometheus/PrometheusReporterDifferentLabelValueTest.java
+++ b/fluss-metrics/fluss-metrics-prometheus/src/test/java/com/alibaba/fluss/metrics/prometheus/PrometheusReporterDifferentLabelValueTest.java
@@ -24,13 +24,15 @@ import com.alibaba.fluss.metrics.groups.MetricGroup;
 import com.alibaba.fluss.metrics.util.TestHistogram;
 import com.alibaba.fluss.metrics.util.TestMeter;
 import com.alibaba.fluss.utils.NetUtils;
-
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.Arrays;
+import java.util.stream.Stream;
 
 import static com.alibaba.fluss.metrics.prometheus.PrometheusReporterTest.pollMetrics;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,17 +44,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class PrometheusReporterDifferentLabelValueTest {
 
     private static final String[] LABEL_NAMES = {"label1", "label2"};
-    private static final String[] LABEL_VALUES_1 = new String[] {"value1_1", "value1_2"};
-    private static final String[] LABEL_VALUES_2 = new String[] {"value2_1", "value2_2"};
     private static final String LOGICAL_SCOPE = "logical_scope";
     private static final String METRIC_NAME = "myMetric";
-
-    private final MetricGroup metricGroup1 =
-            TestUtils.createTestMetricGroup(
-                    LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, LABEL_VALUES_1));
-    private final MetricGroup metricGroup2 =
-            TestUtils.createTestMetricGroup(
-                    LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, LABEL_VALUES_2));
 
     private PrometheusReporter reporter;
 
@@ -68,8 +61,39 @@ class PrometheusReporterDifferentLabelValueTest {
         }
     }
 
-    @Test
-    void countersCanBeAddedSeveralTimesIfTheyDifferInLabels() {
+    private static Stream<Arguments> provideParameters() {
+        final String[] labelValues1 = new String[] {"value1_1", "value1_2"};
+        final String[] labelValues2 = new String[] {"value2_1", "value2_2"};
+        final String[] labelValues3 = new String[] {"value3_1", ""};
+        final String[] labelValues4 = new String[] {"values4_1", ""};
+
+        final MetricGroup metricGroup1 =
+                TestUtils.createTestMetricGroup(
+                        LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, labelValues1));
+        final MetricGroup metricGroup2 =
+                TestUtils.createTestMetricGroup(
+                        LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, labelValues2));
+        final MetricGroup metricGroup3 =
+                TestUtils.createTestMetricGroup(
+                        LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, labelValues3));
+        final MetricGroup metricGroup4 =
+                TestUtils.createTestMetricGroup(
+                        LOGICAL_SCOPE, TestUtils.toMap(LABEL_NAMES, labelValues4));
+
+        return Stream.of(
+                Arguments.of(metricGroup1, labelValues1, metricGroup2, labelValues2),
+                Arguments.of(metricGroup1, labelValues1, metricGroup3, labelValues3),
+                Arguments.of(metricGroup3, labelValues3, metricGroup2, labelValues2),
+                Arguments.of(metricGroup3, labelValues3, metricGroup4, labelValues4));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void countersCanBeAddedSeveralTimesIfTheyDifferInLabelValues(
+            MetricGroup metricGroup1,
+            String[] expectedLabelValues1,
+            MetricGroup metricGroup2,
+            String[] expectedLabelValues2) {
         Counter counter1 = new SimpleCounter();
         counter1.inc(1);
         Counter counter2 = new SimpleCounter();
@@ -80,16 +104,21 @@ class PrometheusReporterDifferentLabelValueTest {
 
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues1))
                 .isEqualTo(1.);
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_2))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues2))
                 .isEqualTo(2.);
     }
 
-    @Test
-    void gaugesCanBeAddedSeveralTimesIfTheyDifferInLabels() {
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void gaugesCanBeAddedSeveralTimesIfTheyDifferInLabelValues(
+            MetricGroup metricGroup1,
+            String[] expectedLabelValues1,
+            MetricGroup metricGroup2,
+            String[] expectedLabelValues2) {
         Gauge<Integer> gauge1 = () -> 3;
         Gauge<Integer> gauge2 = () -> 4;
 
@@ -98,16 +127,21 @@ class PrometheusReporterDifferentLabelValueTest {
 
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues1))
                 .isEqualTo(3.);
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_2))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues2))
                 .isEqualTo(4.);
     }
 
-    @Test
-    void metersCanBeAddedSeveralTimesIfTheyDifferInLabels() {
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void metersCanBeAddedSeveralTimesIfTheyDifferInLabelValues(
+            MetricGroup metricGroup1,
+            String[] expectedLabelValues1,
+            MetricGroup metricGroup2,
+            String[] expectedLabelValues2) {
         Meter meter1 = new TestMeter(1, 1.0);
         Meter meter2 = new TestMeter(2, 2.0);
 
@@ -116,16 +150,22 @@ class PrometheusReporterDifferentLabelValueTest {
 
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues1))
                 .isEqualTo(meter1.getRate());
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_2))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues2))
                 .isEqualTo(meter2.getRate());
     }
 
-    @Test
-    void histogramsCanBeAddedSeveralTimesIfTheyDifferInLabels() throws UnirestException {
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void histogramsCanBeAddedSeveralTimesIfTheyDifferInLabelValues(
+            MetricGroup metricGroup1,
+            String[] expectedLabelValues1,
+            MetricGroup metricGroup2,
+            String[] expectedLabelValues2)
+            throws UnirestException {
         TestHistogram histogram1 = new TestHistogram();
         histogram1.setCount(1);
         TestHistogram histogram2 = new TestHistogram();
@@ -135,8 +175,10 @@ class PrometheusReporterDifferentLabelValueTest {
         reporter.notifyOfAddedMetric(histogram2, METRIC_NAME, metricGroup2);
 
         final String exportedMetrics = pollMetrics(reporter.getPort()).getBody();
-        assertThat(exportedMetrics).contains("label2=\"value1_2\",} 1.0");
-        assertThat(exportedMetrics).contains("label2=\"value2_2\",} 2.0");
+        assertThat(exportedMetrics)
+                .contains(formatAsPrometheusLabels(LABEL_NAMES, expectedLabelValues1) + " 1.0");
+        assertThat(exportedMetrics)
+                .contains(formatAsPrometheusLabels(LABEL_NAMES, expectedLabelValues2) + " 2.0");
 
         final String[] labelNamesWithQuantile = addToArray(LABEL_NAMES, "quantile");
         for (Double quantile : PrometheusReporter.HistogramSummaryProxy.QUANTILES) {
@@ -144,19 +186,24 @@ class PrometheusReporterDifferentLabelValueTest {
                             reporter.registry.getSampleValue(
                                     getLogicalScope(METRIC_NAME),
                                     labelNamesWithQuantile,
-                                    addToArray(LABEL_VALUES_1, "" + quantile)))
+                                    addToArray(expectedLabelValues1, "" + quantile)))
                     .isEqualTo(quantile);
             assertThat(
                             reporter.registry.getSampleValue(
                                     getLogicalScope(METRIC_NAME),
                                     labelNamesWithQuantile,
-                                    addToArray(LABEL_VALUES_2, "" + quantile)))
+                                    addToArray(expectedLabelValues2, "" + quantile)))
                     .isEqualTo(quantile);
         }
     }
 
-    @Test
-    void removingSingleInstanceOfMetricDoesNotBreakOtherInstances() {
+    @ParameterizedTest
+    @MethodSource("provideParameters")
+    void removingSingleInstanceOfMetricDoesNotBreakOtherInstances(
+            MetricGroup metricGroup1,
+            String[] expectedLabelValues1,
+            MetricGroup metricGroup2,
+            String[] expectedLabelValues2) {
         Counter counter1 = new SimpleCounter();
         counter1.inc(1);
         Counter counter2 = new SimpleCounter();
@@ -167,23 +214,23 @@ class PrometheusReporterDifferentLabelValueTest {
 
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues1))
                 .isEqualTo(1.);
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_2))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues2))
                 .isEqualTo(2.);
 
         reporter.notifyOfRemovedMetric(counter2, METRIC_NAME, metricGroup2);
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues1))
                 .isEqualTo(1.);
 
         reporter.notifyOfRemovedMetric(counter1, METRIC_NAME, metricGroup1);
         assertThat(
                         reporter.registry.getSampleValue(
-                                getLogicalScope(METRIC_NAME), LABEL_NAMES, LABEL_VALUES_1))
+                                getLogicalScope(METRIC_NAME), LABEL_NAMES, expectedLabelValues2))
                 .isNull();
     }
 
@@ -198,5 +245,26 @@ class PrometheusReporterDifferentLabelValueTest {
         final String[] labelNames = Arrays.copyOf(array, LABEL_NAMES.length + 1);
         labelNames[LABEL_NAMES.length] = element;
         return labelNames;
+    }
+
+    private static String formatAsPrometheusLabels(String[] labelNames, String[] labelValues) {
+        if (labelNames == null
+                || labelValues == null
+                || labelNames.length == 0
+                || labelValues.length == 0
+                || labelNames.length != labelValues.length) {
+            throw new IllegalStateException("Erroneous test setup!");
+        }
+
+        final StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < labelNames.length; i++) {
+            sb.append(labelNames[i]);
+            sb.append("=\"");
+            sb.append(labelValues[i]);
+            sb.append("\",");
+        }
+        sb.append("}");
+
+        return sb.toString();
     }
 }

--- a/fluss-metrics/fluss-metrics-prometheus/src/test/java/com/alibaba/fluss/metrics/prometheus/PrometheusReporterDifferentLabelValueTest.java
+++ b/fluss-metrics/fluss-metrics-prometheus/src/test/java/com/alibaba/fluss/metrics/prometheus/PrometheusReporterDifferentLabelValueTest.java
@@ -24,6 +24,7 @@ import com.alibaba.fluss.metrics.groups.MetricGroup;
 import com.alibaba.fluss.metrics.util.TestHistogram;
 import com.alibaba.fluss.metrics.util.TestMeter;
 import com.alibaba.fluss.utils.NetUtils;
+
 import com.mashape.unirest.http.exceptions.UnirestException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
@@ -82,8 +82,7 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
         if (physicalTablePath.getPartitionName() != null) {
             variables.put("partition", physicalTablePath.getPartitionName());
         } else {
-            LOG.debug(
-                    "Setting variable 'partition' for non-partitioned table to empty string to ensure consistent metric labels across metric reporters.");
+            LOG.debug("Setting variable 'partition' for non-partitioned table to empty string.");
             variables.put("partition", "");
         }
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
@@ -82,7 +82,7 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
         if (physicalTablePath.getPartitionName() != null) {
             variables.put("partition", physicalTablePath.getPartitionName());
         } else {
-            LOG.debug("Setting variable 'partition' for non-partitioned table to empty string.");
+            // value of empty string indicates non-partitioned tables
             variables.put("partition", "");
         }
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/PhysicalTableMetricGroup.java
@@ -78,8 +78,13 @@ public class PhysicalTableMetricGroup extends AbstractMetricGroup {
     protected void putVariables(Map<String, String> variables) {
         variables.put("database", physicalTablePath.getDatabaseName());
         variables.put("table", physicalTablePath.getTableName());
+
         if (physicalTablePath.getPartitionName() != null) {
             variables.put("partition", physicalTablePath.getPartitionName());
+        } else {
+            LOG.debug(
+                    "Setting variable 'partition' for non-partitioned table to empty string to ensure consistent metric labels across metric reporters.");
+            variables.put("partition", "");
         }
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #302 

### Tests

<!-- List UT and IT cases to verify this change -->
See changes in 
- `com.alibaba.fluss.metrics.prometheus.PrometheusReporterDifferentLabelValueTest`
- `com.alibaba.fluss.metrics.jmx.JMXReporterTest`

Additional manually verification by creating the following 2 tables 

```
CREATE TABLE tbl1(
  a STRING,
  b INT,
  PRIMARY KEY(a, b) NOT ENFORCED 
) PARTITIONED BY (a) WITH (
  'table.auto-partition.enabled' = 'true',
   'table.auto-partition.time-unit' = 'YEAR',
   'table.auto_partitioning.time-zone' = 'Asia/Shanghai'
);

CREATE TABLE tbl2(
  c STRING,
  d INT,
  PRIMARY KEY(c,d) NOT ENFORCED 
);
```

in the Flink SQL client and check if all metrics are reported in Prometheus and JMX.

**Prometheus**

![Screenshot from 2025-01-08 21-09-45](https://github.com/user-attachments/assets/1488b270-142c-4afb-a922-dda4ed96ecc6)


**JMX** (non-partitioned tables have a single entry with an empty string as key)

![Screenshot from 2025-01-08 21-18-42](https://github.com/user-attachments/assets/3830eae8-f4a1-4956-8b68-b7f1c51eeb3c)


### API and Format

<!-- Does this change affect API or storage format -->

n/a

### Documentation

<!-- Does this change introduce a new feature -->

n/a