### PR TITLE
[fluss-client] Deprecate deleteTable/deleteDatabase with dropTable/dropDatabase

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -134,13 +134,37 @@ public interface Admin extends AutoCloseable {
      *       false.
      * </ul>
      *
+     * @param databaseName The name of the database to drop.
+     * @param ignoreIfNotExists Flag to specify behavior when a database with the given name does
+     *     not exist: if set to false, throw a DatabaseNotExistException, if set to true, do
+     *     nothing.
+     * @param cascade Flag to specify whether to drop all tables in the database.
+     * @deprecated use {@link #dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean
+     *     cascade)} instead.
+     */
+    @Deprecated
+    CompletableFuture<Void> deleteDatabase(
+            String databaseName, boolean ignoreIfNotExists, boolean cascade);
+
+    /**
+     * Drop the database with the given name asynchronously.
+     *
+     * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
+     *
+     * <ul>
+     *   <li>{@link DatabaseNotExistException} if the database does not exist and {@code
+     *       ignoreIfNotExists} is false.
+     *   <li>{@link DatabaseNotEmptyException} if the database is not empty and {@code cascade} is
+     *       false.
+     * </ul>
+     *
      * @param databaseName The name of the database to delete.
      * @param ignoreIfNotExists Flag to specify behavior when a database with the given name does
      *     not exist: if set to false, throw a DatabaseNotExistException, if set to true, do
      *     nothing.
      * @param cascade Flag to specify whether to delete all tables in the database.
      */
-    CompletableFuture<Void> deleteDatabase(
+    CompletableFuture<Void> dropDatabase(
             String databaseName, boolean ignoreIfNotExists, boolean cascade);
 
     /**
@@ -191,7 +215,25 @@ public interface Admin extends AutoCloseable {
     CompletableFuture<TableInfo> getTableInfo(TablePath tablePath);
 
     /**
-     * Delete the table with the given table path asynchronously.
+     * Drop the table with the given table path asynchronously.
+     *
+     * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
+     *
+     * <ul>
+     *   <li>{@link TableNotExistException} if the table does not exist and {@code
+     *       ignoreIfNotExists} is false.
+     * </ul>
+     *
+     * @param tablePath The table path of the table.
+     * @param ignoreIfNotExists Flag to specify behavior when a table with the given name does not
+     *     exist: if set to false, throw a TableNotExistException, if set to true, do nothing.
+     * @deprecated use {@link #dropTable(TablePath tablePath, boolean ignoreIfNotExists)} instead.
+     */
+    @Deprecated
+    CompletableFuture<Void> deleteTable(TablePath tablePath, boolean ignoreIfNotExists);
+
+    /**
+     * Drop the table with the given table path asynchronously.
      *
      * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
      *
@@ -204,7 +246,7 @@ public interface Admin extends AutoCloseable {
      * @param ignoreIfNotExists Flag to specify behavior when a table with the given name does not
      *     exist: if set to false, throw a TableNotExistException, if set to true, do nothing.
      */
-    CompletableFuture<Void> deleteTable(TablePath tablePath, boolean ignoreIfNotExists);
+    CompletableFuture<Void> dropTable(TablePath tablePath, boolean ignoreIfNotExists);
 
     /**
      * Get whether table exists asynchronously.

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -123,30 +123,6 @@ public interface Admin extends AutoCloseable {
     CompletableFuture<DatabaseInfo> getDatabaseInfo(String databaseName);
 
     /**
-     * Delete the database with the given name asynchronously.
-     *
-     * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
-     *
-     * <ul>
-     *   <li>{@link DatabaseNotExistException} if the database does not exist and {@code
-     *       ignoreIfNotExists} is false.
-     *   <li>{@link DatabaseNotEmptyException} if the database is not empty and {@code cascade} is
-     *       false.
-     * </ul>
-     *
-     * @param databaseName The name of the database to drop.
-     * @param ignoreIfNotExists Flag to specify behavior when a database with the given name does
-     *     not exist: if set to false, throw a DatabaseNotExistException, if set to true, do
-     *     nothing.
-     * @param cascade Flag to specify whether to drop all tables in the database.
-     * @deprecated use {@link #dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean
-     *     cascade)} instead.
-     */
-    @Deprecated
-    CompletableFuture<Void> deleteDatabase(
-            String databaseName, boolean ignoreIfNotExists, boolean cascade);
-
-    /**
      * Drop the database with the given name asynchronously.
      *
      * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
@@ -213,24 +189,6 @@ public interface Admin extends AutoCloseable {
      * @param tablePath The table path of the table.
      */
     CompletableFuture<TableInfo> getTableInfo(TablePath tablePath);
-
-    /**
-     * Drop the table with the given table path asynchronously.
-     *
-     * <p>The following exceptions can be anticipated when calling {@code get()} on returned future.
-     *
-     * <ul>
-     *   <li>{@link TableNotExistException} if the table does not exist and {@code
-     *       ignoreIfNotExists} is false.
-     * </ul>
-     *
-     * @param tablePath The table path of the table.
-     * @param ignoreIfNotExists Flag to specify behavior when a table with the given name does not
-     *     exist: if set to false, throw a TableNotExistException, if set to true, do nothing.
-     * @deprecated use {@link #dropTable(TablePath tablePath, boolean ignoreIfNotExists)} instead.
-     */
-    @Deprecated
-    CompletableFuture<Void> deleteTable(TablePath tablePath, boolean ignoreIfNotExists);
 
     /**
      * Drop the table with the given table path asynchronously.

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -187,6 +187,17 @@ public class FlussAdmin implements Admin {
     }
 
     @Override
+    public CompletableFuture<Void> dropDatabase(
+            String databaseName, boolean ignoreIfNotExists, boolean cascade) {
+        DropDatabaseRequest request = new DropDatabaseRequest();
+
+        request.setIgnoreIfNotExists(ignoreIfNotExists)
+                .setCascade(cascade)
+                .setDatabaseName(databaseName);
+        return gateway.dropDatabase(request).thenApply(r -> null);
+    }
+
+    @Override
     public CompletableFuture<Boolean> databaseExists(String databaseName) {
         DatabaseExistsRequest request = new DatabaseExistsRequest();
         request.setDatabaseName(databaseName);
@@ -233,6 +244,16 @@ public class FlussAdmin implements Admin {
 
     @Override
     public CompletableFuture<Void> deleteTable(TablePath tablePath, boolean ignoreIfNotExists) {
+        DropTableRequest request = new DropTableRequest();
+        request.setIgnoreIfNotExists(ignoreIfNotExists)
+                .setTablePath()
+                .setDatabaseName(tablePath.getDatabaseName())
+                .setTableName(tablePath.getTableName());
+        return gateway.dropTable(request).thenApply(r -> null);
+    }
+
+    @Override
+    public CompletableFuture<Void> dropTable(TablePath tablePath, boolean ignoreIfNotExists) {
         DropTableRequest request = new DropTableRequest();
         request.setIgnoreIfNotExists(ignoreIfNotExists)
                 .setTablePath()

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -176,17 +176,6 @@ public class FlussAdmin implements Admin {
     }
 
     @Override
-    public CompletableFuture<Void> deleteDatabase(
-            String databaseName, boolean ignoreIfNotExists, boolean cascade) {
-        DropDatabaseRequest request = new DropDatabaseRequest();
-
-        request.setIgnoreIfNotExists(ignoreIfNotExists)
-                .setCascade(cascade)
-                .setDatabaseName(databaseName);
-        return gateway.dropDatabase(request).thenApply(r -> null);
-    }
-
-    @Override
     public CompletableFuture<Void> dropDatabase(
             String databaseName, boolean ignoreIfNotExists, boolean cascade) {
         DropDatabaseRequest request = new DropDatabaseRequest();
@@ -240,16 +229,6 @@ public class FlussAdmin implements Admin {
                                         TableDescriptor.fromJsonBytes(r.getTableJson()),
                                         r.getCreatedTime(),
                                         r.getModifiedTime()));
-    }
-
-    @Override
-    public CompletableFuture<Void> deleteTable(TablePath tablePath, boolean ignoreIfNotExists) {
-        DropTableRequest request = new DropTableRequest();
-        request.setIgnoreIfNotExists(ignoreIfNotExists)
-                .setTablePath()
-                .setDatabaseName(tablePath.getDatabaseName())
-                .setTableName(tablePath.getTableName());
-        return gateway.dropTable(request).thenApply(r -> null);
     }
 
     @Override

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/admin/FlussAdminITCase.java
@@ -404,21 +404,21 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
     @Test
     void testDropDatabaseAndTable() throws Exception {
         // drop not existed database with ignoreIfNotExists false.
-        assertThatThrownBy(() -> admin.deleteDatabase("unknown_db", false, true).get())
+        assertThatThrownBy(() -> admin.dropDatabase("unknown_db", false, true).get())
                 .cause()
                 .isInstanceOf(DatabaseNotExistException.class);
 
         // drop not existed database with ignoreIfNotExists true.
-        admin.deleteDatabase("unknown_db", true, true).get();
+        admin.dropDatabase("unknown_db", true, true).get();
 
         // drop existed database with table exist in db.
-        assertThatThrownBy(() -> admin.deleteDatabase("test_db", false, false).get())
+        assertThatThrownBy(() -> admin.dropDatabase("test_db", false, false).get())
                 .cause()
                 .isInstanceOf(DatabaseNotEmptyException.class);
 
         // drop existed database with table exist in db.
         assertThat(admin.databaseExists("test_db").get()).isTrue();
-        admin.deleteDatabase("test_db", true, true).get();
+        admin.dropDatabase("test_db", true, true).get();
         assertThat(admin.databaseExists("test_db").get()).isFalse();
 
         // re-create.
@@ -427,17 +427,17 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         // drop not existed table with ignoreIfNotExists false.
         assertThatThrownBy(
                         () ->
-                                admin.deleteTable(TablePath.of("test_db", "unknown_table"), false)
+                                admin.dropTable(TablePath.of("test_db", "unknown_table"), false)
                                         .get())
                 .cause()
                 .isInstanceOf(TableNotExistException.class);
 
         // drop not existed table with ignoreIfNotExists true.
-        admin.deleteTable(TablePath.of("test_db", "unknown_table"), true).get();
+        admin.dropTable(TablePath.of("test_db", "unknown_table"), true).get();
 
         // drop existed table.
         assertThat(admin.tableExists(DEFAULT_TABLE_PATH).get()).isTrue();
-        admin.deleteTable(DEFAULT_TABLE_PATH, true).get();
+        admin.dropTable(DEFAULT_TABLE_PATH, true).get();
         assertThat(admin.tableExists(DEFAULT_TABLE_PATH).get()).isFalse();
     }
 

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
@@ -193,7 +193,7 @@ public class FlinkCatalog implements Catalog {
     public void dropDatabase(String databaseName, boolean ignoreIfNotExists, boolean cascade)
             throws DatabaseNotExistException, DatabaseNotEmptyException, CatalogException {
         try {
-            admin.deleteDatabase(databaseName, ignoreIfNotExists, cascade).get();
+            admin.dropDatabase(databaseName, ignoreIfNotExists, cascade).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (CatalogExceptionUtils.isDatabaseNotExist(t)) {
@@ -316,7 +316,7 @@ public class FlinkCatalog implements Catalog {
             throws TableNotExistException, CatalogException {
         TablePath tablePath = toTablePath(objectPath);
         try {
-            admin.deleteTable(tablePath, ignoreIfNotExists).get();
+            admin.dropTable(tablePath, ignoreIfNotExists).get();
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (CatalogExceptionUtils.isTableNotExist(t)) {


### PR DESCRIPTION

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
Deprecate deleteTable/deleteDatabase with dropTable/dropDatabase
<!-- Linking this pull request to the issue -->
Linked issue: close #381

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->
Covered via FlussAdminITCase

### API and Format

<!-- Does this change affect API or storage format -->
Yes, minor affects in client API, but Fluss doesn't has a client API documentation so far, we can introduce a API documentation later

### Documentation

<!-- Does this change introduce a new feature -->
