### PR TITLE
[common] Speed up ConcurrentHashMap#computeIfAbsent

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -61,6 +61,7 @@ import com.alibaba.fluss.rpc.messages.PbListOffsetsRespForBucket;
 import com.alibaba.fluss.rpc.messages.TableExistsRequest;
 import com.alibaba.fluss.rpc.messages.TableExistsResponse;
 import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import javax.annotation.Nullable;
 
@@ -71,7 +72,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeListOffsetsRequest;
 import static com.alibaba.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster;
@@ -332,7 +332,8 @@ public class FlussAdmin implements Admin {
         Map<Integer, ListOffsetsRequest> requestMap =
                 prepareListOffsetsRequests(
                         metadataUpdater, tableId, partitionId, buckets, offsetSpec);
-        Map<Integer, CompletableFuture<Long>> bucketToOffsetMap = new ConcurrentHashMap<>();
+        Map<Integer, CompletableFuture<Long>> bucketToOffsetMap =
+                ConcurrentHashMapUtils.newConcurrentHashMap();
         for (int bucket : buckets) {
             bucketToOffsetMap.put(bucket, new CompletableFuture<>());
         }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/RemoteLogDownloader.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/RemoteLogDownloader.java
@@ -28,6 +28,7 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.remote.RemoteLogSegment;
 import com.alibaba.fluss.utils.CloseableRegistry;
 import com.alibaba.fluss.utils.FlussPaths;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.ShutdownableThread;
 
 import org.slf4j.Logger;
@@ -101,7 +102,7 @@ public class RemoteLogDownloader implements Closeable {
             long pollTimeout) {
         this.segmentsToFetch = new LinkedBlockingQueue<>();
         this.segmentsToRecycle = new LinkedBlockingQueue<>();
-        this.fetchedFiles = new ConcurrentHashMap<>();
+        this.fetchedFiles = ConcurrentHashMapUtils.newConcurrentHashMap();
         this.remoteFileDownloader = remoteFileDownloader;
         this.scannerMetricGroup = scannerMetricGroup;
         this.pollTimeout = pollTimeout;

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/concurrent/ConcurrentHashMapUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/concurrent/ConcurrentHashMapUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.utils.concurrent;
+
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/** Utilities that expand the usage of {@link ConcurrentHashMap}. */
+public class ConcurrentHashMapUtils {
+
+    public static <K, V> ConcurrentHashMap<K, V> newConcurrentHashMap() {
+        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
+            return new ConcurrentHashMap<>();
+        } else {
+            return new ConcurrentHashMapForJDK8<>();
+        }
+    }
+
+    /**
+     * For JDK8, there is a bug in {@code ConcurrentHashMap#computeIfAbsent}, checking the key
+     * existence to speed up. See details in JDK-8161372.
+     */
+    private static class ConcurrentHashMapForJDK8<K, V> extends ConcurrentHashMap<K, V> {
+
+        public ConcurrentHashMapForJDK8() {
+            super();
+        }
+
+        @Override
+        public V computeIfAbsent(K key, Function<? super K, ? extends V> mappingFunction) {
+            V result;
+            if (null == (result = get(key))) {
+                result = super.computeIfAbsent(key, mappingFunction);
+            }
+            return result;
+        }
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/fs/TestFileSystem.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/fs/TestFileSystem.java
@@ -21,11 +21,11 @@ import com.alibaba.fluss.fs.local.LocalDataOutputStream;
 import com.alibaba.fluss.fs.local.LocalFileStatus;
 import com.alibaba.fluss.fs.local.LocalFileSystem;
 import com.alibaba.fluss.utils.Preconditions;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -41,7 +41,7 @@ public class TestFileSystem extends LocalFileSystem {
 
     // current number of created, unclosed (output) stream
     private static final Map<FsPath, Integer> currentUnclosedOutputStream =
-            new ConcurrentHashMap<>();
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     public static int getNumtimeStreamOpened() {
         return streamOpenCounter.get();

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/metrics/ConnectionMetricGroup.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/metrics/ConnectionMetricGroup.java
@@ -25,13 +25,13 @@ import com.alibaba.fluss.metrics.groups.AbstractMetricGroup;
 import com.alibaba.fluss.metrics.groups.MetricGroup;
 import com.alibaba.fluss.metrics.registry.MetricRegistry;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.alibaba.fluss.metrics.utils.MetricGroupUtils.makeScope;
@@ -44,7 +44,8 @@ public class ConnectionMetricGroup extends AbstractMetricGroup {
     private final String serverId;
 
     /** Metrics for different request/response metrics with specify {@link ApiKeys}. */
-    private final Map<String, Metrics> metricsByRequestName = new ConcurrentHashMap<>();
+    private final Map<String, Metrics> metricsByRequestName =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     public ConnectionMetricGroup(
             MetricRegistry registry, String serverId, ClientMetricGroup parent) {

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/NettyClient.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/NettyClient.java
@@ -29,6 +29,7 @@ import com.alibaba.fluss.shaded.netty4.io.netty.bootstrap.Bootstrap;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.PooledByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelOption;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.EventLoopGroup;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.FutureUtils;
 
 import org.slf4j.Logger;
@@ -40,7 +41,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
@@ -72,7 +72,7 @@ public final class NettyClient implements RpcClient {
     private volatile boolean isClosed = false;
 
     public NettyClient(Configuration conf, ClientMetricGroup clientMetricGroup) {
-        this.connections = new ConcurrentHashMap<>();
+        this.connections = ConcurrentHashMapUtils.newConcurrentHashMap();
 
         // build bootstrap
         this.eventGroup =

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/ServerConnection.java
@@ -35,6 +35,7 @@ import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.Channel;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelFuture;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelFutureListener;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,7 +49,6 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /** Connection to a Netty server used by the {@link NettyClient}. */
@@ -59,7 +59,8 @@ final class ServerConnection {
     private final ServerNode node;
 
     // TODO: add max inflight requests limit like Kafka's "max.in.flight.requests.per.connection"
-    private final Map<Integer, InflightRequest> inflightRequests = new ConcurrentHashMap<>();
+    private final Map<Integer, InflightRequest> inflightRequests =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
     private final ConnectionMetricGroup connectionMetricGroup;
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/KvManager.java
@@ -40,6 +40,7 @@ import com.alibaba.fluss.shaded.arrow.org.apache.arrow.memory.BufferAllocator;
 import com.alibaba.fluss.shaded.arrow.org.apache.arrow.memory.RootAllocator;
 import com.alibaba.fluss.utils.FileUtils;
 import com.alibaba.fluss.utils.FlussPaths;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.types.Tuple2;
 
 import org.slf4j.Logger;
@@ -53,7 +54,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 
 import static com.alibaba.fluss.utils.concurrent.LockUtils.inLock;
 
@@ -70,7 +70,8 @@ public final class KvManager extends TabletManagerBase {
 
     private final ZooKeeperClient zkClient;
 
-    private final Map<TableBucket, KvTablet> currentKvs = new ConcurrentHashMap<>();
+    private final Map<TableBucket, KvTablet> currentKvs =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     /**
      * For arrow log format. The buffer allocator to allocate memory for arrow write batch of

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogManager.java
@@ -32,6 +32,7 @@ import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.utils.FileUtils;
 import com.alibaba.fluss.utils.FlussPaths;
 import com.alibaba.fluss.utils.clock.Clock;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.Scheduler;
 import com.alibaba.fluss.utils.types.Tuple2;
 
@@ -48,7 +49,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
@@ -77,7 +77,8 @@ public final class LogManager extends TabletManagerBase {
     private final Clock clock;
     private final ReentrantLock logCreationOrDeletionLock = new ReentrantLock();
 
-    private final Map<TableBucket, LogTablet> currentLogs = new ConcurrentHashMap<>();
+    private final Map<TableBucket, LogTablet> currentLogs =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     private volatile OffsetCheckpointFile recoveryPointCheckpoint;
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogManager.java
@@ -32,6 +32,7 @@ import com.alibaba.fluss.server.zk.data.RemoteLogManifestHandle;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.clock.Clock;
 import com.alibaba.fluss.utils.clock.SystemClock;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.ExecutorThreadFactory;
 
 import org.slf4j.Logger;
@@ -46,7 +47,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -75,8 +75,10 @@ public class RemoteLogManager implements Closeable {
     private final Clock clock;
     private final ZooKeeperClient zkClient;
 
-    private final Map<TableBucket, TaskWithFuture> rlmTasks = new ConcurrentHashMap<>();
-    private final Map<TableBucket, RemoteLogTablet> remoteLogs = new ConcurrentHashMap<>();
+    private final Map<TableBucket, TaskWithFuture> rlmTasks =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
+    private final Map<TableBucket, RemoteLogTablet> remoteLogs =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     public RemoteLogManager(
             Configuration conf, ZooKeeperClient zkClient, CoordinatorGateway coordinatorGateway)

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/TabletServerMetricGroup.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metrics/group/TabletServerMetricGroup.java
@@ -24,9 +24,9 @@ import com.alibaba.fluss.metrics.MetricNames;
 import com.alibaba.fluss.metrics.ThreadSafeSimpleCounter;
 import com.alibaba.fluss.metrics.groups.AbstractMetricGroup;
 import com.alibaba.fluss.metrics.registry.MetricRegistry;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 /** The metric group for tablet server. */
 public class TabletServerMetricGroup extends AbstractMetricGroup {
@@ -34,7 +34,7 @@ public class TabletServerMetricGroup extends AbstractMetricGroup {
     private static final String NAME = "tabletserver";
 
     private final Map<PhysicalTablePath, PhysicalTableMetricGroup> metricGroupByPhysicalTable =
-            new ConcurrentHashMap<>();
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     protected final String clusterId;
     protected final String hostname;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/AdjustIsrManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/AdjustIsrManager.java
@@ -26,6 +26,7 @@ import com.alibaba.fluss.rpc.protocol.Errors;
 import com.alibaba.fluss.server.entity.AdjustIsrResultForBucket;
 import com.alibaba.fluss.server.utils.RpcMessageUtils;
 import com.alibaba.fluss.server.zk.data.LeaderAndIsr;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.Scheduler;
 
 import org.slf4j.Logger;
@@ -36,7 +37,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
@@ -59,7 +59,8 @@ public class AdjustIsrManager {
     private final int serverId;
 
     /** Used to allow only one pending adjust Isr request per bucket (visible for testing). */
-    protected final Map<TableBucket, AdjustIsrItem> unsentAdjustIsrMap = new ConcurrentHashMap<>();
+    protected final Map<TableBucket, AdjustIsrItem> unsentAdjustIsrMap =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     /** Used to allow only one in-flight request at a time. */
     private final AtomicBoolean inflightRequest = new AtomicBoolean(false);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -90,6 +90,7 @@ import com.alibaba.fluss.utils.CloseableRegistry;
 import com.alibaba.fluss.utils.FlussPaths;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.clock.Clock;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.types.Tuple2;
 
 import org.slf4j.Logger;
@@ -114,7 +115,6 @@ import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -181,7 +181,8 @@ public final class Replica {
      *
      * <p>followerId -> {@link FollowerReplica}.
      */
-    private final Map<Integer, FollowerReplica> followerReplicasMap = new ConcurrentHashMap<>();
+    private final Map<Integer, FollowerReplica> followerReplicasMap =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     private volatile IsrState isrState = new IsrState.CommittedIsrState(Collections.emptyList());
     private volatile int leaderEpoch = LeaderAndIsr.INITIAL_LEADER_EPOCH - 1;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -99,6 +99,7 @@ import com.alibaba.fluss.utils.FileUtils;
 import com.alibaba.fluss.utils.FlussPaths;
 import com.alibaba.fluss.utils.Preconditions;
 import com.alibaba.fluss.utils.clock.Clock;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.Scheduler;
 
 import org.slf4j.Logger;
@@ -118,7 +119,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -145,7 +145,8 @@ public class ReplicaManager {
     private final OffsetCheckpointFile highWatermarkCheckpoint;
 
     @GuardedBy("replicaStateChangeLock")
-    private final Map<TableBucket, HostedReplica> allReplicas = new ConcurrentHashMap<>();
+    private final Map<TableBucket, HostedReplica> allReplicas =
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     private final ServerMetadataCache metadataCache;
     private final Lock replicaStateChangeLock = new ReentrantLock();

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/delay/DelayedOperationManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/delay/DelayedOperationManager.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.server.utils.timer.DefaultTimer;
 import com.alibaba.fluss.server.utils.timer.Timer;
 import com.alibaba.fluss.server.utils.timer.TimerTask;
 import com.alibaba.fluss.utils.Preconditions;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 import com.alibaba.fluss.utils.concurrent.ShutdownableThread;
 
 import org.slf4j.Logger;
@@ -33,7 +34,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
@@ -235,7 +235,7 @@ public final class DelayedOperationManager<T extends DelayedOperation> {
         private final Lock watcherLock;
 
         public WatcherList() {
-            this.watchersByKey = new ConcurrentHashMap<>();
+            this.watchersByKey = ConcurrentHashMapUtils.newConcurrentHashMap();
             this.watcherLock = new ReentrantLock();
         }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/TestingCompletedKvSnapshotCommitter.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/TestingCompletedKvSnapshotCommitter.java
@@ -17,12 +17,12 @@
 package com.alibaba.fluss.server.kv.snapshot;
 
 import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.utils.concurrent.ConcurrentHashMapUtils;
 
 import java.time.Duration;
 import java.util.Deque;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
@@ -34,7 +34,7 @@ import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
 public class TestingCompletedKvSnapshotCommitter implements CompletedKvSnapshotCommitter {
 
     protected final Map<TableBucket, Deque<CompletedSnapshot>> snapshots =
-            new ConcurrentHashMap<>();
+            ConcurrentHashMapUtils.newConcurrentHashMap();
 
     @Override
     public void commitKvSnapshot(


### PR DESCRIPTION
### Purpose

Linked issue: close #375

Fluss supports JDK8, which could meet the bug mentioned in [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372). Therefore, we could check the key existence before invoking `computeIfAbsent`.

Introduce `ConcurrentHashMapForJDK8` to check the key existence for speed up, which solves the bug [JDK-8161372](https://bugs.openjdk.org/browse/JDK-8161372) to speed up `ConcurrentHashMap#computeIfAbsent`.

Backport https://github.com/apache/incubator-uniffle/issues/519.

### Tests

The JMH testing result is as follows:

```
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Level;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.Setup;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Threads;
import org.openjdk.jmh.annotations.Warmup;

import java.util.Map;
import java.util.concurrent.ConcurrentHashMap;

@Fork(3)
@Warmup(iterations = 3, time = 5)
@Measurement(iterations = 3, time = 5)
@Threads(16)
@State(Scope.Benchmark)
public class ConcurrentHashMapBenchmark {
    
    private static final String KEY = "key";
    
    private static final Object VALUE = new Object();
    
    private final Map<String, Object> concurrentMap = new ConcurrentHashMap<>(1, 1);
    
    @Setup(Level.Iteration)
    public void setup() {
        concurrentMap.clear();
    }
    
    @Benchmark
    public Object benchGetBeforeComputeIfAbsent() {
        Object result = concurrentMap.get(KEY);
        if (null == result) {
            result = concurrentMap.computeIfAbsent(KEY, __ -> VALUE);
        }
        return result;
    }
    
    @Benchmark
    public Object benchComputeIfAbsent() {
        return concurrentMap.computeIfAbsent(KEY, __ -> VALUE);
    }
}
```
- JDK-8: The performance of the two methods is many orders of magnitude higher. The performance of directly calling computeIfAbsent is one million per second. The performance of calling get first to check is one billion per second, and this is equivalent to a 16-thread test. In terms of resources, the CPU utilization during the benchComputeIfAbsent test has been maintained at around 20%; while the CPU utilization during the benchGetBeforeComputeIfAbsent test has been maintained at around 100%.
```
# JMH version: 1.33
# VM version: JDK 1.8.0_311, Java HotSpot(TM) 64-Bit Server VM, 25.311-b11
# VM invoker: /usr/local/java/jdk1.8.0_311/jre/bin/java
# VM options: -Dvisualvm.id=172855224679674
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration
# Threads: 16 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark:ConcurrentHashMapBenchmark.benchComputeIfAbsent

# Run progress: 0.00% complete, ETA 00:03:00
# Fork: 1 of 3
# Warmup Iteration   1: 11173878.242 ops/s
# Warmup Iteration   2: 8471364.065 ops/s
# Warmup Iteration   3: 8766401.960 ops/s
Iteration   1: 8776260.796 ops/s
Iteration   2: 8632907.974 ops/s
Iteration   3: 8557264.788 ops/s

# Run progress: 16.67% complete, ETA 00:02:33
# Fork: 2 of 3
# Warmup Iteration   1: 7757506.431 ops/s
# Warmup Iteration   2: 8176991.807 ops/s
# Warmup Iteration   3: 8795107.589 ops/s
Iteration   1: 8668883.337 ops/s
Iteration   2: 8866318.073 ops/s
Iteration   3: 8848517.540 ops/s

# Run progress: 33.33% complete, ETA 00:02:02
# Fork: 3 of 3
# Warmup Iteration   1: 8154698.571 ops/s
# Warmup Iteration   2: 8317945.491 ops/s
# Warmup Iteration   3: 8884286.732 ops/s
Iteration   1: 8912555.062 ops/s
Iteration   2: 8894750.001 ops/s
Iteration   3: 8780504.227 ops/s


Result "ConcurrentHashMapBenchmark.benchComputeIfAbsent":
  8770884.644 ±(99.9%) 210678.797 ops/s [Average]
  (min, avg, max) = (8557264.788, 8770884.644, 8912555.062), stdev = 125371.573
  CI (99.9%): [8560205.847, 8981563.442] (assumes normal distribution)


# JMH version: 1.33
# VM version: JDK 1.8.0_311, Java HotSpot(TM) 64-Bit Server VM, 25.311-b11
# VM invoker: /usr/local/java/jdk1.8.0_311/jre/bin/java
# VM options: -Dvisualvm.id=172855224679674
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration
# Threads: 16 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent

# Run progress: 50.00% complete, ETA 00:01:31
# Fork: 1 of 3
# Warmup Iteration   1: 1881091972.510 ops/s
# Warmup Iteration   2: 1843432746.197 ops/s
# Warmup Iteration   3: 2353506882.860 ops/s
Iteration   1: 2389458285.091 ops/s
Iteration   2: 2391001171.657 ops/s
Iteration   3: 2387181602.010 ops/s

# Run progress: 66.67% complete, ETA 00:01:01
# Fork: 2 of 3
# Warmup Iteration   1: 1872514017.315 ops/s
# Warmup Iteration   2: 1855584197.510 ops/s
# Warmup Iteration   3: 2342392977.207 ops/s
Iteration   1: 2378551289.692 ops/s
Iteration   2: 2374081014.168 ops/s
Iteration   3: 2389909613.865 ops/s

# Run progress: 83.33% complete, ETA 00:00:30
# Fork: 3 of 3
# Warmup Iteration   1: 1880210774.729 ops/s
# Warmup Iteration   2: 1804266170.900 ops/s
# Warmup Iteration   3: 2337740394.373 ops/s
Iteration   1: 2363741084.192 ops/s
Iteration   2: 2372565304.724 ops/s
Iteration   3: 2388015878.515 ops/s


Result "ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent":
  2381611693.768 ±(99.9%) 16356182.057 ops/s [Average]
  (min, avg, max) = (2363741084.192, 2381611693.768, 2391001171.657), stdev = 9733301.586
  CI (99.9%): [2365255511.711, 2397967875.825] (assumes normal distribution)


# Run complete. Total time: 00:03:03

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                                  Mode  Cnt           Score          Error  Units
ConcurrentHashMapBenchmark.benchComputeIfAbsent           thrpt    9     8770884.644 ±   210678.797  ops/s
ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent  thrpt    9  2381611693.768 ± 16356182.057  ops/s
```
- JDK-17: The performance of computeIfAbsent is slightly lower than get first, but the performance is at least the same order of magnitude. Moreover, the CPU is fully loaded during the running of both use cases.
```
# JMH version: 1.33
# VM version: JDK 17.0.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.1+12-LTS-39
# VM invoker: /usr/local/java/jdk-17.0.1/bin/java
# VM options: -Dvisualvm.id=173221627574053
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration
# Threads: 16 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: ConcurrentHashMapBenchmark.benchComputeIfAbsent

# Run progress: 0.00% complete, ETA 00:03:00
# Fork: 1 of 3
# Warmup Iteration   1: 1544327446.565 ops/s
# Warmup Iteration   2: 1475077923.449 ops/s
# Warmup Iteration   3: 1565544222.606 ops/s
Iteration   1: 1564346089.698 ops/s
Iteration   2: 1560062375.891 ops/s
Iteration   3: 1552569020.412 ops/s

# Run progress: 16.67% complete, ETA 00:02:33
# Fork: 2 of 3
# Warmup Iteration   1: 1617143507.004 ops/s
# Warmup Iteration   2: 1433136907.916 ops/s
# Warmup Iteration   3: 1527623176.866 ops/s
Iteration   1: 1522331660.180 ops/s
Iteration   2: 1524798683.186 ops/s
Iteration   3: 1522686827.744 ops/s

# Run progress: 33.33% complete, ETA 00:02:02
# Fork: 3 of 3
# Warmup Iteration   1: 1671732222.173 ops/s
# Warmup Iteration   2: 1462966231.429 ops/s
# Warmup Iteration   3: 1553792663.545 ops/s
Iteration   1: 1549840468.944 ops/s
Iteration   2: 1549245571.349 ops/s
Iteration   3: 1554801575.735 ops/s


Result "ConcurrentHashMapBenchmark.benchComputeIfAbsent":
  1544520252.571 ±(99.9%) 27953594.118 ops/s [Average]
  (min, avg, max) = (1522331660.180, 1544520252.571, 1564346089.698), stdev = 16634735.479
  CI (99.9%): [1516566658.453, 1572473846.689] (assumes normal distribution)


# JMH version: 1.33
# VM version: JDK 17.0.1, Java HotSpot(TM) 64-Bit Server VM, 17.0.1+12-LTS-39
# VM invoker: /usr/local/java/jdk-17.0.1/bin/java
# VM options: -Dvisualvm.id=173221627574053
# Blackhole mode: full + dont-inline hint (default, use -Djmh.blackhole.autoDetect=true to auto-detect)
# Warmup: 3 iterations, 5 s each
# Measurement: 3 iterations, 5 s each
# Timeout: 10 min per iteration的
# Threads: 16 threads, will synchronize iterations
# Benchmark mode: Throughput, ops/time
# Benchmark: ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent

# Run progress: 50.00% complete, ETA 00:01:31
# Fork: 1 of 3
# Warmup Iteration   1: 1813078468.960 ops/s
# Warmup Iteration   2: 1944438216.902 ops/s
# Warmup Iteration   3: 2232703681.960 ops/s
Iteration   1: 2233727123.664 ops/s
Iteration   2: 2233657163.983 ops/s
Iteration   3: 2229008772.953 ops/s

# Run progress: 66.67% complete, ETA 00:01:01
# Fork: 2 of 3
# Warmup Iteration   1: 1767187585.805 ops/s
# Warmup Iteration   2: 1900420998.518 ops/s
# Warmup Iteration   3: 2175122268.840 ops/s
Iteration   1: 2180409680.029 ops/s
Iteration   2: 2181398523.091 ops/s
Iteration   3: 2176454597.329 ops/s

# Run progress: 83.33% complete, ETA 00:00:30
# Fork: 3 of 3
# Warmup Iteration   1: 1822355551.990 ops/s
# Warmup Iteration   2: 1832618832.110 ops/s
# Warmup Iteration   3: 2225265888.631 ops/s
Iteration   1: 2240765668.888 ops/s
Iteration   2: 2225847700.599 ops/s
Iteration   3: 2232257415.965 ops/s


Result "ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent":
  2214836294.056 ±(99.9%) 45190341.578 ops/s [Average]
  (min, avg, max) = (2176454597.329, 2214836294.056, 2240765668.888), stdev = 26892047.412
  CI (99.9%): [2169645952.478, 2260026635.633] (assumes normal distribution)


# Run complete. Total time: 00:03:03

REMEMBER: The numbers below are just data. To gain reusable insights, you need to follow up on
why the numbers are the way they are. Use profilers (see -prof, -lprof), design factorial
experiments, perform baseline and negative tests that provide experimental control, make sure
the benchmarking environment is safe on JVM/OS/HW level, ask for reviews from the domain experts.
Do not assume the numbers tell you what you want them to tell.

Benchmark                                                  Mode  Cnt           Score          Error  Units
ConcurrentHashMapBenchmark.benchComputeIfAbsent           thrpt    9  1544520252.571 ± 27953594.118  ops/s
ConcurrentHashMapBenchmark.benchGetBeforeComputeIfAbsent  thrpt    9  2214836294.056 ± 45190341.578  ops/s
```

### API and Format

No.

### Documentation

No.