### PR TITLE
[common] Declare serialVersionUID explicitly for serializable class

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/config/Password.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/Password.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 
 /** A wrapper class for passwords to hide them while logging a config. */
 public class Password implements Serializable {
+    private static final long serialVersionUID = 1L;
     // the hidden content to be displayed
     public static final String HIDDEN_CONTENT = "******";
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/Schema.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/Schema.java
@@ -330,6 +330,7 @@ public final class Schema implements Serializable {
      */
     @PublicStable
     public static final class Column implements Serializable {
+        private static final long serialVersionUID = 1L;
         private final String columnName;
         private final DataType dataType;
         private final @Nullable String comment;


### PR DESCRIPTION
### Purpose

Linked issue: close #409

Declare `serialVersionUID` explicitly for serializable class `Password` and `Column`.

### Tests

No.

### API and Format

No.

### Documentation

No.