### PR TITLE
[kv] The kv pre-write buffer need to truncate while receive duplicated batches

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metrics/MetricNames.java
@@ -108,6 +108,13 @@ public class MetricNames {
 
     // for kv tablet
     public static final String KV_LATEST_SNAPSHOT_SIZE = "latestSnapshotSize";
+    public static final String KV_PRE_WRITE_BUFFER_TRUNCATE_AS_DUPLICATED_RATE =
+            "preWriteBufferTruncateAsDuplicatedPerSecond";
+    public static final String KV_PRE_WRITE_BUFFER_TRUNCATE_AS_ERROR_RATE =
+            "preWriteBufferTruncateAsErrorPerSecond";
+    public static final String KV_PRE_WRITE_BUFFER_FLUSH_RATE = "preWriteBufferFlushPerSecond";
+    public static final String KV_PRE_WRITE_BUFFER_FLUSH_LATENCY_MS =
+            "preWriteBufferFlushLatencyMs";
 
     // --------------------------------------------------------------------------------------------
     // metrics for rpc client

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
@@ -41,7 +41,7 @@ import com.alibaba.fluss.row.arrow.ArrowWriterProvider;
 import com.alibaba.fluss.row.encode.ValueDecoder;
 import com.alibaba.fluss.row.encode.ValueEncoder;
 import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer;
-import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer.KvPreWriteBufferTruncateReason;
+import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer.TruncateReason;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBKv;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBKvBuilder;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBResourceContainer;
@@ -373,8 +373,7 @@ public final class KvTablet {
                         // already written.
                         if (logAppendInfo.duplicated()) {
                             kvPreWriteBuffer.truncateTo(
-                                    logEndOffsetOfPrevBatch,
-                                    KvPreWriteBufferTruncateReason.DUPLICATED);
+                                    logEndOffsetOfPrevBatch, TruncateReason.DUPLICATED);
                         }
                         return logAppendInfo;
                     } catch (Throwable t) {
@@ -384,8 +383,7 @@ public final class KvTablet {
                         // retry-send batch will produce incorrect CDC logs.
                         // TODO for some errors, the cdc logs may already be written to disk, for
                         //  those errors, we should not truncate the kvPreWriteBuffer.
-                        kvPreWriteBuffer.truncateTo(
-                                logEndOffsetOfPrevBatch, KvPreWriteBufferTruncateReason.ERROR);
+                        kvPreWriteBuffer.truncateTo(logEndOffsetOfPrevBatch, TruncateReason.ERROR);
                         throw t;
                     } finally {
                         // deallocate the memory and arrow writer used by the wal builder

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvTablet.java
@@ -28,6 +28,9 @@ import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.metrics.MeterView;
+import com.alibaba.fluss.metrics.MetricNames;
+import com.alibaba.fluss.metrics.groups.MetricGroup;
 import com.alibaba.fluss.record.KvRecord;
 import com.alibaba.fluss.record.KvRecordBatch;
 import com.alibaba.fluss.record.KvRecordReadContext;
@@ -38,6 +41,7 @@ import com.alibaba.fluss.row.arrow.ArrowWriterProvider;
 import com.alibaba.fluss.row.encode.ValueDecoder;
 import com.alibaba.fluss.row.encode.ValueEncoder;
 import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer;
+import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer.KvPreWriteBufferTruncateReason;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBKv;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBKvBuilder;
 import com.alibaba.fluss.server.kv.rocksdb.RocksDBResourceContainer;
@@ -50,6 +54,7 @@ import com.alibaba.fluss.server.kv.wal.IndexWalBuilder;
 import com.alibaba.fluss.server.kv.wal.WalBuilder;
 import com.alibaba.fluss.server.log.LogAppendInfo;
 import com.alibaba.fluss.server.log.LogTablet;
+import com.alibaba.fluss.server.metrics.group.BucketMetricGroup;
 import com.alibaba.fluss.server.utils.FatalErrorHandler;
 import com.alibaba.fluss.shaded.arrow.org.apache.arrow.memory.BufferAllocator;
 import com.alibaba.fluss.types.DataType;
@@ -237,6 +242,24 @@ public final class KvTablet {
         return flushedLogOffset;
     }
 
+    public void registerMetrics(BucketMetricGroup bucketMetricGroup) {
+        MetricGroup metricGroup = bucketMetricGroup.addGroup("kv");
+
+        // about pre-write buffer.
+        metricGroup.meter(
+                MetricNames.KV_PRE_WRITE_BUFFER_FLUSH_RATE,
+                new MeterView(kvPreWriteBuffer.getFlushCount()));
+        metricGroup.histogram(
+                MetricNames.KV_PRE_WRITE_BUFFER_FLUSH_LATENCY_MS,
+                kvPreWriteBuffer.getFlushLatencyHistogram());
+        metricGroup.meter(
+                MetricNames.KV_PRE_WRITE_BUFFER_TRUNCATE_AS_DUPLICATED_RATE,
+                new MeterView(kvPreWriteBuffer.getTruncateAsDuplicatedCount()));
+        metricGroup.meter(
+                MetricNames.KV_PRE_WRITE_BUFFER_TRUNCATE_AS_ERROR_RATE,
+                new MeterView(kvPreWriteBuffer.getTruncateAsErrorCount()));
+    }
+
     /**
      * Put the KvRecordBatch into the kv storage, and return the appended wal log info.
      *
@@ -344,7 +367,16 @@ public final class KvTablet {
                         // put a batch into file with recordCount 0 and offset plus 1L, it will
                         // update the batchSequence corresponding to the writerId and also increment
                         // the CDC log offset by 1.
-                        return logTablet.appendAsLeader(walBuilder.build());
+                        LogAppendInfo logAppendInfo = logTablet.appendAsLeader(walBuilder.build());
+
+                        // if the batch is duplicated, we should truncate the kvPreWriteBuffer
+                        // already written.
+                        if (logAppendInfo.duplicated()) {
+                            kvPreWriteBuffer.truncateTo(
+                                    logEndOffsetOfPrevBatch,
+                                    KvPreWriteBufferTruncateReason.DUPLICATED);
+                        }
+                        return logAppendInfo;
                     } catch (Throwable t) {
                         // While encounter error here, the CDC logs may fail writing to disk,
                         // and the client probably will resend the batch. If we do not remove the
@@ -352,7 +384,8 @@ public final class KvTablet {
                         // retry-send batch will produce incorrect CDC logs.
                         // TODO for some errors, the cdc logs may already be written to disk, for
                         //  those errors, we should not truncate the kvPreWriteBuffer.
-                        kvPreWriteBuffer.truncateTo(logEndOffsetOfPrevBatch, t.getMessage());
+                        kvPreWriteBuffer.truncateTo(
+                                logEndOffsetOfPrevBatch, KvPreWriteBufferTruncateReason.ERROR);
                         throw t;
                     } finally {
                         // deallocate the memory and arrow writer used by the wal builder

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -18,11 +18,12 @@ package com.alibaba.fluss.server.kv.prewrite;
 
 import com.alibaba.fluss.annotation.VisibleForTesting;
 import com.alibaba.fluss.memory.MemorySegment;
+import com.alibaba.fluss.metrics.Counter;
+import com.alibaba.fluss.metrics.DescriptiveStatisticsHistogram;
+import com.alibaba.fluss.metrics.Histogram;
+import com.alibaba.fluss.metrics.SimpleCounter;
 import com.alibaba.fluss.server.kv.KvBatchWriter;
 import com.alibaba.fluss.utils.MurmurHashUtils;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -85,9 +86,6 @@ import static com.alibaba.fluss.utils.UnsafeUtils.BYTE_ARRAY_BASE_OFFSET;
  */
 @NotThreadSafe
 public class KvPreWriteBuffer implements AutoCloseable {
-
-    private static final Logger LOG = LoggerFactory.getLogger(KvPreWriteBuffer.class);
-
     private final KvBatchWriter kvBatchWriter;
 
     // a mapping from the key to the kv-entry
@@ -96,11 +94,23 @@ public class KvPreWriteBuffer implements AutoCloseable {
     // a linked list for all kv entries
     private final LinkedList<KvEntry> allKvEntries = new LinkedList<>();
 
+    // metrics related.
+    private final Counter flushCount;
+    private final Histogram flushLatencyHistogram;
+    private final Counter truncateAsDuplicatedCount;
+    private final Counter truncateAsErrorCount;
+
     // the max LSN in the buffer
     private long maxLogSequenceNumber = -1;
 
     public KvPreWriteBuffer(KvBatchWriter kvBatchWriter) {
         this.kvBatchWriter = kvBatchWriter;
+
+        flushCount = new SimpleCounter();
+        // consider won't flush frequently, we set a small window size
+        flushLatencyHistogram = new DescriptiveStatisticsHistogram(5);
+        truncateAsDuplicatedCount = new SimpleCounter();
+        truncateAsErrorCount = new SimpleCounter();
     }
 
     /**
@@ -164,11 +174,13 @@ public class KvPreWriteBuffer implements AutoCloseable {
      * @param targetLogSequenceNumber the lower bound of the log sequence number truncated to.
      * @param truncateReason the reason to truncate
      */
-    public void truncateTo(long targetLogSequenceNumber, String truncateReason) {
-        LOG.info(
-                "Truncate the kv pre-write buffer to {} because we encounter error while building cdc logs: {}",
-                targetLogSequenceNumber,
-                truncateReason);
+    public void truncateTo(
+            long targetLogSequenceNumber, KvPreWriteBufferTruncateReason truncateReason) {
+        if (truncateReason == KvPreWriteBufferTruncateReason.DUPLICATED) {
+            truncateAsDuplicatedCount.inc();
+        } else {
+            truncateAsErrorCount.inc();
+        }
 
         Iterator<KvEntry> descIter = allKvEntries.descendingIterator();
         while (descIter.hasNext()) {
@@ -196,6 +208,7 @@ public class KvPreWriteBuffer implements AutoCloseable {
      *     be flushed
      */
     public void flush(long exclusiveUpToLogSequenceNumber) throws IOException {
+        int flushedCount = 0;
         for (Iterator<KvEntry> it = allKvEntries.iterator(); it.hasNext(); ) {
             KvEntry entry = it.next();
             // if find one entry whose sequence number is greater than the given sequence number,
@@ -210,8 +223,10 @@ public class KvPreWriteBuffer implements AutoCloseable {
             // then write data using write batch writer
             Value value = entry.getValue();
             if (value.value != null) {
+                flushedCount += 1;
                 kvBatchWriter.put(entry.getKey().key, value.value);
             } else {
+                flushedCount += 1;
                 kvBatchWriter.delete(entry.getKey().key);
             }
 
@@ -221,7 +236,12 @@ public class KvPreWriteBuffer implements AutoCloseable {
             kvEntryMap.remove(entry.getKey(), entry);
         }
         // flush to underlying kv tablet
-        kvBatchWriter.flush();
+        if (flushedCount > 0) {
+            long start = System.nanoTime();
+            kvBatchWriter.flush();
+            flushCount.inc();
+            flushLatencyHistogram.update((System.nanoTime() - start) / 1_000_000);
+        }
     }
 
     @VisibleForTesting
@@ -244,6 +264,22 @@ public class KvPreWriteBuffer implements AutoCloseable {
         if (kvBatchWriter != null) {
             kvBatchWriter.close();
         }
+    }
+
+    public Histogram getFlushLatencyHistogram() {
+        return flushLatencyHistogram;
+    }
+
+    public Counter getFlushCount() {
+        return flushCount;
+    }
+
+    public Counter getTruncateAsDuplicatedCount() {
+        return truncateAsDuplicatedCount;
+    }
+
+    public Counter getTruncateAsErrorCount() {
+        return truncateAsErrorCount;
     }
 
     /**
@@ -425,5 +461,11 @@ public class KvPreWriteBuffer implements AutoCloseable {
         public String toString() {
             return value == null ? "null" : "[" + Base64.getEncoder().encodeToString(value) + "]";
         }
+    }
+
+    /** The reason why we truncate the kv pre-write buffer. */
+    public enum KvPreWriteBufferTruncateReason {
+        DUPLICATED,
+        ERROR,
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBuffer.java
@@ -174,9 +174,8 @@ public class KvPreWriteBuffer implements AutoCloseable {
      * @param targetLogSequenceNumber the lower bound of the log sequence number truncated to.
      * @param truncateReason the reason to truncate
      */
-    public void truncateTo(
-            long targetLogSequenceNumber, KvPreWriteBufferTruncateReason truncateReason) {
-        if (truncateReason == KvPreWriteBufferTruncateReason.DUPLICATED) {
+    public void truncateTo(long targetLogSequenceNumber, TruncateReason truncateReason) {
+        if (truncateReason == TruncateReason.DUPLICATED) {
             truncateAsDuplicatedCount.inc();
         } else {
             truncateAsErrorCount.inc();
@@ -464,7 +463,7 @@ public class KvPreWriteBuffer implements AutoCloseable {
     }
 
     /** The reason why we truncate the kv pre-write buffer. */
-    public enum KvPreWriteBufferTruncateReason {
+    public enum TruncateReason {
         DUPLICATED,
         ERROR,
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogAppendInfo.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogAppendInfo.java
@@ -36,6 +36,9 @@ public final class LogAppendInfo {
     private long maxTimestamp;
     private long startOffsetOfMaxTimestamp;
 
+    /** Whether the appended log data is duplicated. */
+    private boolean duplicated;
+
     /** Creates an instance with the given params. */
     public LogAppendInfo(
             long firstOffset,
@@ -74,6 +77,7 @@ public final class LogAppendInfo {
         this.validBytes = validBytes;
         this.offsetsMonotonic = offsetsMonotonic;
         this.errorMessage = errorMessage;
+        this.duplicated = false;
     }
 
     public long firstOffset() {
@@ -117,6 +121,14 @@ public final class LogAppendInfo {
         this.startOffsetOfMaxTimestamp = startOffsetOfMaxTimestamp;
     }
 
+    public boolean duplicated() {
+        return duplicated;
+    }
+
+    public void setDuplicated(boolean duplicated) {
+        this.duplicated = duplicated;
+    }
+
     public boolean offsetsMonotonic() {
         return offsetsMonotonic;
     }
@@ -150,6 +162,8 @@ public final class LogAppendInfo {
                 + validBytes
                 + ", offsetsMonotonic="
                 + offsetsMonotonic
+                + ", duplicated="
+                + duplicated
                 + ", recordErrors="
                 + errorMessage
                 + ')';

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
@@ -632,6 +632,7 @@ public final class LogTablet {
                 appendInfo.setLastOffset(duplicatedBatch.lastOffset);
                 appendInfo.setMaxTimestamp(duplicatedBatch.timestamp);
                 appendInfo.setStartOffsetOfMaxTimestamp(startOffset);
+                appendInfo.setDuplicated(true);
             } else {
                 // Append the records, and increment the local log end offset immediately after
                 // append because write to the transaction index below may fail, and we want to

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -627,6 +627,9 @@ public final class Replica {
                                 tableConfig,
                                 arrowCompressionInfo);
             }
+
+            kvTablet.registerMetrics(bucketMetricGroup);
+
             logTablet.updateMinRetainOffset(restoreStartOffset);
             recoverKvTablet(restoreStartOffset);
         } catch (Exception e) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
@@ -145,7 +145,7 @@ class KvPreWriteBufferTest {
         assertThat(buffer.getMaxLSN()).isEqualTo(elementCount - 1);
 
         // truncate to 5.
-        buffer.truncateTo(5, "test");
+        buffer.truncateTo(5, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(4);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(5);
         for (int i = 0; i < 5; i++) {
@@ -165,7 +165,7 @@ class KvPreWriteBufferTest {
         bufferPut(buffer, "key1", "value1-1", elementCount++);
         assertThat(getValue(buffer, "key1")).isEqualTo("value1-1");
         assertThat(buffer.getMaxLSN()).isEqualTo(elementCount - 1);
-        buffer.truncateTo(5, "test");
+        buffer.truncateTo(5, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(4);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(5);
         // to delete records and update records operation will be truncate.
@@ -175,7 +175,7 @@ class KvPreWriteBufferTest {
         }
 
         // truncate to zero
-        buffer.truncateTo(0, "test");
+        buffer.truncateTo(0, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(-1);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(0);
         assertThat(buffer.getKvEntryMap().size()).isEqualTo(0);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/prewrite/KvPreWriteBufferTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.kv.prewrite;
 
 import com.alibaba.fluss.server.kv.KvBatchWriter;
+import com.alibaba.fluss.server.kv.prewrite.KvPreWriteBuffer.TruncateReason;
 
 import org.junit.jupiter.api.Test;
 
@@ -145,7 +146,7 @@ class KvPreWriteBufferTest {
         assertThat(buffer.getMaxLSN()).isEqualTo(elementCount - 1);
 
         // truncate to 5.
-        buffer.truncateTo(5, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
+        buffer.truncateTo(5, TruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(4);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(5);
         for (int i = 0; i < 5; i++) {
@@ -165,7 +166,7 @@ class KvPreWriteBufferTest {
         bufferPut(buffer, "key1", "value1-1", elementCount++);
         assertThat(getValue(buffer, "key1")).isEqualTo("value1-1");
         assertThat(buffer.getMaxLSN()).isEqualTo(elementCount - 1);
-        buffer.truncateTo(5, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
+        buffer.truncateTo(5, TruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(4);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(5);
         // to delete records and update records operation will be truncate.
@@ -175,7 +176,7 @@ class KvPreWriteBufferTest {
         }
 
         // truncate to zero
-        buffer.truncateTo(0, KvPreWriteBuffer.KvPreWriteBufferTruncateReason.ERROR);
+        buffer.truncateTo(0, TruncateReason.ERROR);
         assertThat(buffer.getMaxLSN()).isEqualTo(-1);
         assertThat(buffer.getAllKvEntries().size()).isEqualTo(0);
         assertThat(buffer.getKvEntryMap().size()).isEqualTo(0);

--- a/website/docs/maintenance/monitor-metrics.md
+++ b/website/docs/maintenance/monitor-metrics.md
@@ -629,12 +629,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="5">table_bucket_kv_snapshot</td>
-      <td>latestSnapshotSize</td>
-      <td>The latest kv snapshot size in bytes for this table bucket.</td>
-      <td>Gauge</td>
-    </tr>
-     <tr>
+      <td rowspan="4">table_bucket_kv</td>
       <td>preWriteBufferFlushPerSecond</td>
       <td>The kv pre-write buffer flush count per second.</td>
       <td>Meter</td>
@@ -653,6 +648,12 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>preWriteBufferTruncateAsErrorPerSecond</td>
       <td>The number of kv pre-write buffer truncate due to the error happened when writing cdc to log per second.</td>
       <td>Meter</td>
+    </tr>
+    <tr>
+      <td rowspan="1">table_bucket_kv_snapshot</td>
+      <td>latestSnapshotSize</td>
+      <td>The latest kv snapshot size in bytes for this table bucket.</td>
+      <td>Gauge</td>
     </tr>
   </tbody>
 </table>

--- a/website/docs/maintenance/monitor-metrics.md
+++ b/website/docs/maintenance/monitor-metrics.md
@@ -454,7 +454,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-      <th rowspan="35"><strong>tabletserver</strong></th>
+      <th rowspan="39"><strong>tabletserver</strong></th>
       <td rowspan="20">table</td>
       <td>messagesInPerSecond</td>
       <td>The number of messages written per second to this table</td>
@@ -629,10 +629,30 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="1">table_bucket_kv_snapshot</td>
+      <td rowspan="5">table_bucket_kv_snapshot</td>
       <td>latestSnapshotSize</td>
       <td>The latest kv snapshot size in bytes for this table bucket.</td>
       <td>Gauge</td>
+    </tr>
+     <tr>
+      <td>preWriteBufferFlushPerSecond</td>
+      <td>The kv pre-write buffer flush count per second.</td>
+      <td>Meter</td>
+    </tr>
+     <tr>
+      <td>preWriteBufferFlushLatencyMs</td>
+      <td>The kv pre-write buffer latency in ms.</td>
+      <td>Histogram</td>
+    </tr>
+     <tr>
+      <td>preWriteBufferTruncateAsDuplicatedPerSecond</td>
+      <td>The number of kv pre-write buffer truncate due to the batch duplicated per second.</td>
+      <td>Meter</td>
+    </tr>
+     <tr>
+      <td>preWriteBufferTruncateAsErrorPerSecond</td>
+      <td>The number of kv pre-write buffer truncate due to the error happened when writing cdc to log per second.</td>
+      <td>Meter</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/325

Currently, the `kv pre-write buffer` writes data into the buffer before submitting the CDC log. However, for duplicate KV batches, the duplicated CDC logs that we submit will not be written to disk by the logTablet, and the logEndOffset will not be increase. This results in `the MSN` in the `pre-write buffer` being greater than the `logEndOffset`, leading to an error. The purpose of this PR is to fix this issue. If we detect a duplicate KV batch, the data that has already been written into the `pre-write buffer` needs to be truncated.

Also, I add some metrics to avoid print so much logs when duplicated or error happend in `pre-write buffer`.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
