### PR TITLE
[bug][client] check table bucket is for a partition and update info

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -124,7 +124,12 @@ public class MetadataUpdater {
         if (serverNode == null) {
             for (int i = 0; i < MAX_RETRY_TIMES; i++) {
                 TablePath tablePath = cluster.getTablePathOrElseThrow(tableBucket.getTableId());
-                updateMetadata(Collections.singleton(tablePath), null, null);
+                //check if bucket is for a partition
+                if (tableBucket.getPartitionId() != null) {
+                    updateMetadata(Collections.singleton(tablePath), null, Collections.singleton(tableBucket.getPartitionId()));
+                } else {
+                    updateMetadata(Collections.singleton(tablePath), null, null);
+                }
                 serverNode = cluster.leaderFor(tableBucket);
                 if (serverNode != null) {
                     break;

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -124,9 +124,12 @@ public class MetadataUpdater {
         if (serverNode == null) {
             for (int i = 0; i < MAX_RETRY_TIMES; i++) {
                 TablePath tablePath = cluster.getTablePathOrElseThrow(tableBucket.getTableId());
-                //check if bucket is for a partition
+                // check if bucket is for a partition
                 if (tableBucket.getPartitionId() != null) {
-                    updateMetadata(Collections.singleton(tablePath), null, Collections.singleton(tableBucket.getPartitionId()));
+                    updateMetadata(
+                            Collections.singleton(tablePath),
+                            null,
+                            Collections.singleton(tableBucket.getPartitionId()));
                 } else {
                     updateMetadata(Collections.singleton(tablePath), null, null);
                 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
fix #344 

In method `MetadataUpdater`#leaderFor , we should check whether the table bucket is for a partition.
<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format
Not applicable.
<!-- Does this change affect API or storage format -->

### Documentation
Not applicable.
<!-- Does this change introduce a new feature -->
