### PR TITLE
[flink] Change the name of default value from initial to full for scan.startup.mode option

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/FlinkConnectorOptions.java
@@ -76,9 +76,11 @@ public class FlinkConnectorOptions {
     public static final ConfigOption<ScanStartupMode> SCAN_STARTUP_MODE =
             ConfigOptions.key("scan.startup.mode")
                     .enumType(ScanStartupMode.class)
-                    .defaultValue(ScanStartupMode.INITIAL)
+                    .defaultValue(ScanStartupMode.FULL)
                     .withDescription(
-                            "Optional startup mode for Fluss source. Default is 'initial'.");
+                            String.format(
+                                    "Optional startup mode for Fluss source. Default is '%s'.",
+                                    ScanStartupMode.FULL.value));
 
     public static final ConfigOption<String> SCAN_STARTUP_TIMESTAMP =
             ConfigOptions.key("scan.startup.timestamp")
@@ -122,14 +124,14 @@ public class FlinkConnectorOptions {
 
     /** Startup mode for the fluss scanner, see {@link #SCAN_STARTUP_MODE}. */
     public enum ScanStartupMode implements DescribedEnum {
-        INITIAL(
-                "initial",
+        FULL(
+                "full",
                 text(
-                        "Performs an initial snapshot n the table upon first startup, "
-                                + "ans continue to read the latest changelog with exactly once guarantee. "
-                                + "If the table to read is a log table, the initial snapshot means "
+                        "Performs a full snapshot on the table upon first startup, "
+                                + "and continue to read the latest changelog with exactly once guarantee. "
+                                + "If the table to read is a log table, the full snapshot means "
                                 + "reading from earliest log offset. If the table to read is a primary key table, "
-                                + "the initial snapshot means reading a latest snapshot which "
+                                + "the full snapshot means reading a latest snapshot which "
                                 + "materializes all changes on the table.")),
         EARLIEST("earliest", text("Start reading logs from the earliest offset.")),
         LATEST("latest", text("Start reading logs from the latest offset.")),

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -239,7 +239,7 @@ public class FlinkTableSource
             case LATEST:
                 offsetsInitializer = OffsetsInitializer.latest();
                 break;
-            case INITIAL:
+            case FULL:
                 offsetsInitializer = OffsetsInitializer.initial();
                 break;
             case TIMESTAMP:
@@ -378,11 +378,11 @@ public class FlinkTableSource
     public Result applyFilters(List<ResolvedExpression> filters) {
         // only apply pk equal filters when all the condition satisfied:
         // (1) batch execution mode,
-        // (2) default (initial) startup mode,
+        // (2) default (full) startup mode,
         // (3) the table is a pk table,
         // (4) all filters are pk field equal expression
         if (streaming
-                || startupOptions.startupMode != FlinkConnectorOptions.ScanStartupMode.INITIAL
+                || startupOptions.startupMode != FlinkConnectorOptions.ScanStartupMode.FULL
                 || !hasPrimaryKey()
                 || filters.size() != primaryKeyIndexes.length) {
             return Result.of(Collections.emptyList(), filters);

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceITCase.java
@@ -426,8 +426,8 @@ class FlinkTableSourceITCase extends FlinkTestBase {
         // for second batch, we don't wait snapshot finish.
         writeRows(tablePath, rows2, true);
 
-        // 1. read log table with scan.startup.mode='initial'
-        String options = " /*+ OPTIONS('scan.startup.mode' = 'initial') */";
+        // 1. read log table with scan.startup.mode='full'
+        String options = " /*+ OPTIONS('scan.startup.mode' = 'full') */";
         String query = "select a, b, c, d from " + tableName + options;
         List<String> expected =
                 Arrays.asList(
@@ -458,10 +458,10 @@ class FlinkTableSourceITCase extends FlinkTestBase {
     }
 
     @Test
-    void testReadKvTableWithScanStartupModeEqualsInitial() throws Exception {
+    void testReadKvTableWithScanStartupModeEqualsFull() throws Exception {
         tEnv.executeSql(
-                "create table read_initial_test (a int not null primary key not enforced, b varchar)");
-        TablePath tablePath = TablePath.of(DEFAULT_DB, "read_initial_test");
+                "create table read_full_test (a int not null primary key not enforced, b varchar)");
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "read_full_test");
 
         List<InternalRow> rows1 =
                 Arrays.asList(
@@ -480,8 +480,8 @@ class FlinkTableSourceITCase extends FlinkTestBase {
                         compactedRow(DATA1_ROW_TYPE, new Object[] {2, "v22"}),
                         compactedRow(DATA1_ROW_TYPE, new Object[] {4, "v4"}));
 
-        String options = " /*+ OPTIONS('scan.startup.mode' = 'initial') */";
-        String query = "select a, b from read_initial_test " + options;
+        String options = " /*+ OPTIONS('scan.startup.mode' = 'full') */";
+        String query = "select a, b from read_full_test " + options;
         List<String> expected =
                 Arrays.asList(
                         "+I[1, v1]",

--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -114,7 +114,7 @@ SELECT COUNT(*) FROM log_table;
 
 ### scan.startup.mode
 The scan startup mode enables you to specify the starting point for data consumption. Fluss currently supports the following `scan.startup.mode` options:
-- `initial` (default): For primary key tables, it first consumes the full data set and then consumes incremental data. For log tables, it starts consuming from the earliest offset.
+- `full` (default): For primary key tables, it first consumes the full data set and then consumes incremental data. For log tables, it starts consuming from the earliest offset.
 - `earliest`: For primary key tables, it starts consuming from the earliest changelog offset; for log tables, it starts consuming from the earliest log offset.
 - `latest`: For primary key tables, it starts consuming from the latest changelog offset; for log tables, it starts consuming from the latest log offset.
 - `timestamp`: For primary key tables, it starts consuming the changelog from a specified time (defined by the configuration item `scan.startup.timestamp`); for log tables, it starts consuming from the offset corresponding to the specified time.


### PR DESCRIPTION
### Purpose

Linked issue: close #346

The default value of `scan.startup.mode` is `initial` at present, which means `perform an initial snapshot first, and then continue read latest logs`. The `initial` name is confusing for users that it only performs the "initial snapshot". `full` is a better name that reads the full content/data from the table. For streaming mode, it produces the latest snapshot on the table (no matter Log Table or Primary Key Table) upon first startup, and continue to read the latest logs. For batch mode, it just produces the latest snapshot but does not read new logs. The `full` word reflects it reads all data in batch mode, and read all data for current and future in streaming mode. Paimon also uses [`full`](https://paimon.apache.org/docs/master/maintenance/configurations/) for the same semantics. Paimon deprecated `full` and uses `compacted-full`, `latest-full`, `from-snapshot-full` instead. However, Fluss is not a data lake format (no compaction, no snapshots), and only has latest-full. Therefore, we can use the simplified `full` as the scan mode.

### Tests

- `FlinkTableSourceITCase#testReadLogTableWithDifferentScanStartupMode`
- `FlinkTableSourceITCase#testReadKvTableWithScanStartupModeEqualsFull`

### API and Format

The name of default value for `scan.startup.mode` option changes from `initial` to `full`.

### Documentation

The name of default value for `scan.startup.mode` option changes from `initial` to `full` in `reads.md`.