### PR TITLE
[client] Bug Fix Test RecordAccumulatorTest.testDrainCompressedBatches is unstable

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
@@ -196,7 +196,12 @@ public class RecordAccumulatorTest {
         // the compression ratio is smaller than 1.0,
         // so bucketNum * batch_size should contain all compressed batches for each bucket
         assertThat(batches.containsKey(node1.id())).isTrue();
-        assertThat(batches.get(node1.id()).size()).isEqualTo(bucketNum);
+        int batchCount = batches.get(node1.id()).size();
+        assertThat(batchCount).isBetween(bucketNum - 1, bucketNum);
+
+        int totalBatchSize = batches.values().stream().mapToInt(List::size).sum();
+        int expectedBatchSize = batchSize * bucketNum;
+        assertThat(totalBatchSize >= expectedBatchSize * 0.9 && totalBatchSize <= expectedBatchSize * 1.1);
     }
 
     private void appendUntilCompressionRatioStable(RecordAccumulator accum, int batchSize)


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
To address this, you could adjust the test to allow the return of either bucketNum or bucketNum-1 batches. Additionally, ensure that the average batch size falls close to batchSize, for example within the range of [batchSize * 0.9, batchSize * 1.1].


<!-- Linking this pull request to the issue -->
Linked issue: close #349

<!-- What is the purpose of the change -->

### Tests
RecordAccumulatorTest.testDrainCompressedBatches
<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
