### PR TITLE
[kv] when table(partition) is deleted, drop corresponding snapshots

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableInfo.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableInfo.java
@@ -149,6 +149,11 @@ public final class TableInfo {
         return !primaryKeys.isEmpty();
     }
 
+    /** Check if the table is a primary key table or a log table. */
+    public boolean isPrimaryKeyTable() {
+        return hasPrimaryKey();
+    }
+
     /**
      * Returns the logical primary keys of the table. The logical primary keys are the defined
      * PRIMARY KEY clause when creating table.

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableInfo.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/TableInfo.java
@@ -149,11 +149,6 @@ public final class TableInfo {
         return !primaryKeys.isEmpty();
     }
 
-    /** Check if the table is a primary key table or a log table. */
-    public boolean isPrimaryKeyTable() {
-        return hasPrimaryKey();
-    }
-
     /**
      * Returns the logical primary keys of the table. The logical primary keys are the defined
      * PRIMARY KEY clause when creating table.

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -31,10 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
@@ -94,6 +91,12 @@ public class CompletedSnapshotStoreManager {
                                 e);
                     }
                 });
+    }
+
+    public void onRemoveCompletedSnapshotStoreByTableBuckets(Set<TableBucket> tableBuckets) {
+        for (TableBucket tableBucket : tableBuckets) {
+            bucketCompletedSnapshotStores.remove(tableBucket);
+        }
     }
 
     private CompletedSnapshotStore createCompletedSnapshotStore(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -137,4 +137,8 @@ public class CompletedSnapshotStoreManager {
                 completedSnapshotHandleStore,
                 ioExecutor);
     }
+
+    public Map<TableBucket, CompletedSnapshotStore> getBucketCompletedSnapshotStores() {
+        return bucketCompletedSnapshotStores;
+    }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -94,6 +94,8 @@ public class CompletedSnapshotStoreManager {
     }
 
     public void onRemoveCompletedSnapshotStoreByTableBuckets(Set<TableBucket> tableBuckets) {
+        // Remove CompletedSnapshotStore is all we need to do, as remote KV files have already
+        // been cleaned up  when drop tables or partitions
         for (TableBucket tableBucket : tableBuckets) {
             bucketCompletedSnapshotStores.remove(tableBucket);
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -97,9 +97,7 @@ public class CompletedSnapshotStoreManager {
                 });
     }
 
-    public void onRemoveCompletedSnapshotStoreByTableBuckets(Set<TableBucket> tableBuckets) {
-        // Remove CompletedSnapshotStore is all we need to do, as remote KV files have already
-        // been cleaned up  when drop tables or partitions
+    public void removeCompletedSnapshotStoreByTableBuckets(Set<TableBucket> tableBuckets) {
         for (TableBucket tableBucket : tableBuckets) {
             bucketCompletedSnapshotStores.remove(tableBucket);
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManager.java
@@ -31,7 +31,11 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.concurrent.NotThreadSafe;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorContext.java
@@ -219,6 +219,10 @@ public class CoordinatorContext {
         this.partitionNameById.put(partitionId, partitionName);
     }
 
+    public TableInfo getTableInfoById(long tableId) {
+        return this.tableInfoById.get(tableId);
+    }
+
     public TablePath getTablePathById(long tableId) {
         return this.tablePathById.get(tableId);
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -499,6 +499,12 @@ public class CoordinatorEventProcessor implements EventProcessor {
     }
 
     private void processDropTable(DropTableEvent dropTableEvent) {
+        // When drop a table, drop its snapshot store meanwhile.
+        Set<TableBucket> deleteTableBuckets =
+                coordinatorContext.getAllBucketsForTable(dropTableEvent.getTableId());
+        completedSnapshotStoreManager.onRemoveCompletedSnapshotStoreByTableBuckets(
+                deleteTableBuckets);
+
         coordinatorContext.queueTableDeletion(Collections.singleton(dropTableEvent.getTableId()));
         tableManager.onDeleteTable(dropTableEvent.getTableId());
         if (dropTableEvent.isAutoPartitionTable()) {
@@ -510,6 +516,14 @@ public class CoordinatorEventProcessor implements EventProcessor {
         TablePartition tablePartition =
                 new TablePartition(
                         dropPartitionEvent.getTableId(), dropPartitionEvent.getPartitionId());
+
+        // When drop a table partition, drop its snapshot store meanwhile.
+        Set<TableBucket> deleteTableBuckets =
+                coordinatorContext.getAllBucketsForPartition(
+                        dropPartitionEvent.getTableId(), dropPartitionEvent.getPartitionId());
+        completedSnapshotStoreManager.onRemoveCompletedSnapshotStoreByTableBuckets(
+                deleteTableBuckets);
+
         coordinatorContext.queuePartitionDeletion(Collections.singleton(tablePartition));
         tableManager.onDeletePartition(
                 dropPartitionEvent.getTableId(), dropPartitionEvent.getPartitionId());

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -501,7 +501,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
     private void processDropTable(DropTableEvent dropTableEvent) {
         // If this is a primary key table, drop the kv snapshot store.
         TableInfo dropTableInfo = coordinatorContext.getTableInfoById(dropTableEvent.getTableId());
-        if (dropTableInfo.isPrimaryKeyTable()) {
+        if (dropTableInfo.hasPrimaryKey()) {
             Set<TableBucket> deleteTableBuckets =
                     coordinatorContext.getAllBucketsForTable(dropTableEvent.getTableId());
             completedSnapshotStoreManager.removeCompletedSnapshotStoreByTableBuckets(
@@ -523,7 +523,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
         // If this is a primary key table partition, drop the kv snapshot store.
         TableInfo dropTableInfo =
                 coordinatorContext.getTableInfoById(dropPartitionEvent.getTableId());
-        if (dropTableInfo.isPrimaryKeyTable()) {
+        if (dropTableInfo.hasPrimaryKey()) {
             Set<TableBucket> deleteTableBuckets =
                     coordinatorContext.getAllBucketsForPartition(
                             dropPartitionEvent.getTableId(), dropPartitionEvent.getPartitionId());

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -78,11 +78,13 @@ import com.alibaba.fluss.server.zk.data.TabletServerRegistration;
 import com.alibaba.fluss.server.zk.data.ZkData.PartitionIdsZNode;
 import com.alibaba.fluss.server.zk.data.ZkData.TableIdsZNode;
 import com.alibaba.fluss.utils.types.Tuple2;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -28,6 +28,7 @@ import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,10 +36,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -135,6 +133,28 @@ class CompletedSnapshotStoreManagerTest {
                                 .getOrCreateCompletedSnapshotStore(nonExistBucket)
                                 .getAllSnapshots())
                 .hasSize(0);
+    }
+
+    @Test
+    void testRemoveCompletedSnapshotStoreFromManager() throws Exception {
+        CompletedSnapshotStoreManager completedSnapshotStoreManager =
+                createCompletedSnapshotStoreManager(10);
+        Set<TableBucket> tableBuckets = createTableBuckets(1, 2);
+        int snapshotNum = 3;
+        for (TableBucket tableBucket : tableBuckets) {
+            // add some snapshots
+            for (int snapshot = 0; snapshot < snapshotNum; snapshot++) {
+                CompletedSnapshot completedSnapshot =
+                        KvTestUtils.mockCompletedSnapshot(tempDir, tableBucket, snapshot);
+                addCompletedSnapshot(completedSnapshotStoreManager, completedSnapshot);
+            }
+        }
+        // before remove CompletedSnapshotStore
+        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores().size())
+                .isEqualTo(2);
+        // after remove CompletedSnapshotStore
+        completedSnapshotStoreManager.onRemoveCompletedSnapshotStoreByTableBuckets(tableBuckets);
+        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores()).isEmpty();
     }
 
     private CompletedSnapshotStoreManager createCompletedSnapshotStoreManager(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -25,7 +25,6 @@ import com.alibaba.fluss.server.zk.NOPErrorHandler;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperExtension;
 import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
-
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -36,7 +35,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -25,6 +25,7 @@ import com.alibaba.fluss.server.zk.NOPErrorHandler;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperExtension;
 import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CompletedSnapshotStoreManagerTest.java
@@ -156,7 +156,7 @@ class CompletedSnapshotStoreManagerTest {
         assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores().size())
                 .isEqualTo(2);
         // after remove CompletedSnapshotStore
-        completedSnapshotStoreManager.onRemoveCompletedSnapshotStoreByTableBuckets(tableBuckets);
+        completedSnapshotStoreManager.removeCompletedSnapshotStoreByTableBuckets(tableBuckets);
         assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores()).isEmpty();
     }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -56,6 +56,7 @@ import com.alibaba.fluss.server.zk.data.ZkData.PartitionIdsZNode;
 import com.alibaba.fluss.server.zk.data.ZkData.TableIdsZNode;
 import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
 import com.alibaba.fluss.types.DataTypes;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -627,34 +627,18 @@ class CoordinatorEventProcessorTest {
                 nBuckets,
                 replicationFactor);
 
-        // mock CompletedSnapshotStore for partition1 and partition2
+        // mock CompletedSnapshotStore for partition1
         Set<TableBucket> tableBuckets4partition1 =
                 coordinatorContext.getAllBucketsForPartition(tableId, partition1Id);
-        Set<TableBucket> tableBuckets4partition2 =
-                coordinatorContext.getAllBucketsForPartition(tableId, partition2Id);
-        int sizeofCompletedSnapshotStore4partition1 = 0;
-        int sizeofCompletedSnapshotStore4partition2 = 0;
         for (TableBucket tableBucket : tableBuckets4partition1) {
             completedSnapshotStoreManager.getOrCreateCompletedSnapshotStore(
                     new TableBucket(
                             tableBucket.getTableId(),
                             tableBucket.getPartitionId(),
                             tableBucket.getBucket()));
-            sizeofCompletedSnapshotStore4partition1++;
-        }
-        for (TableBucket tableBucket : tableBuckets4partition2) {
-            completedSnapshotStoreManager.getOrCreateCompletedSnapshotStore(
-                    new TableBucket(
-                            tableBucket.getTableId(),
-                            tableBucket.getPartitionId(),
-                            tableBucket.getBucket()));
-            sizeofCompletedSnapshotStore4partition2++;
         }
 
-        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores().size())
-                .isEqualTo(
-                        sizeofCompletedSnapshotStore4partition1
-                                + sizeofCompletedSnapshotStore4partition2);
+        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores()).isNotEmpty();
 
         // drop the partition
         DropPartitionEvent dropPartitionEvent = new DropPartitionEvent(tableId, partition1Id);
@@ -663,8 +647,7 @@ class CoordinatorEventProcessorTest {
         verifyPartitionDropped(coordinatorContext, tableId, partition1Id);
 
         // verify CompleteSnapshotStore has been removed when the table partition1 is dropped
-        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores().size())
-                .isEqualTo(sizeofCompletedSnapshotStore4partition2);
+        assertThat(completedSnapshotStoreManager.getBucketCompletedSnapshotStores()).isEmpty();
 
         // now, drop the table and restart the coordinator event processor,
         // the partition2 should be dropped


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #412 

<!-- What is the purpose of the change -->
Currently, when kv table is deleted or table partition is expired, memory still persist its kv snapshot, which causes memory leak. This pr will fix it.
### Tests

<!-- List UT and IT cases to verify this change -->
**CompletedSnapshotStoreManagerTest::testRemoveCompletedSnapshotStoreFromManager**
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
