### PR TITLE
[client] Fix the possible data loss error while MemoryLogRecordsArrowBuilder#resetWriterState

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilder.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilder.java
@@ -60,6 +60,7 @@ public class MemoryLogRecordsArrowBuilder implements AutoCloseable {
     private int recordCount;
     private boolean isClosed;
     private boolean reCalculateSizeInBytes = false;
+    private boolean resetBatchHeader = false;
 
     private MemoryLogRecordsArrowBuilder(
             long baseLogOffset,
@@ -111,6 +112,10 @@ public class MemoryLogRecordsArrowBuilder implements AutoCloseable {
 
     public MultiBytesView build() throws IOException {
         if (bytesView != null) {
+            if (resetBatchHeader) {
+                writeBatchHeader();
+                resetBatchHeader = false;
+            }
             return bytesView;
         }
 
@@ -162,8 +167,8 @@ public class MemoryLogRecordsArrowBuilder implements AutoCloseable {
     }
 
     public void resetWriterState(long writerId, int batchSequence) {
-        // trigger to rewrite batch header
-        this.bytesView = null;
+        // trigger to rewrite batch header when next build.
+        this.resetBatchHeader = true;
         this.writerId = writerId;
         this.batchSequence = batchSequence;
     }


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/353

<!-- What is the purpose of the change -->

When MemoryLogRecordsArrowBuilder try to resetWriterState in case the produceLog request failed and the batch is re-enqueue to send with different write state, we will reset the bytesView to null, this is very dangerous. Because once we set bytesView to null, we won't be able to retrieve the data from arrowWriter while next build, which means data in this batch will be lost. The correct approach is to simply reset the batch header instead of reset the whole batch.

This pr is aims to fix this error by introducing a bool variable `resetBatchHeader` to reset batch header while next build call.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
