### PR TITLE
[common] Change Classname DefaultLogRecord to IndexedLogRecord

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/WriteRecord.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/WriteRecord.java
@@ -20,8 +20,8 @@ import com.alibaba.fluss.annotation.Internal;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.record.DefaultKvRecord;
 import com.alibaba.fluss.record.DefaultKvRecordBatch;
-import com.alibaba.fluss.record.DefaultLogRecord;
 import com.alibaba.fluss.record.DefaultLogRecordBatch;
+import com.alibaba.fluss.record.IndexedLogRecord;
 import com.alibaba.fluss.row.BinaryRow;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.row.indexed.IndexedRow;
@@ -84,7 +84,7 @@ public final class WriteRecord {
             PhysicalTablePath tablePath, IndexedRow row, @Nullable byte[] bucketKey) {
         checkNotNull(row);
         int estimatedSizeInBytes =
-                DefaultLogRecord.sizeOf(row) + DefaultLogRecordBatch.RECORD_BATCH_HEADER_SIZE;
+                IndexedLogRecord.sizeOf(row) + DefaultLogRecordBatch.RECORD_BATCH_HEADER_SIZE;
         return new WriteRecord(
                 tablePath,
                 null,

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/IndexedLogWriteBatchTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/IndexedLogWriteBatchTest.java
@@ -19,8 +19,8 @@ package com.alibaba.fluss.client.write;
 import com.alibaba.fluss.memory.MemorySegment;
 import com.alibaba.fluss.memory.PreAllocatedPagedOutputView;
 import com.alibaba.fluss.metadata.TableBucket;
-import com.alibaba.fluss.record.DefaultLogRecord;
 import com.alibaba.fluss.record.DefaultLogRecordBatch;
+import com.alibaba.fluss.record.IndexedLogRecord;
 import com.alibaba.fluss.record.LogRecord;
 import com.alibaba.fluss.record.LogRecordBatch;
 import com.alibaba.fluss.record.LogRecordReadContext;
@@ -52,7 +52,7 @@ public class IndexedLogWriteBatchTest {
     @BeforeEach
     void setup() {
         row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
-        estimatedSizeInBytes = DefaultLogRecord.sizeOf(row);
+        estimatedSizeInBytes = IndexedLogRecord.sizeOf(row);
     }
 
     @Test

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
@@ -31,7 +31,7 @@ import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.record.DefaultKvRecord;
-import com.alibaba.fluss.record.DefaultLogRecord;
+import com.alibaba.fluss.record.IndexedLogRecord;
 import com.alibaba.fluss.record.LogRecord;
 import com.alibaba.fluss.record.LogRecordBatch;
 import com.alibaba.fluss.record.LogRecordReadContext;
@@ -391,7 +391,7 @@ public class RecordAccumulatorTest {
     void testPartialDrain() throws Exception {
         IndexedRow row = indexedRow(DATA1_ROW_TYPE, new Object[] {1, "a"});
         RecordAccumulator accum = createTestRecordAccumulator(1024, 10L * 1024);
-        int appends = 1024 / DefaultLogRecord.sizeOf(row) + 1;
+        int appends = 1024 / IndexedLogRecord.sizeOf(row) + 1;
         List<TableBucket> buckets = Arrays.asList(tb1, tb2);
         for (TableBucket tb : buckets) {
             for (int i = 0; i < appends; i++) {
@@ -597,7 +597,7 @@ public class RecordAccumulatorTest {
         int size = RECORD_BATCH_HEADER_SIZE;
         int offsetDelta = 0;
         while (true) {
-            int recordSize = DefaultLogRecord.sizeOf(row);
+            int recordSize = IndexedLogRecord.sizeOf(row);
             if (size + recordSize > batchSize) {
                 return offsetDelta;
             }

--- a/fluss-common/src/main/java/com/alibaba/fluss/record/DefaultKvRecord.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/DefaultKvRecord.java
@@ -36,7 +36,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 /**
- * This class is an immutable kv record. Different from {@link DefaultLogRecord}, it isn't designed
+ * This class is an immutable kv record. Different from {@link IndexedLogRecord}, it isn't designed
  * for persistence. The schema is as follows:
  *
  * <ul>

--- a/fluss-common/src/main/java/com/alibaba/fluss/record/DefaultLogRecordBatch.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/DefaultLogRecordBatch.java
@@ -280,8 +280,8 @@ public class DefaultLogRecordBatch implements LogRecordBatch {
 
             @Override
             protected LogRecord readNext(long baseOffset) {
-                DefaultLogRecord logRecord =
-                        DefaultLogRecord.readFrom(
+                IndexedLogRecord logRecord =
+                        IndexedLogRecord.readFrom(
                                 segment, position, baseOffset + rowId, timestamp, fieldTypes);
                 rowId++;
                 position += logRecord.getSizeInBytes();

--- a/fluss-common/src/main/java/com/alibaba/fluss/record/IndexedLogRecord.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/IndexedLogRecord.java
@@ -54,8 +54,7 @@ import static com.alibaba.fluss.record.DefaultLogRecordBatch.LENGTH_LENGTH;
  * @since 0.1
  */
 @PublicEvolving
-// TODO: should rename to IndexedLogRecord as it only indexed row?
-public class DefaultLogRecord implements LogRecord {
+public class IndexedLogRecord implements LogRecord {
 
     private static final int ATTRIBUTES_LENGTH = 1;
 
@@ -67,7 +66,7 @@ public class DefaultLogRecord implements LogRecord {
     private int offset;
     private int sizeInBytes;
 
-    DefaultLogRecord(long logOffset, long timestamp, DataType[] fieldTypes) {
+    IndexedLogRecord(long logOffset, long timestamp, DataType[] fieldTypes) {
         this.logOffset = logOffset;
         this.fieldTypes = fieldTypes;
         this.timestamp = timestamp;
@@ -93,7 +92,7 @@ public class DefaultLogRecord implements LogRecord {
             return false;
         }
 
-        DefaultLogRecord that = (DefaultLogRecord) o;
+        IndexedLogRecord that = (IndexedLogRecord) o;
         return sizeInBytes == that.sizeInBytes
                 && segment.equalTo(that.segment, offset, that.offset, sizeInBytes);
     }
@@ -149,14 +148,14 @@ public class DefaultLogRecord implements LogRecord {
         return sizeInBytes + LENGTH_LENGTH;
     }
 
-    public static DefaultLogRecord readFrom(
+    public static IndexedLogRecord readFrom(
             MemorySegment segment,
             int position,
             long logOffset,
             long logTimestamp,
             DataType[] colTypes) {
         int sizeInBytes = segment.getInt(position);
-        DefaultLogRecord logRecord = new DefaultLogRecord(logOffset, logTimestamp, colTypes);
+        IndexedLogRecord logRecord = new IndexedLogRecord(logOffset, logTimestamp, colTypes);
         logRecord.pointTo(segment, position, sizeInBytes + LENGTH_LENGTH);
         return logRecord;
     }

--- a/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsIndexedBuilder.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsIndexedBuilder.java
@@ -109,7 +109,7 @@ public class MemoryLogRecordsIndexedBuilder implements AutoCloseable {
      * appended, then this returns true.
      */
     public boolean hasRoomFor(IndexedRow row) {
-        return sizeInBytes + DefaultLogRecord.sizeOf(row) <= writeLimit;
+        return sizeInBytes + IndexedLogRecord.sizeOf(row) <= writeLimit;
     }
 
     public void append(RowKind rowKind, IndexedRow row) throws Exception {
@@ -122,7 +122,7 @@ public class MemoryLogRecordsIndexedBuilder implements AutoCloseable {
                     "Tried to append a record, but MemoryLogRecordsBuilder is closed for record appends");
         }
 
-        int recordByteSizes = DefaultLogRecord.writeTo(pagedOutputView, rowKind, row);
+        int recordByteSizes = IndexedLogRecord.writeTo(pagedOutputView, rowKind, row);
         currentRecordNumber++;
         sizeInBytes += recordByteSizes;
     }

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/IndexedLogRecordTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/IndexedLogRecordTest.java
@@ -29,8 +29,8 @@ import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/** Test for {@link DefaultLogRecord}. */
-class DefaultLogRecordTest extends LogTestBase {
+/** Test for {@link IndexedLogRecord}. */
+class IndexedLogRecordTest extends LogTestBase {
 
     @Test
     void testBase() throws IOException {
@@ -43,10 +43,10 @@ class DefaultLogRecordTest extends LogTestBase {
         writer.writeString(BinaryString.fromString("abc"));
         row.pointTo(writer.segment(), 0, writer.position());
 
-        DefaultLogRecord.writeTo(outputView, RowKind.APPEND_ONLY, row);
+        IndexedLogRecord.writeTo(outputView, RowKind.APPEND_ONLY, row);
         // Test read from.
-        DefaultLogRecord defaultLogRecord =
-                DefaultLogRecord.readFrom(
+        IndexedLogRecord defaultLogRecord =
+                IndexedLogRecord.readFrom(
                         MemorySegment.wrap(outputView.getCopyOfBuffer()),
                         0,
                         1000,
@@ -64,13 +64,13 @@ class DefaultLogRecordTest extends LogTestBase {
     void testWriteToAndReadFromWithRandomData() throws IOException {
         // Test write to.
         IndexedRow row = TestInternalRowGenerator.genIndexedRowForAllType();
-        DefaultLogRecord.writeTo(outputView, RowKind.APPEND_ONLY, row);
+        IndexedLogRecord.writeTo(outputView, RowKind.APPEND_ONLY, row);
         DataType[] allColTypes =
                 TestInternalRowGenerator.createAllRowType().getChildren().toArray(new DataType[0]);
 
         // Test read from.
         LogRecord defaultLogRecord =
-                DefaultLogRecord.readFrom(
+                IndexedLogRecord.readFrom(
                         MemorySegment.wrap(outputView.getCopyOfBuffer()),
                         0,
                         1000,

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/LogTestBase.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/LogTestBase.java
@@ -83,8 +83,8 @@ public abstract class LogTestBase {
                 CloseableIterator<LogRecord> expectIter = expected.records(readContext)) {
             int i = 0;
             while (actualIter.hasNext() && expectIter.hasNext()) {
-                DefaultLogRecord actualRecord = (DefaultLogRecord) actualIter.next();
-                DefaultLogRecord expectedRecord = (DefaultLogRecord) expectIter.next();
+                IndexedLogRecord actualRecord = (IndexedLogRecord) actualIter.next();
+                IndexedLogRecord expectedRecord = (IndexedLogRecord) expectIter.next();
                 assertIndexedRecordEquals(actualRecord, expectedRecord, rows.get(i), i);
                 i++;
             }


### PR DESCRIPTION

### Purpose

Linked issue: close #389

* Rename DefaultLogRecord class to IndexedLogRecord as it only indexed row and updated its dependencies.
* Also renamed DefaultLogRecordTest to IndexedLogRecordTest as it was only having unit test with respect to the same.

### Tests

### API and Format

### Documentation
