### PR TITLE
[feat] [issue-345] feat: remove 'table.' and 'client.' validation for flink connector fa…

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -24,6 +24,7 @@ import com.alibaba.fluss.connector.flink.sink.FlinkTableSink;
 import com.alibaba.fluss.connector.flink.source.FlinkTableSource;
 import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.metadata.TablePath;
+
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.CoreOptions;

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -24,7 +24,6 @@ import com.alibaba.fluss.connector.flink.sink.FlinkTableSink;
 import com.alibaba.fluss.connector.flink.source.FlinkTableSource;
 import com.alibaba.fluss.connector.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.metadata.TablePath;
-
 import org.apache.flink.api.common.RuntimeExecutionMode;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.CoreOptions;
@@ -71,7 +70,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         }
 
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-        helper.validate();
+        helper.validateExcept("table.", "client.");
 
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)
@@ -135,7 +134,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
     @Override
     public DynamicTableSink createDynamicTableSink(Context context) {
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
-        helper.validate();
+        helper.validateExcept("table.", "client.");
 
         boolean isStreamingMode =
                 context.getConfiguration().get(ExecutionOptions.RUNTIME_MODE)

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalogITCase.java
@@ -313,6 +313,46 @@ class FlinkCatalogITCase {
                 .hasMessage("Cannot discover a connector using option: 'connector'='fluss'");
     }
 
+    @Test
+    void testCreateTableWithUnknownOptions() {
+        // create fluss table with unknown options whose prefix is 'table.*' or 'client.*'
+        tEnv.executeSql(
+                "create table test_table_unknown_options (a int, b int)"
+                        + " with ('connector' = 'fluss', 'bootstrap.servers' = 'localhost:9092', 'table.unknown.option' = 'table-unknown-val', 'client.unknown.option' = 'client-unknown-val')");
+
+        // test table as source
+        String sourcePlan = tEnv.explainSql("select * from test_table_unknown_options");
+        assertThat(sourcePlan)
+                .contains(
+                        "TableSourceScan(table=[[testcatalog, fluss, test_table_unknown_options]], fields=[a, b])");
+
+        // test table as sink
+        String sinkPlan = tEnv.explainSql("insert into test_table_unknown_options values (1, 2)");
+        assertThat(sinkPlan)
+                .contains(
+                        "Sink(table=[testcatalog.fluss.test_table_unknown_options], fields=[EXPR$0, EXPR$1])");
+
+        // create fluss table with other invalid unknown option
+        tEnv.executeSql(
+                "create table test_table_other_unknown_options (a int, b int)"
+                        + " with ('connector' = 'fluss', 'bootstrap.servers' = 'localhost:9092', 'other.unknown.option' = 'other-unknown-val')");
+
+        // test invalid table as source
+        assertThatThrownBy(() -> tEnv.explainSql("select * from test_table_other_unknown_options"))
+                .cause()
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Unsupported options found for 'fluss'");
+
+        // test invalid table as sink
+        assertThatThrownBy(
+                        () ->
+                                tEnv.explainSql(
+                                        "insert into test_table_other_unknown_options values (1, 2)"))
+                .cause()
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Unsupported options found for 'fluss'");
+    }
+
     private static void assertOptionsEqual(
             Map<String, String> actualOptions, Map<String, String> expectedOptions) {
         actualOptions.remove(ConfigOptions.BOOTSTRAP_SERVERS.key());


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #345 

<!-- What is the purpose of the change -->
Remove 'table.' and 'client.' options validation in flink connector factory.

### Tests

N/A

### API and Format

N/A

### Documentation

N/A