### PR TITLE
[server] Fix the IndexOutOfBoundsException when reading cdc log from pk table with projection

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/record/FileLogProjection.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/FileLogProjection.java
@@ -177,6 +177,14 @@ public class FileLogProjection {
                 return new BytesViewLogRecords(builder.build());
             }
 
+            // Skip empty batch. The empty batch was generated when build cdc log batch when there
+            // is no cdc log generated for this kv batch. See the comments about the field
+            // 'lastOffsetDelta' in DefaultLogRecordBatch.
+            if (batchSizeInBytes == RECORD_BATCH_HEADER_SIZE) {
+                position += batchSizeInBytes;
+                continue;
+            }
+
             int rowKindBytes = logHeaderBuffer.getInt(RECORDS_COUNT_OFFSET);
             long arrowHeaderOffset = position + RECORD_BATCH_HEADER_SIZE + rowKindBytes;
             // read arrow header

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/TestData.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/TestData.java
@@ -213,8 +213,5 @@ public final class TestData {
                     .withComment("b is second column")
                     .primaryKey("a")
                     .build();
-    public static final TablePath DATA3_TABLE_PATH_PK =
-            TablePath.of("test_db_3", "test_pk_table_3");
     // ---------------------------- data3 table info end ------------------------------
-
 }

--- a/fluss-common/src/test/java/com/alibaba/fluss/testutils/LogRecordBatchAssert.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/testutils/LogRecordBatchAssert.java
@@ -33,6 +33,7 @@ public class LogRecordBatchAssert extends AbstractAssert<LogRecordBatchAssert, L
 
     private RowType rowType;
     private LogFormat logFormat;
+    private boolean assertCheckSum = true;
 
     /** Creates assertions for {@link LogRecordBatch}. */
     public static LogRecordBatchAssert assertThatLogRecordBatch(LogRecordBatch actual) {
@@ -45,6 +46,11 @@ public class LogRecordBatchAssert extends AbstractAssert<LogRecordBatchAssert, L
 
     public LogRecordBatchAssert withSchema(RowType rowType) {
         this.rowType = rowType;
+        return this;
+    }
+
+    public LogRecordBatchAssert assertCheckSum(boolean assertCheckSum) {
+        this.assertCheckSum = assertCheckSum;
         return this;
     }
 
@@ -95,9 +101,12 @@ public class LogRecordBatchAssert extends AbstractAssert<LogRecordBatchAssert, L
         assertThat(actual.sizeInBytes())
                 .as("LogRecordBatch#sizeInBytes()")
                 .isEqualTo(expected.sizeInBytes());
-        assertThat(actual.checksum())
-                .as("LogRecordBatch#checksum()")
-                .isEqualTo(expected.checksum());
+
+        if (assertCheckSum) {
+            assertThat(actual.checksum())
+                    .as("LogRecordBatch#checksum()")
+                    .isEqualTo(expected.checksum());
+        }
         return this;
     }
 

--- a/fluss-common/src/test/java/com/alibaba/fluss/testutils/LogRecordsAssert.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/testutils/LogRecordsAssert.java
@@ -36,6 +36,7 @@ public class LogRecordsAssert extends AbstractAssert<LogRecordsAssert, LogRecord
     }
 
     private RowType rowType;
+    private boolean assertCheckSum = true;
 
     private LogRecordsAssert(LogRecords actual) {
         super(actual, LogRecordsAssert.class);
@@ -43,6 +44,11 @@ public class LogRecordsAssert extends AbstractAssert<LogRecordsAssert, LogRecord
 
     public LogRecordsAssert withSchema(RowType rowType) {
         this.rowType = rowType;
+        return this;
+    }
+
+    public LogRecordsAssert assertCheckSum(boolean assertCheckSum) {
+        this.assertCheckSum = assertCheckSum;
         return this;
     }
 
@@ -59,7 +65,10 @@ public class LogRecordsAssert extends AbstractAssert<LogRecordsAssert, LogRecord
         Iterator<LogRecordBatch> actualIter = actual.batches().iterator();
         for (LogRecordBatch expectedNext : expected.batches()) {
             assertThat(actualIter.hasNext()).isTrue();
-            assertThatLogRecordBatch(actualIter.next()).withSchema(rowType).isEqualTo(expectedNext);
+            assertThatLogRecordBatch(actualIter.next())
+                    .withSchema(rowType)
+                    .assertCheckSum(assertCheckSum)
+                    .isEqualTo(expectedNext);
         }
         assertThat(actualIter.hasNext()).isFalse();
         assertThat(actual.sizeInBytes())

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/KvTabletTest.java
@@ -28,6 +28,7 @@ import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.record.FileLogProjection;
 import com.alibaba.fluss.record.KvRecord;
 import com.alibaba.fluss.record.KvRecordBatch;
 import com.alibaba.fluss.record.KvRecordTestUtils;
@@ -57,6 +58,10 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nullable;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -78,6 +83,7 @@ import static com.alibaba.fluss.record.TestData.DATA3_SCHEMA_PK;
 import static com.alibaba.fluss.record.TestData.DEFAULT_SCHEMA_ID;
 import static com.alibaba.fluss.testutils.DataTestUtils.compactedRow;
 import static com.alibaba.fluss.testutils.DataTestUtils.createBasicMemoryLogRecords;
+import static com.alibaba.fluss.testutils.LogRecordsAssert.assertThatLogRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Fail.fail;
@@ -114,10 +120,17 @@ class KvTabletTest {
 
     private void initLogTabletAndKvTablet(Schema schema, Map<String, String> tableConfig)
             throws Exception {
-        PhysicalTablePath tablePath = PhysicalTablePath.of(TablePath.of("testDb", "t1"));
-        logTablet = createLogTablet(tempLogDir, 0L, tablePath);
+        initLogTabletAndKvTablet(TablePath.of("testDb", "t1"), schema, tableConfig);
+    }
+
+    private void initLogTabletAndKvTablet(
+            TablePath tablePath, Schema schema, Map<String, String> tableConfig) throws Exception {
+        PhysicalTablePath physicalTablePath = PhysicalTablePath.of(tablePath);
+        logTablet = createLogTablet(tempLogDir, 0L, physicalTablePath);
         TableBucket tableBucket = logTablet.getTableBucket();
-        kvTablet = createKvTablet(tablePath, tableBucket, logTablet, tmpKvDir, schema, tableConfig);
+        kvTablet =
+                createKvTablet(
+                        physicalTablePath, tableBucket, logTablet, tmpKvDir, schema, tableConfig);
     }
 
     private LogTablet createLogTablet(File tempLogDir, long tableId, PhysicalTablePath tablePath)
@@ -579,11 +592,24 @@ class KvTabletTest {
         assertThat(kvTablet.getKvPreWriteBuffer().getMaxLSN()).isEqualTo(3);
     }
 
-    @Test
-    void testFirstRowMergeEngine() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testFirstRowMergeEngine(boolean doProjection) throws Exception {
         Map<String, String> config = new HashMap<>();
         config.put("table.merge-engine", "first_row");
-        initLogTabletAndKvTablet(DATA1_SCHEMA_PK, config);
+        String tableName =
+                "test_first_row_merge_engine_" + (doProjection ? "projection" : "no_projection");
+        TablePath tablePath = TablePath.of("testDb", tableName);
+        initLogTabletAndKvTablet(tablePath, DATA1_SCHEMA_PK, config);
+        RowType rowType = DATA1_SCHEMA_PK.getRowType();
+        FileLogProjection logProjection = null;
+        if (doProjection) {
+            logProjection = new FileLogProjection();
+            logProjection.setCurrentProjection(
+                    0L, rowType, ArrowCompressionInfo.NO_COMPRESSION, new int[] {0});
+        }
+
+        RowType readLogRowType = doProjection ? rowType.project(new int[] {0}) : rowType;
 
         List<KvRecord> kvData1 =
                 Arrays.asList(
@@ -593,44 +619,83 @@ class KvTabletTest {
         KvRecordBatch kvRecordBatch1 = kvRecordBatchFactory.ofRecords(kvData1);
         kvTablet.putAsLeader(kvRecordBatch1, null);
         long endOffset = logTablet.localLogEndOffset();
-        LogRecords actualLogRecords = readLogRecords(logTablet);
-        List<MemoryLogRecords> expectedLogs =
-                Collections.singletonList(
-                        logRecords(
-                                DATA1_SCHEMA_PK.getRowType(),
-                                0,
-                                Arrays.asList(RowKind.INSERT, RowKind.INSERT),
-                                Arrays.asList(new Object[] {1, "v11"}, new Object[] {2, "v21"})));
-        checkEqual(actualLogRecords, expectedLogs);
+        LogRecords actualLogRecords = readLogRecords(logTablet, 0L, logProjection);
+        LogRecords expectedLogs =
+                logRecords(
+                        readLogRowType,
+                        0,
+                        Arrays.asList(RowKind.INSERT, RowKind.INSERT),
+                        doProjection
+                                ? Arrays.asList(new Object[] {1}, new Object[] {2})
+                                : Arrays.asList(new Object[] {1, "v11"}, new Object[] {2, "v21"}));
+        assertThatLogRecords(actualLogRecords)
+                .withSchema(readLogRowType)
+                .assertCheckSum(!doProjection)
+                .isEqualTo(expectedLogs);
 
-        List<KvRecord> kvData2 =
+        // append some new batches which will not generate only cdc logs, but the endOffset will be
+        // updated.
+        int emptyBatchCount = 10;
+        long offsetBefore = endOffset;
+        for (int i = 0; i < emptyBatchCount; i++) {
+            List<KvRecord> kvData2 =
+                    Arrays.asList(
+                            kvRecordFactory.ofRecord("k1".getBytes(), new Object[] {1, "v111"}),
+                            kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v222"}),
+                            kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v233"}));
+            KvRecordBatch kvRecordBatch2 = kvRecordBatchFactory.ofRecords(kvData2);
+            kvTablet.putAsLeader(kvRecordBatch2, null);
+            endOffset = logTablet.localLogEndOffset();
+            assertThat(endOffset).isEqualTo(offsetBefore + i + 1);
+            actualLogRecords = readLogRecords(logTablet, endOffset);
+            assertThat(actualLogRecords.batches().iterator().hasNext()).isFalse();
+        }
+
+        List<KvRecord> kvData3 =
                 Arrays.asList(
                         kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, "v22"}),
                         kvRecordFactory.ofRecord("k1".getBytes(), new Object[] {1, "v21"}),
                         kvRecordFactory.ofRecord("k1".getBytes(), null),
                         kvRecordFactory.ofRecord("k3".getBytes(), new Object[] {3, "v31"}));
-        KvRecordBatch kvRecordBatch2 = kvRecordBatchFactory.ofRecords(kvData2);
-        kvTablet.putAsLeader(kvRecordBatch2, null);
+        KvRecordBatch kvRecordBatch3 = kvRecordBatchFactory.ofRecords(kvData3);
+        kvTablet.putAsLeader(kvRecordBatch3, null);
 
         expectedLogs =
-                Collections.singletonList(
-                        logRecords(
-                                DATA1_SCHEMA_PK.getRowType(),
-                                endOffset,
-                                Collections.singletonList(RowKind.INSERT),
-                                Collections.singletonList(new Object[] {3, "v31"})));
-        actualLogRecords = readLogRecords(logTablet, endOffset);
-        checkEqual(actualLogRecords, expectedLogs);
+                logRecords(
+                        readLogRowType,
+                        endOffset,
+                        Collections.singletonList(RowKind.INSERT),
+                        Collections.singletonList(
+                                doProjection ? new Object[] {3} : new Object[] {3, "v31"}));
+        actualLogRecords = readLogRecords(logTablet, endOffset, logProjection);
+        assertThatLogRecords(actualLogRecords)
+                .withSchema(readLogRowType)
+                .assertCheckSum(!doProjection)
+                .isEqualTo(expectedLogs);
     }
 
-    @Test
-    void testVersionRowMergeEngine() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testVersionRowMergeEngine(boolean doProjection) throws Exception {
         Map<String, String> config = new HashMap<>();
         config.put("table.merge-engine", "versioned");
         config.put("table.merge-engine.versioned.ver-column", "b");
-        initLogTabletAndKvTablet(DATA3_SCHEMA_PK, config);
+        String tableName =
+                "test_versioned_row_merge_engine_"
+                        + (doProjection ? "projection" : "no_projection");
+        TablePath tablePath = TablePath.of("testDb", tableName);
+        initLogTabletAndKvTablet(tablePath, DATA3_SCHEMA_PK, config);
+        RowType rowType = DATA3_SCHEMA_PK.getRowType();
         KvRecordTestUtils.KvRecordFactory kvRecordFactory =
-                KvRecordTestUtils.KvRecordFactory.of(DATA3_SCHEMA_PK.getRowType());
+                KvRecordTestUtils.KvRecordFactory.of(rowType);
+
+        FileLogProjection logProjection = null;
+        if (doProjection) {
+            logProjection = new FileLogProjection();
+            logProjection.setCurrentProjection(
+                    0L, rowType, ArrowCompressionInfo.NO_COMPRESSION, new int[] {0});
+        }
+        RowType readLogRowType = doProjection ? rowType.project(new int[] {0}) : rowType;
 
         List<KvRecord> kvData1 =
                 Arrays.asList(
@@ -641,25 +706,50 @@ class KvTabletTest {
         kvTablet.putAsLeader(kvRecordBatch1, null);
 
         long endOffset = logTablet.localLogEndOffset();
-        LogRecords actualLogRecords = readLogRecords(logTablet);
-        List<MemoryLogRecords> expectedLogs =
-                Collections.singletonList(
-                        logRecords(
-                                DATA3_SCHEMA_PK.getRowType(),
-                                0,
-                                Arrays.asList(
-                                        RowKind.INSERT,
-                                        RowKind.INSERT,
-                                        RowKind.UPDATE_BEFORE,
-                                        RowKind.UPDATE_AFTER),
-                                Arrays.asList(
+        LogRecords actualLogRecords = readLogRecords(logTablet, 0L, logProjection);
+        LogRecords expectedLogs =
+                logRecords(
+                        readLogRowType,
+                        0,
+                        Arrays.asList(
+                                RowKind.INSERT,
+                                RowKind.INSERT,
+                                RowKind.UPDATE_BEFORE,
+                                RowKind.UPDATE_AFTER),
+                        doProjection
+                                ? Arrays.asList(
+                                        new Object[] {1},
+                                        new Object[] {2},
+                                        new Object[] {2},
+                                        new Object[] {2})
+                                : Arrays.asList(
                                         new Object[] {1, 1000L},
                                         new Object[] {2, 1000L},
                                         new Object[] {2, 1000L},
-                                        new Object[] {2, 1001L})));
-        checkEqual(actualLogRecords, expectedLogs, DATA3_SCHEMA_PK.getRowType());
+                                        new Object[] {2, 1001L}));
+        assertThatLogRecords(actualLogRecords)
+                .withSchema(readLogRowType)
+                .assertCheckSum(!doProjection)
+                .isEqualTo(expectedLogs);
 
-        List<KvRecord> kvData2 =
+        // append some new batches which will not generate only cdc logs, but the endOffset will be
+        // updated.
+        int emptyBatchCount = 10;
+        long offsetBefore = endOffset;
+        for (int i = 0; i < emptyBatchCount; i++) {
+            List<KvRecord> kvData2 =
+                    Arrays.asList(
+                            kvRecordFactory.ofRecord("k1".getBytes(), new Object[] {1, 999L}),
+                            kvRecordFactory.ofRecord("k2".getBytes(), new Object[] {2, 998L}));
+            KvRecordBatch kvRecordBatch2 = kvRecordBatchFactory.ofRecords(kvData2);
+            kvTablet.putAsLeader(kvRecordBatch2, null);
+            endOffset = logTablet.localLogEndOffset();
+            assertThat(endOffset).isEqualTo(offsetBefore + i + 1);
+            actualLogRecords = readLogRecords(logTablet, endOffset);
+            assertThat(actualLogRecords.batches().iterator().hasNext()).isFalse();
+        }
+
+        List<KvRecord> kvData3 =
                 Arrays.asList(
                         kvRecordFactory.ofRecord(
                                 "k2".getBytes(), new Object[] {2, 1000L}), // not update
@@ -667,24 +757,26 @@ class KvTabletTest {
                                 "k1".getBytes(), new Object[] {1, 1001L}), // -U , +U
                         kvRecordFactory.ofRecord("k1".getBytes(), null), // not update
                         kvRecordFactory.ofRecord("k3".getBytes(), new Object[] {3, 1000L})); // +I
-        KvRecordBatch kvRecordBatch2 = kvRecordBatchFactory.ofRecords(kvData2);
-        kvTablet.putAsLeader(kvRecordBatch2, null);
+        KvRecordBatch kvRecordBatch3 = kvRecordBatchFactory.ofRecords(kvData3);
+        kvTablet.putAsLeader(kvRecordBatch3, null);
 
         expectedLogs =
-                Collections.singletonList(
-                        logRecords(
-                                DATA3_SCHEMA_PK.getRowType(),
-                                endOffset,
-                                Arrays.asList(
-                                        RowKind.UPDATE_BEFORE,
-                                        RowKind.UPDATE_AFTER,
-                                        RowKind.INSERT),
-                                Arrays.asList(
+                logRecords(
+                        readLogRowType,
+                        endOffset,
+                        Arrays.asList(RowKind.UPDATE_BEFORE, RowKind.UPDATE_AFTER, RowKind.INSERT),
+                        doProjection
+                                ? Arrays.asList(
+                                        new Object[] {1}, new Object[] {1}, new Object[] {3})
+                                : Arrays.asList(
                                         new Object[] {1, 1000L},
                                         new Object[] {1, 1001L},
-                                        new Object[] {3, 1000L})));
-        actualLogRecords = readLogRecords(logTablet, endOffset);
-        checkEqual(actualLogRecords, expectedLogs, DATA3_SCHEMA_PK.getRowType());
+                                        new Object[] {3, 1000L}));
+        actualLogRecords = readLogRecords(logTablet, endOffset, logProjection);
+        assertThatLogRecords(actualLogRecords)
+                .withSchema(readLogRowType)
+                .assertCheckSum(!doProjection)
+                .isEqualTo(expectedLogs);
     }
 
     @Test
@@ -725,13 +817,15 @@ class KvTabletTest {
         return readLogRecords(logTablet, startOffset);
     }
 
-    private LogRecords readLogRecords(LogTablet logTablet) throws Exception {
-        return readLogRecords(logTablet, 0L);
+    private LogRecords readLogRecords(LogTablet logTablet, long startOffset) throws Exception {
+        return readLogRecords(logTablet, startOffset, null);
     }
 
-    private LogRecords readLogRecords(LogTablet logTablet, long startOffset) throws Exception {
+    private LogRecords readLogRecords(
+            LogTablet logTablet, long startOffset, @Nullable FileLogProjection projection)
+            throws Exception {
         return logTablet
-                .read(startOffset, Integer.MAX_VALUE, FetchIsolation.LOG_END, false, null)
+                .read(startOffset, Integer.MAX_VALUE, FetchIsolation.LOG_END, false, projection)
                 .getRecords();
     }
 


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/416

This pr is aims to fix the IndexOutOfBoundsException when reading cdc log from pk table with projection. This case will happen when we create a primary key table with `FIRST_ROW` or  `VERSION_BASED` merge engine enable. As `FIRST_ROW` for example, we will generate cdc log batch which contains no records, however, if we try to read this cdc log batch with projection, we will incorrectly read the arrow header in `FileLogProjection` even if it was empty, this pr is trying to fix it.

<!-- What is the purpose of the change -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
