### PR TITLE
[rocksdb] Bump frocksdbjni from 6.20.3-ververica-2.0 to 8.10.0-ververica-1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <paimon.version>0.8.2</paimon.version>
 
         <fluss.hadoop.version>2.10.2</fluss.hadoop.version>
-        <frocksdb.version>6.20.3-ververica-2.0</frocksdb.version>
+        <frocksdb.version>8.10.0-ververica-1.0</frocksdb.version>
         <slf4j.version>1.7.36</slf4j.version>
         <log4j.version>2.17.1</log4j.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>


### PR DESCRIPTION
### Purpose

Linked issue: close #387

Bump frocksdbjni from 6.20.3-ververica-2.0 to 8.10.0-ververica-1.0.

### Tests

CI.

### API and Format

No.

### Documentation

No.