### PR TITLE
[bug] Remove unnecessary generation of CoordinatorServer server id

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -216,7 +216,7 @@ public class CoordinatorServer extends ServerBase {
 
     private void registerCoordinatorLeader() throws Exception {
         // set server id
-        String serverId = UUID.randomUUID().toString();
+        String serverId = this.serverId;
         CoordinatorAddress coordinatorAddress =
                 new CoordinatorAddress(serverId, rpcServer.getHostname(), rpcServer.getPort());
         zkClient.registerCoordinatorLeader(coordinatorAddress);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -215,10 +215,8 @@ public class CoordinatorServer extends ServerBase {
     }
 
     private void registerCoordinatorLeader() throws Exception {
-        // set server id
-        String serverId = this.serverId;
         CoordinatorAddress coordinatorAddress =
-                new CoordinatorAddress(serverId, rpcServer.getHostname(), rpcServer.getPort());
+                new CoordinatorAddress(this.serverId, rpcServer.getHostname(), rpcServer.getPort());
         zkClient.registerCoordinatorLeader(coordinatorAddress);
     }
 


### PR DESCRIPTION
### Purpose
Reuse generated server id rather than generate a new one
