### PR TITLE
[flink] Fix connector option "sink.ignore_delete" to "sink.ignore-delete"

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
@@ -99,7 +99,7 @@ public class FlinkConnectorOptions {
                                     + " A non-positive value disables the partition discovery.");
 
     public static final ConfigOption<Boolean> SINK_IGNORE_DELETE =
-            ConfigOptions.key("sink.ignore_delete")
+            ConfigOptions.key("sink.ignore-delete")
                     .booleanType()
                     .defaultValue(false)
                     .withDescription("Whether to ignore retract（-U/-D) record.");

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
@@ -472,7 +472,7 @@ class FlinkTableSinkITCase {
                                 + "c string "
                                 + (isPrimaryKeyTable ? ", primary key (a) NOT ENFORCED" : "")
                                 + ") with('bucket.num' = '3',"
-                                + " 'sink.ignore_delete'='true')",
+                                + " 'sink.ignore-delete'='true')",
                         sinkName));
         tEnv.executeSql(String.format("INSERT INTO %s SELECT * FROM %s", sinkName, sourceName))
                 .await();


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

Rename connector option key from "sink.ignore_delete" to "sink.ignore-delete". Using dash to keep align with all other config option styles. 

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

Covered  by `FlinkTableSinkITCase#testIgnoreDelete`.

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
