### PR TITLE
[hotfix] Revert build a Flink CatalogTable use CatalogTable#newBuilder() to backward compatible with lower Flink version

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlinkConversions.java
@@ -131,12 +131,11 @@ public class FlinkConversions {
         // deserialize watermark
         CatalogPropertiesUtils.deserializeWatermark(newOptions, schemaBuilder);
 
-        return CatalogTable.newBuilder()
-                .schema(schemaBuilder.build())
-                .comment(tableInfo.getComment().orElse(null))
-                .partitionKeys(tableInfo.getPartitionKeys())
-                .options(CatalogPropertiesUtils.deserializeOptions(newOptions))
-                .build();
+        return CatalogTable.of(
+                schemaBuilder.build(),
+                tableInfo.getComment().orElse(null),
+                tableInfo.getPartitionKeys(),
+                CatalogPropertiesUtils.deserializeOptions(newOptions));
     }
 
     /** Convert Flink's table to Fluss's table. */


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

In pr https://github.com/alibaba/fluss/pull/360, we change the way of building Flink `CatalogTable`, using `CatalogTable#newBuilder()` instead of `CatalogTable#of()` in `FlinkConversions#toFlinkTable()`. However, in lower version of Flink, like 'flink-1.17', `CatalogTable#newBuilder()` has not been introduced yet, so in order to maintain better compatibility with lower Flink versions, this PR will revert this change.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
