### PR TITLE
[flink] Fix split will lose offset when restore from state

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/lakehouse/paimon/split/PaimonSnapshotAndFlussLogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/lakehouse/paimon/split/PaimonSnapshotAndFlussLogSplitState.java
@@ -30,6 +30,7 @@ public class PaimonSnapshotAndFlussLogSplitState extends SourceSplitState {
             PaimonSnapshotAndFlussLogSplit paimonSnapshotAndFlussLogSplit) {
         super(paimonSnapshotAndFlussLogSplit);
         this.paimonSnapshotAndFlussLogSplit = paimonSnapshotAndFlussLogSplit;
+        this.recordsToSkip = paimonSnapshotAndFlussLogSplit.getRecordsToSkip();
     }
 
     public void setRecordsToSkip(long recordsToSkip) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/lakehouse/paimon/split/PaimonSnapshotSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/lakehouse/paimon/split/PaimonSnapshotSplitState.java
@@ -30,6 +30,7 @@ public class PaimonSnapshotSplitState extends SourceSplitState {
     public PaimonSnapshotSplitState(PaimonSnapshotSplit paimonSnapshotSplit) {
         super(paimonSnapshotSplit);
         this.paimonSnapshotSplit = paimonSnapshotSplit;
+        this.recordsToSkip = paimonSnapshotSplit.getFileStoreSourceSplit().recordsToSkip();
     }
 
     public void setRecordsToSkip(long recordsToSkip) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
@@ -67,7 +67,7 @@ public class FlinkRecordEmitter implements RecordEmitter<RecordAndPos, RowData, 
             if (scanRecord.logOffset() >= 0) {
                 // record is with a valid offset, means it's in incremental phase,
                 // update the log offset
-                hybridSnapshotLogSplitState.setCurrentOffset(scanRecord.logOffset() + 1);
+                hybridSnapshotLogSplitState.setNextOffset(scanRecord.logOffset() + 1);
             } else {
                 // record is with an invalid offset, means it's in snapshot phase,
                 // update the records number to skip
@@ -75,9 +75,7 @@ public class FlinkRecordEmitter implements RecordEmitter<RecordAndPos, RowData, 
             }
             emitRecord(scanRecord, sourceOutput);
         } else if (splitState.isLogSplitState()) {
-            splitState
-                    .asLogSplitState()
-                    .setCurrentOffset(recordAndPosition.record().logOffset() + 1);
+            splitState.asLogSplitState().setNextOffset(recordAndPosition.record().logOffset() + 1);
             emitRecord(recordAndPosition.record(), sourceOutput);
         } else if (splitState.isLakeSplit()) {
             if (lakeRecordRecordEmitter == null) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
@@ -67,7 +67,7 @@ public class FlinkRecordEmitter implements RecordEmitter<RecordAndPos, RowData, 
             if (scanRecord.logOffset() >= 0) {
                 // record is with a valid offset, means it's in incremental phase,
                 // update the log offset
-                hybridSnapshotLogSplitState.setOffset(scanRecord.logOffset() + 1);
+                hybridSnapshotLogSplitState.setCurrentOffset(scanRecord.logOffset() + 1);
             } else {
                 // record is with an invalid offset, means it's in snapshot phase,
                 // update the records number to skip
@@ -75,7 +75,9 @@ public class FlinkRecordEmitter implements RecordEmitter<RecordAndPos, RowData, 
             }
             emitRecord(scanRecord, sourceOutput);
         } else if (splitState.isLogSplitState()) {
-            splitState.asLogSplitState().setOffset(recordAndPosition.record().logOffset() + 1);
+            splitState
+                    .asLogSplitState()
+                    .setCurrentOffset(recordAndPosition.record().logOffset() + 1);
             emitRecord(recordAndPosition.record(), sourceOutput);
         } else if (splitState.isLakeSplit()) {
             if (lakeRecordRecordEmitter == null) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
@@ -25,10 +25,13 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
     private boolean snapshotFinished;
 
     /** The next log offset to read. */
-    private long offset;
+    private long currentOffset;
 
     public HybridSnapshotLogSplitState(HybridSnapshotLogSplit hybridSnapshotLogSplit) {
         super(hybridSnapshotLogSplit);
+        this.recordsToSkip = hybridSnapshotLogSplit.recordsToSkip();
+        this.snapshotFinished = hybridSnapshotLogSplit.isSnapshotFinished();
+        this.currentOffset = hybridSnapshotLogSplit.getLogStartingOffset();
     }
 
     @Override
@@ -40,16 +43,16 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
                 hybridSnapshotLogSplit.getSnapshotId(),
                 recordsToSkip,
                 snapshotFinished,
-                offset);
+                currentOffset);
     }
 
     public void setRecordsToSkip(long recordsToSkip) {
         this.recordsToSkip = recordsToSkip;
     }
 
-    public void setOffset(long offset) {
+    public void setCurrentOffset(long currentOffset) {
         // if set offset, means snapshot is finished
         snapshotFinished = true;
-        this.offset = offset;
+        this.currentOffset = currentOffset;
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/HybridSnapshotLogSplitState.java
@@ -25,13 +25,13 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
     private boolean snapshotFinished;
 
     /** The next log offset to read. */
-    private long currentOffset;
+    private long nextOffset;
 
     public HybridSnapshotLogSplitState(HybridSnapshotLogSplit hybridSnapshotLogSplit) {
         super(hybridSnapshotLogSplit);
         this.recordsToSkip = hybridSnapshotLogSplit.recordsToSkip();
         this.snapshotFinished = hybridSnapshotLogSplit.isSnapshotFinished();
-        this.currentOffset = hybridSnapshotLogSplit.getLogStartingOffset();
+        this.nextOffset = hybridSnapshotLogSplit.getLogStartingOffset();
     }
 
     @Override
@@ -43,16 +43,16 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
                 hybridSnapshotLogSplit.getSnapshotId(),
                 recordsToSkip,
                 snapshotFinished,
-                currentOffset);
+                nextOffset);
     }
 
     public void setRecordsToSkip(long recordsToSkip) {
         this.recordsToSkip = recordsToSkip;
     }
 
-    public void setCurrentOffset(long currentOffset) {
+    public void setNextOffset(long nextOffset) {
         // if set offset, means snapshot is finished
         snapshotFinished = true;
-        this.currentOffset = currentOffset;
+        this.nextOffset = nextOffset;
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
@@ -16,22 +16,29 @@
 
 package com.alibaba.fluss.connector.flink.source.split;
 
+import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPING_OFFSET;
+
 /** The state of {@link LogSplit}. */
 public class LogSplitState extends SourceSplitState {
 
-    private long offset;
+    private long currentOffset;
 
     public LogSplitState(LogSplit split) {
         super(split);
+        this.currentOffset = split.getStartingOffset();
     }
 
-    public void setOffset(long offset) {
-        this.offset = offset;
+    public void setCurrentOffset(long currentOffset) {
+        this.currentOffset = currentOffset;
     }
 
     @Override
     public LogSplit toSourceSplit() {
         final LogSplit logSplit = (LogSplit) split;
-        return new LogSplit(logSplit.tableBucket, logSplit.getPartitionName(), offset);
+        return new LogSplit(
+                logSplit.tableBucket,
+                logSplit.getPartitionName(),
+                currentOffset,
+                logSplit.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/split/LogSplitState.java
@@ -21,15 +21,16 @@ import static com.alibaba.fluss.connector.flink.source.split.LogSplit.NO_STOPPIN
 /** The state of {@link LogSplit}. */
 public class LogSplitState extends SourceSplitState {
 
-    private long currentOffset;
+    /** The next log offset to read. */
+    private long nextOffset;
 
     public LogSplitState(LogSplit split) {
         super(split);
-        this.currentOffset = split.getStartingOffset();
+        this.nextOffset = split.getStartingOffset();
     }
 
-    public void setCurrentOffset(long currentOffset) {
-        this.currentOffset = currentOffset;
+    public void setNextOffset(long nextOffset) {
+        this.nextOffset = nextOffset;
     }
 
     @Override
@@ -38,7 +39,7 @@ public class LogSplitState extends SourceSplitState {
         return new LogSplit(
                 logSplit.tableBucket,
                 logSplit.getPartitionName(),
-                currentOffset,
+                nextOffset,
                 logSplit.getStoppingOffset().orElse(NO_STOPPING_OFFSET));
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/state/SourceSplitStateTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/state/SourceSplitStateTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.connector.flink.source.state;
+
+import com.alibaba.fluss.connector.flink.source.split.HybridSnapshotLogSplit;
+import com.alibaba.fluss.connector.flink.source.split.HybridSnapshotLogSplitState;
+import com.alibaba.fluss.connector.flink.source.split.LogSplit;
+import com.alibaba.fluss.connector.flink.source.split.LogSplitState;
+import com.alibaba.fluss.metadata.TableBucket;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link LogSplitState} and {@link HybridSnapshotLogSplitState} . */
+class SourceSplitStateTest {
+
+    @Test
+    void testLogSplitState() {
+        TableBucket tableBucket = new TableBucket(0, 0L, 0);
+
+        // verify if no stopping offset
+        LogSplit logSplit = new LogSplit(tableBucket, "partition1", 100L);
+        LogSplitState logSplitState = new LogSplitState(logSplit);
+        assertThat(logSplitState.toSourceSplit()).isEqualTo(logSplit);
+
+        // advance current offset of log split state, and verify
+        logSplitState.setCurrentOffset(200L);
+        LogSplit expectedLogSplit = new LogSplit(tableBucket, "partition1", 200L);
+        assertThat(logSplitState.toSourceSplit()).isEqualTo(expectedLogSplit);
+
+        // verify with stopping offset
+        logSplit = new LogSplit(tableBucket, "partition1", 100L, 2000L);
+        logSplitState = new LogSplitState(logSplit);
+        assertThat(logSplitState.toSourceSplit()).isEqualTo(logSplit);
+
+        // advance current offset of log split state, and verify
+        logSplitState.setCurrentOffset(300L);
+        expectedLogSplit = new LogSplit(tableBucket, "partition1", 300L, 2000L);
+        assertThat(logSplitState.toSourceSplit()).isEqualTo(expectedLogSplit);
+    }
+
+    @Test
+    void testHybridSnapshotLogSplitState() {
+        TableBucket tableBucket = new TableBucket(0, 0L, 0);
+
+        // verify the split that snapshot is not finished
+        HybridSnapshotLogSplit hybridSnapshotLogSplit =
+                new HybridSnapshotLogSplit(tableBucket, "partition1", 1L, 100L);
+        HybridSnapshotLogSplitState hybridSnapshotLogSplitState =
+                new HybridSnapshotLogSplitState(hybridSnapshotLogSplit);
+        assertThat(hybridSnapshotLogSplitState.toSourceSplit()).isEqualTo(hybridSnapshotLogSplit);
+
+        // set record to skip and verify
+        hybridSnapshotLogSplitState.setRecordsToSkip(200L);
+        HybridSnapshotLogSplit expectedHybridSnapshotLogSplit =
+                new HybridSnapshotLogSplit(tableBucket, "partition1", 1L, 200L, false, 100L);
+        assertThat(hybridSnapshotLogSplitState.toSourceSplit())
+                .isEqualTo(expectedHybridSnapshotLogSplit);
+
+        // set current offset and verify
+        hybridSnapshotLogSplitState.setCurrentOffset(500L);
+        expectedHybridSnapshotLogSplit =
+                new HybridSnapshotLogSplit(tableBucket, "partition1", 1L, 200L, true, 500L);
+        assertThat(hybridSnapshotLogSplitState.toSourceSplit())
+                .isEqualTo(expectedHybridSnapshotLogSplit);
+
+        // verify the split that snapshot is finished
+        hybridSnapshotLogSplit =
+                new HybridSnapshotLogSplit(tableBucket, "partition1", 1L, 100L, true, 100L);
+        hybridSnapshotLogSplitState = new HybridSnapshotLogSplitState(hybridSnapshotLogSplit);
+        assertThat(hybridSnapshotLogSplitState.toSourceSplit()).isEqualTo(hybridSnapshotLogSplit);
+
+        // set current offset and verify
+        hybridSnapshotLogSplitState = new HybridSnapshotLogSplitState(hybridSnapshotLogSplit);
+        hybridSnapshotLogSplitState.setCurrentOffset(500L);
+        expectedHybridSnapshotLogSplit =
+                new HybridSnapshotLogSplit(tableBucket, "partition1", 1L, 100L, true, 500L);
+        assertThat(hybridSnapshotLogSplitState.toSourceSplit())
+                .isEqualTo(expectedHybridSnapshotLogSplit);
+    }
+}

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/emitter/FlinkRecordEmitter.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/emitter/FlinkRecordEmitter.java
@@ -52,13 +52,13 @@ public class FlinkRecordEmitter
             HybridSnapshotLogSplitState hybridSnapshotLogSplitState =
                     (HybridSnapshotLogSplitState) splitState;
             if (cdcRecord.getOffset() >= 0) {
-                hybridSnapshotLogSplitState.setOffset(cdcRecord.getOffset() + 1);
+                hybridSnapshotLogSplitState.setCurrentOffset(cdcRecord.getOffset() + 1);
             } else {
                 hybridSnapshotLogSplitState.setRecordsToSkip(recordAndPos.readRecordsCount());
             }
             sourceOutput.collect(cdcRecord);
         } else if (splitState.isLogSplitState()) {
-            splitState.asLogSplitState().setOffset(recordAndPos.record().getOffset() + 1);
+            splitState.asLogSplitState().setCurrentOffset(recordAndPos.record().getOffset() + 1);
             sourceOutput.collect(recordAndPos.record());
         } else {
             LOG.warn("Unknown split state type: {}", splitState.getClass());

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/emitter/FlinkRecordEmitter.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/emitter/FlinkRecordEmitter.java
@@ -52,13 +52,13 @@ public class FlinkRecordEmitter
             HybridSnapshotLogSplitState hybridSnapshotLogSplitState =
                     (HybridSnapshotLogSplitState) splitState;
             if (cdcRecord.getOffset() >= 0) {
-                hybridSnapshotLogSplitState.setCurrentOffset(cdcRecord.getOffset() + 1);
+                hybridSnapshotLogSplitState.setNextOffset(cdcRecord.getOffset() + 1);
             } else {
                 hybridSnapshotLogSplitState.setRecordsToSkip(recordAndPos.readRecordsCount());
             }
             sourceOutput.collect(cdcRecord);
         } else if (splitState.isLogSplitState()) {
-            splitState.asLogSplitState().setCurrentOffset(recordAndPos.record().getOffset() + 1);
+            splitState.asLogSplitState().setNextOffset(recordAndPos.record().getOffset() + 1);
             sourceOutput.collect(recordAndPos.record());
         } else {
             LOG.warn("Unknown split state type: {}", splitState.getClass());

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/HybridSnapshotLogSplitState.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/HybridSnapshotLogSplitState.java
@@ -26,10 +26,13 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
     private boolean snapshotFinished;
 
     /** The next log offset to read. */
-    private long offset;
+    private long currentOffset;
 
     public HybridSnapshotLogSplitState(HybridSnapshotLogSplit hybridSnapshotLogSplit) {
         super(hybridSnapshotLogSplit);
+        this.recordsToSkip = hybridSnapshotLogSplit.recordsToSkip();
+        this.snapshotFinished = hybridSnapshotLogSplit.isSnapshotFinished();
+        this.currentOffset = hybridSnapshotLogSplit.getLogStartingOffset();
     }
 
     @Override
@@ -42,16 +45,16 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
                 hybridSnapshotLogSplit.getSnapshotId(),
                 recordsToSkip,
                 snapshotFinished,
-                offset);
+                currentOffset);
     }
 
     public void setRecordsToSkip(long recordsToSkip) {
         this.recordsToSkip = recordsToSkip;
     }
 
-    public void setOffset(long offset) {
+    public void setCurrentOffset(long currentOffset) {
         // if set offset, means snapshot is finished
         snapshotFinished = true;
-        this.offset = offset;
+        this.currentOffset = currentOffset;
     }
 }

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/HybridSnapshotLogSplitState.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/HybridSnapshotLogSplitState.java
@@ -26,13 +26,13 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
     private boolean snapshotFinished;
 
     /** The next log offset to read. */
-    private long currentOffset;
+    private long nextOffset;
 
     public HybridSnapshotLogSplitState(HybridSnapshotLogSplit hybridSnapshotLogSplit) {
         super(hybridSnapshotLogSplit);
         this.recordsToSkip = hybridSnapshotLogSplit.recordsToSkip();
         this.snapshotFinished = hybridSnapshotLogSplit.isSnapshotFinished();
-        this.currentOffset = hybridSnapshotLogSplit.getLogStartingOffset();
+        this.nextOffset = hybridSnapshotLogSplit.getLogStartingOffset();
     }
 
     @Override
@@ -45,16 +45,16 @@ public class HybridSnapshotLogSplitState extends SourceSplitState {
                 hybridSnapshotLogSplit.getSnapshotId(),
                 recordsToSkip,
                 snapshotFinished,
-                currentOffset);
+                nextOffset);
     }
 
     public void setRecordsToSkip(long recordsToSkip) {
         this.recordsToSkip = recordsToSkip;
     }
 
-    public void setCurrentOffset(long currentOffset) {
+    public void setNextOffset(long nextOffset) {
         // if set offset, means snapshot is finished
         snapshotFinished = true;
-        this.currentOffset = currentOffset;
+        this.nextOffset = nextOffset;
     }
 }

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/LogSplitState.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/LogSplitState.java
@@ -20,23 +20,21 @@ package com.alibaba.fluss.lakehouse.paimon.source.split;
 public class LogSplitState extends SourceSplitState {
 
     /** The next log offset to read. */
-    private long currentOffset;
+    private long nextOffset;
 
     public LogSplitState(LogSplit split) {
         super(split);
+        this.nextOffset = split.getStartingOffset();
     }
 
-    public void setCurrentOffset(long currentOffset) {
-        this.currentOffset = currentOffset;
+    public void setNextOffset(long nextOffset) {
+        this.nextOffset = nextOffset;
     }
 
     @Override
     public LogSplit toSourceSplit() {
         final LogSplit logSplit = (LogSplit) split;
         return new LogSplit(
-                logSplit.tablePath,
-                logSplit.tableBucket,
-                logSplit.getPartitionName(),
-                currentOffset);
+                logSplit.tablePath, logSplit.tableBucket, logSplit.getPartitionName(), nextOffset);
     }
 }

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/LogSplitState.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/split/LogSplitState.java
@@ -19,20 +19,24 @@ package com.alibaba.fluss.lakehouse.paimon.source.split;
 /** The state of {@link LogSplit}. */
 public class LogSplitState extends SourceSplitState {
 
-    private long offset;
+    /** The next log offset to read. */
+    private long currentOffset;
 
     public LogSplitState(LogSplit split) {
         super(split);
     }
 
-    public void setOffset(long offset) {
-        this.offset = offset;
+    public void setCurrentOffset(long currentOffset) {
+        this.currentOffset = currentOffset;
     }
 
     @Override
     public LogSplit toSourceSplit() {
         final LogSplit logSplit = (LogSplit) split;
         return new LogSplit(
-                logSplit.tablePath, logSplit.tableBucket, logSplit.getPartitionName(), offset);
+                logSplit.tablePath,
+                logSplit.tableBucket,
+                logSplit.getPartitionName(),
+                currentOffset);
     }
 }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #358

<!-- What is the purpose of the change -->
To fix the issue that split will lose offset when restore from state.

When init the SplitState from split, SplitState should use the logoffset from split to init.


### Tests

<!-- List UT and IT cases to verify this change -->
UT: SourceSplitStateTest
IT: Let's add the IT that restore from savapoint in #280 


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
