### PR TITLE
[hotfix][fluss-server] Set createdTime and modifiedTime to the same value during initial registration

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -126,6 +126,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
                 false);
         DatabaseInfo databaseInfo = admin.getDatabaseInfo("test_db_2").get();
         long timestampAfterCreate = System.currentTimeMillis();
+        assertThat(databaseInfo.getCreatedTime()).isEqualTo(databaseInfo.getModifiedTime());
         assertThat(databaseInfo.getDatabaseName()).isEqualTo("test_db_2");
         assertThat(databaseInfo.getDatabaseDescriptor().getComment().get())
                 .isEqualTo("test comment");
@@ -150,6 +151,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         assertThat(tableInfo.toTableDescriptor())
                 .isEqualTo(DEFAULT_TABLE_DESCRIPTOR.withReplicationFactor(3));
         assertThat(schemaInfo2).isEqualTo(schemaInfo);
+        assertThat(tableInfo.getCreatedTime()).isEqualTo(tableInfo.getModifiedTime());
         assertThat(tableInfo.getCreatedTime()).isLessThan(timestampAfterCreate);
 
         // unknown table

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/TestData.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/TestData.java
@@ -82,14 +82,16 @@ public final class TestData {
             TableDescriptor.builder().schema(DATA1_SCHEMA).distributedBy(3).build();
     public static final PhysicalTablePath DATA1_PHYSICAL_TABLE_PATH =
             PhysicalTablePath.of(DATA1_TABLE_PATH);
+
+    private static final long currentMillis = System.currentTimeMillis();
     public static final TableInfo DATA1_TABLE_INFO =
             TableInfo.of(
                     DATA1_TABLE_PATH,
                     DATA1_TABLE_ID,
                     1,
                     DATA1_TABLE_DESCRIPTOR,
-                    System.currentTimeMillis(),
-                    System.currentTimeMillis());
+                    currentMillis,
+                    currentMillis);
 
     // for log table / partition table
     public static final TableDescriptor DATA1_PARTITIONED_TABLE_DESCRIPTOR =
@@ -104,14 +106,6 @@ public final class TestData {
                     .build();
     public static final PhysicalTablePath DATA1_PHYSICAL_TABLE_PATH_PA_2024 =
             PhysicalTablePath.of(DATA1_TABLE_PATH, "2024");
-    public static final TableInfo DATA1_PARTITIONED_TABLE_INFO =
-            TableInfo.of(
-                    DATA1_TABLE_PATH,
-                    DATA1_TABLE_ID,
-                    1,
-                    DATA1_PARTITIONED_TABLE_DESCRIPTOR,
-                    System.currentTimeMillis(),
-                    System.currentTimeMillis());
 
     // for pk table
     public static final RowType DATA1_KEY_TYPE = DataTypes.ROW(new DataField("a", DataTypes.INT()));
@@ -137,8 +131,8 @@ public final class TestData {
                     DATA1_TABLE_ID_PK,
                     1,
                     DATA1_TABLE_DESCRIPTOR_PK,
-                    System.currentTimeMillis(),
-                    System.currentTimeMillis());
+                    currentMillis,
+                    currentMillis);
 
     public static final PhysicalTablePath DATA1_PHYSICAL_TABLE_PATH_PK_PA_2024 =
             PhysicalTablePath.of(DATA1_TABLE_PATH_PK, "2024");

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConversionsTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConversionsTest.java
@@ -192,14 +192,15 @@ class FlinkConversionsTest {
 
         // test convert fluss table to flink table
         TablePath tablePath = TablePath.of("db", "table");
+        long currentMillis = System.currentTimeMillis();
         TableInfo tableInfo =
                 TableInfo.of(
                         tablePath,
                         1L,
                         1,
                         flussTable.withBucketCount(1),
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis());
+                        currentMillis,
+                        currentMillis);
         // get the converted flink table
         CatalogTable convertedFlinkTable = FlinkConversions.toFlinkTable(tableInfo);
 

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/sink/NewTableAddedPaimonListenerTest.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/sink/NewTableAddedPaimonListenerTest.java
@@ -116,29 +116,18 @@ class NewTableAddedPaimonListenerTest {
         Identifier paimonPkTableId = Identifier.create(DATABASE, pkTablePath.getTableName());
 
         // then, add the two tables
+        long currentMillis = System.currentTimeMillis();
         newTableAddedPaimonListener.onNewTablesAdded(
                 Arrays.asList(
-                        TableInfo.of(
-                                logTablePath,
-                                1L,
-                                1,
-                                logTable,
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis()),
-                        TableInfo.of(
-                                pkTablePath,
-                                2L,
-                                1,
-                                pkTable,
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis()),
+                        TableInfo.of(logTablePath, 1L, 1, logTable, currentMillis, currentMillis),
+                        TableInfo.of(pkTablePath, 2L, 1, pkTable, currentMillis, currentMillis),
                         TableInfo.of(
                                 logNoBucketKeyTablePath,
                                 3L,
                                 1,
                                 logNoBucketKeyTable,
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis())));
+                                currentMillis,
+                                currentMillis)));
 
         Table paimonPkTable = paimonCatalog.getTable(paimonPkTableId);
         // check the gotten pk table
@@ -220,8 +209,8 @@ class NewTableAddedPaimonListenerTest {
                                 4L,
                                 1,
                                 partitionedTableDescriptor,
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis())));
+                                currentMillis,
+                                currentMillis)));
 
         Identifier paimonPartitionedTableId =
                 Identifier.create(DATABASE, partitionedTablePath.getTableName());

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/DatabaseRegistration.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/DatabaseRegistration.java
@@ -54,11 +54,12 @@ public class DatabaseRegistration {
     }
 
     public static DatabaseRegistration of(DatabaseDescriptor databaseDescriptor) {
+        final long currentMillis = System.currentTimeMillis();
         return new DatabaseRegistration(
                 databaseDescriptor.getComment().orElse(null),
                 databaseDescriptor.getCustomProperties(),
-                System.currentTimeMillis(),
-                System.currentTimeMillis());
+                currentMillis,
+                currentMillis);
     }
 
     @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
@@ -95,7 +95,7 @@ public class TableRegistration {
         checkArgument(
                 tableDescriptor.getTableDistribution().isPresent(),
                 "Table distribution is required for table registration.");
-        long now = System.currentTimeMillis();
+        final long currentMillis = System.currentTimeMillis();
         return new TableRegistration(
                 tableId,
                 tableDescriptor.getComment().orElse(null),
@@ -103,8 +103,8 @@ public class TableRegistration {
                 tableDescriptor.getTableDistribution().get(),
                 tableDescriptor.getProperties(),
                 tableDescriptor.getCustomProperties(),
-                now,
-                now);
+                currentMillis,
+                currentMillis);
     }
 
     @Override

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/AutoPartitionManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/AutoPartitionManagerTest.java
@@ -325,14 +325,9 @@ class AutoPartitionManagerTest {
                         .property(ConfigOptions.TABLE_AUTO_PARTITION_NUM_RETENTION, 2)
                         .property(ConfigOptions.TABLE_AUTO_PARTITION_NUM_PRECREATE, 4)
                         .build();
+        long currentMillis = System.currentTimeMillis();
         TableInfo tableInfo =
-                TableInfo.of(
-                        tablePath,
-                        tableId,
-                        1,
-                        descriptor,
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis());
+                TableInfo.of(tablePath, tableId, 1, descriptor, currentMillis, currentMillis);
         TableRegistration registration = TableRegistration.newTable(tableId, descriptor);
         zookeeperClient.registerTable(tablePath, registration);
         return tableInfo;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
@@ -108,6 +108,7 @@ class TableChangeWatcherTest {
             long tableId =
                     metadataManager.createTable(tablePath, TEST_TABLE, tableAssignment, false);
             SchemaInfo schemaInfo = metadataManager.getLatestSchema(tablePath);
+            long currentMillis = System.currentTimeMillis();
             expectedCreateTableEvents.add(
                     new CreateTableEvent(
                             TableInfo.of(
@@ -115,8 +116,8 @@ class TableChangeWatcherTest {
                                     tableId,
                                     schemaInfo.getSchemaId(),
                                     TEST_TABLE,
-                                    System.currentTimeMillis(),
-                                    System.currentTimeMillis()),
+                                    currentMillis,
+                                    currentMillis),
                             tableAssignment));
         }
 
@@ -165,6 +166,7 @@ class TableChangeWatcherTest {
         List<CoordinatorEvent> expectedEvents = new ArrayList<>();
         SchemaInfo schemaInfo = metadataManager.getLatestSchema(tablePath);
         // create table event
+        long currentMillis = System.currentTimeMillis();
         expectedEvents.add(
                 new CreateTableEvent(
                         TableInfo.of(
@@ -172,8 +174,8 @@ class TableChangeWatcherTest {
                                 tableId,
                                 schemaInfo.getSchemaId(),
                                 partitionedTable,
-                                System.currentTimeMillis(),
-                                System.currentTimeMillis()),
+                                currentMillis,
+                                currentMillis),
                         TableAssignment.builder().build()));
 
         // register partition

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/zk/ZooKeeperClientTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/zk/ZooKeeperClientTest.java
@@ -163,6 +163,7 @@ class ZooKeeperClientTest {
         Map<String, String> options = new HashMap<>();
         options.put("option-1", "100");
         options.put("option-2", "200");
+        long currentMillis = System.currentTimeMillis();
         TableRegistration tableReg =
                 new TableRegistration(
                         11,
@@ -171,8 +172,8 @@ class ZooKeeperClientTest {
                         new TableDescriptor.TableDistribution(16, Collections.singletonList("a")),
                         options,
                         Collections.singletonMap("custom-1", "100"),
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis());
+                        currentMillis,
+                        currentMillis);
 
         zookeeperClient.registerTable(tablePath, tableReg);
         Optional<TableRegistration> optionalTable = zookeeperClient.getTable(tablePath);
@@ -180,6 +181,7 @@ class ZooKeeperClientTest {
         assertThat(optionalTable.get()).isEqualTo(tableReg);
 
         // update table.
+        currentMillis = System.currentTimeMillis();
         tableReg =
                 new TableRegistration(
                         22,
@@ -188,8 +190,8 @@ class ZooKeeperClientTest {
                         new TableDescriptor.TableDistribution(16, Collections.singletonList("a")),
                         options,
                         Collections.singletonMap("custom-2", "200"),
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis());
+                        currentMillis,
+                        currentMillis);
         zookeeperClient.updateTable(tablePath, tableReg);
         optionalTable = zookeeperClient.getTable(tablePath);
         assertThat(optionalTable.isPresent()).isTrue();
@@ -329,6 +331,7 @@ class ZooKeeperClientTest {
         // first create a table
         TablePath tablePath = TablePath.of("db", "tb");
         long tableId = 12;
+        long currentMillis = System.currentTimeMillis();
         TableRegistration tableReg =
                 new TableRegistration(
                         tableId,
@@ -337,8 +340,8 @@ class ZooKeeperClientTest {
                         new TableDescriptor.TableDistribution(16, Collections.singletonList("a")),
                         Collections.emptyMap(),
                         Collections.emptyMap(),
-                        System.currentTimeMillis(),
-                        System.currentTimeMillis());
+                        currentMillis,
+                        currentMillis);
         zookeeperClient.registerTable(tablePath, tableReg);
 
         Set<String> partitions = zookeeperClient.getPartitions(tablePath);


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Set createdTime and modifiedTime to the same value during initial registration

<!-- What is the purpose of the change -->

### Tests

Added UT in FlussAdminITCase for table registration and database registration

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

No
