### PR TITLE
[hotfix] ZstdCompressionCodec should use decompressedSize to get error name

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
@@ -77,7 +77,7 @@ public class ZstdArrowCompressionCodec extends AbstractCompressionCodec {
         if (Zstd.isError(decompressedSize)) {
             uncompressedBuffer.close();
             throw new RuntimeException(
-                    "Error decompressing: " + Zstd.getErrorName(decompressedLength));
+                    "Error decompressing: " + Zstd.getErrorName(decompressedSize));
         }
         if (decompressedLength != decompressedSize) {
             uncompressedBuffer.close();


### PR DESCRIPTION

This has been fixed in https://github.com/apache/arrow-java/pull/619

<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

The error message is wrong when for zstd compression codec, I've fixed this in upstream project (https://github.com/apache/arrow-java/pull/619)

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
