### PR TITLE
[hotfix] Don't initialize LakeTableBucketAssigner to avoid load unnecessary dependencies if dataLake disabled for target table

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/PrefixKeyLookuper.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/lookup/PrefixKeyLookuper.java
@@ -54,8 +54,6 @@ class PrefixKeyLookuper implements Lookuper {
     /** Extract bucket key from prefix lookup key row. */
     private final KeyEncoder bucketKeyEncoder;
 
-    private final boolean isDataLakeEnable;
-
     private final int numBuckets;
 
     private final LakeTableBucketAssigner lakeTableBucketAssigner;
@@ -84,9 +82,15 @@ class PrefixKeyLookuper implements Lookuper {
         RowType lookupRowType = tableInfo.getRowType().project(lookupColumnNames);
         this.bucketKeyEncoder =
                 KeyEncoder.createKeyEncoder(lookupRowType, tableInfo.getBucketKeys());
-        this.isDataLakeEnable = tableInfo.getTableConfig().isDataLakeEnabled();
-        this.lakeTableBucketAssigner =
-                new LakeTableBucketAssigner(lookupRowType, tableInfo.getBucketKeys(), numBuckets);
+
+        if (tableInfo.getTableConfig().isDataLakeEnabled()) {
+            this.lakeTableBucketAssigner =
+                    new LakeTableBucketAssigner(
+                            lookupRowType, tableInfo.getBucketKeys(), numBuckets);
+        } else {
+            this.lakeTableBucketAssigner = null;
+        }
+
         this.partitionGetter =
                 tableInfo.isPartitioned()
                         ? new PartitionGetter(lookupRowType, tableInfo.getPartitionKeys())
@@ -154,7 +158,6 @@ class PrefixKeyLookuper implements Lookuper {
                         bucketKeyBytes,
                         prefixKey,
                         lakeTableBucketAssigner,
-                        isDataLakeEnable,
                         numBuckets,
                         metadataUpdater);
 

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/ClientUtils.java
@@ -30,6 +30,8 @@ import com.alibaba.fluss.row.InternalRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
@@ -136,11 +138,10 @@ public final class ClientUtils {
     public static int getBucketId(
             byte[] keyBytes,
             InternalRow key,
-            LakeTableBucketAssigner lakeTableBucketAssigner,
-            boolean isDataLakeEnable,
+            @Nullable LakeTableBucketAssigner lakeTableBucketAssigner,
             int numBuckets,
             MetadataUpdater metadataUpdater) {
-        if (!isDataLakeEnable) {
+        if (lakeTableBucketAssigner == null) {
             return HashBucketAssigner.bucketForRowKey(keyBytes, numBuckets);
         } else {
             return lakeTableBucketAssigner.assignBucket(


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

Currently, In `PrimaryKeyLookuper` and `PrefixKeyLookuper`, we will always initialize the `LakeTableBucketAssigner`, even if the table doesn't enable dataLake. Since the current implementation of `LakeTableBucketAssigner` will always load the Paimon dependency, this can lead to situations where the dependency is not found after the actual packaging. 

Therefore, in this PR, we have modified it to only initialize the `LakeTableBucketAssigner` when dataLake is enabled.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
