### PR TITLE
[hotfix] Fix stack overflow exception for cluster metadata in client

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -314,15 +314,14 @@ public class MetadataUpdater {
     }
 
     /** Invalid the bucket metadata for the given physical table paths. */
-    public void invalidPhysicalTableBucketMeta(
-            Collection<PhysicalTablePath> physicalTablesToInvalid) {
+    public void invalidPhysicalTableBucketMeta(Set<PhysicalTablePath> physicalTablesToInvalid) {
         if (!physicalTablesToInvalid.isEmpty()) {
             cluster = cluster.invalidPhysicalTableBucketMeta(physicalTablesToInvalid);
         }
     }
 
     /** Get the table physical paths by table ids and partition ids. */
-    public Collection<PhysicalTablePath> getPhysicalTablePathByIds(
+    public Set<PhysicalTablePath> getPhysicalTablePathByIds(
             @Nullable Collection<Long> tableId,
             @Nullable Collection<TablePartition> tablePartitions) {
         Set<PhysicalTablePath> physicalTablePaths = new HashSet<>();

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/scanner/log/LogFetcher.java
@@ -59,7 +59,6 @@ import javax.annotation.concurrent.GuardedBy;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -270,7 +269,7 @@ public class LogFetcher implements Closeable {
                 // if is invalid metadata exception, we need to clear table bucket meta
                 // to enable another round of log fetch to request new medata
                 if (e instanceof InvalidMetadataException) {
-                    Collection<PhysicalTablePath> physicalTablePaths =
+                    Set<PhysicalTablePath> physicalTablePaths =
                             metadataUpdater.getPhysicalTablePathByIds(
                                     tableOrPartitionsInFetchRequest.tableIds,
                                     tableOrPartitionsInFetchRequest.tablePartitions);

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/BucketLocation.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/BucketLocation.java
@@ -22,6 +22,9 @@ import com.alibaba.fluss.metadata.TableBucket;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.Objects;
+
 /** This is used to describe per-bucket location information. */
 @Internal
 public final class BucketLocation {
@@ -71,6 +74,26 @@ public final class BucketLocation {
 
     public ServerNode[] getReplicas() {
         return replicas;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) {
+            return true;
+        }
+        if (!(object instanceof BucketLocation)) {
+            return false;
+        }
+        BucketLocation that = (BucketLocation) object;
+        return Objects.equals(physicalTablePath, that.physicalTablePath)
+                && Objects.equals(tableBucket, that.tableBucket)
+                && Objects.equals(leader, that.leader)
+                && Objects.deepEquals(replicas, that.replicas);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(physicalTablePath, tableBucket, leader, Arrays.hashCode(replicas));
     }
 
     @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/Cluster.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/Cluster.java
@@ -27,12 +27,12 @@ import com.alibaba.fluss.metadata.TablePath;
 import javax.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * An immutable representation of a subset of the server nodes, tables, and buckets and schemas in
@@ -122,12 +122,19 @@ public final class Cluster {
         this.pathByTableId = Collections.unmodifiableMap(tempPathByTableId);
     }
 
-    public Cluster invalidPhysicalTableBucketMeta(
-            Collection<PhysicalTablePath> physicalTablesToInvalid) {
+    public Cluster invalidPhysicalTableBucketMeta(Set<PhysicalTablePath> physicalTablesToInvalid) {
+        // should remove invalid tables from current availableLocationsByPath
         Map<PhysicalTablePath, List<BucketLocation>> newBucketLocationsByPath =
-                new HashMap<>(availableLocationsByPath);
-        for (PhysicalTablePath path : physicalTablesToInvalid) {
-            newBucketLocationsByPath.remove(path);
+                new HashMap<>(availableLocationsByPath.size() - physicalTablesToInvalid.size());
+        // copy the metadata from current availableLocationsByPath to newBucketLocationsByPath
+        // except for the tables in physicalTablesToInvalid
+        for (Map.Entry<PhysicalTablePath, List<BucketLocation>> tablePathAndBucketLocations :
+                availableLocationsByPath.entrySet()) {
+            if (!physicalTablesToInvalid.contains(tablePathAndBucketLocations.getKey())) {
+                newBucketLocationsByPath.put(
+                        tablePathAndBucketLocations.getKey(),
+                        new ArrayList<>(tablePathAndBucketLocations.getValue()));
+            }
         }
         return new Cluster(
                 new HashMap<>(aliveTabletServersById),


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
It try to fix the follow exception that may be thrown by client
```
nCaused by: java.lang.StackOverflowError\n\tat java.util.Collections$UnmodifiableCollection$1.<init>
(Collections.java:1041) ~[?:1.8.0_372]\n\tat java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040) ~[?:1.8.0_372]
 java.util.Collections$UnmodifiableCollection$1.<init>(Collections.java:1041) ~[?:1.8.0_372]
java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040) ~[?:1.8.0_372]\njava.util.Collections$UnmodifiableCollection$1.<init>(Collections.java:1041) ~[?:1.8.0_372]
java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040) ~[?:1.8.0_372]
java.util.Collections$UnmodifiableCollection$1.<init>(Collections.java:1041) ~[?:1.8.0_372]
java.util.Collections$UnmodifiableCollection.iterator(Collections.java:1040) ~[?:1.8.0_372]
```
Can be produced by test [testInvalidMetaAndUpdate](https://github.com/alibaba/fluss/pull/329/files#diff-cbd0ad8ddd51be66687882bee2e04d63d0a0b44c6a6d0796d556022448f84c1bR100) in this pr if without this fix.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
