### PR TITLE
[bug][tools] fix source release contains ._* files when build on Mac

### DIFF
--- a/tools/releasing/create_source_release.sh
+++ b/tools/releasing/create_source_release.sh
@@ -40,6 +40,8 @@ fi
 
 if [ "$(uname)" == "Darwin" ]; then
     SHASUM="shasum -a 512"
+    #Disable the creation of ._* files on macOS.
+    export COPYFILE_DISABLE=1
 else
     SHASUM="sha512sum"
 fi


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
fix #335 
<!-- What is the purpose of the change -->
Remove the source release  ._* files when build on Mac
### Tests

<!-- List UT and IT cases to verify this change -->
Run  `tools/releasing/create_source_release.sh`
### API and Format
Not applicable.
<!-- Does this change affect API or storage format -->

### Documentation
Not applicable.

<!-- Does this change introduce a new feature -->