### PR TITLE
[test] Enable FlussTableITCase#testAppendWithSmallBuffer

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/table/FlussTableITCase.java
@@ -49,7 +49,6 @@ import com.alibaba.fluss.types.StringType;
 import com.alibaba.fluss.utils.Preconditions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -108,7 +107,6 @@ class FlussTableITCase extends ClientToServerITCaseBase {
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
-    @Disabled("TODO, fix me in #116")
     void testAppendWithSmallBuffer(boolean indexedFormat) throws Exception {
         TableDescriptor desc =
                 indexedFormat


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #116

<!-- What is the purpose of the change -->
The original test was frequently hang on `at com.alibaba.fluss.client.write.WriterMemoryBuffer.allocate(WriterMemoryBuffer.java:187)`. But we have refactored the writer memory pool in d0b466fb by removing `WriterMemoryBuffer` and enhance `LazyMemorySegmentPool`. This problem shouldn't exist now. 

### Tests

<!-- List UT and IT cases to verify this change -->

Run several times of `FlussTableITCase#testAppendWithSmallBuffer` in local, and passed successfully. 

We should also run several times of github actions, to make sure it is not unstable. 

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
