### PR TITLE
[build] fix a build typo on start param

### DIFF
--- a/fluss-dist/src/main/resources/bin/coordinator-server.sh
+++ b/fluss-dist/src/main/resources/bin/coordinator-server.sh
@@ -41,7 +41,7 @@ SERVICE=coordinator-server
 
 if [[ $STARTSTOP == "start" ]] || [[ $STARTSTOP == "start-foreground" ]]; then
     # Add coordinator-specific JVM options
-    export FLUSS_ENV_JAVA_OPTS="${FLUSS_ENV_JAVA_OPTS} ${FLUSS_ENV_JAVA_OPTS_JM}"
+    export FLUSS_ENV_JAVA_OPTS="${FLUSS_ENV_JAVA_OPTS} ${FLUSS_ENV_JAVA_OPTS_CS}"
 
     args=("--configDir" "${FLUSS_CONF_DIR}" "${args[@]}")
     if [ ! -z $HOST ]; then


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose
fix a typo on JVM param for adding coordinator-specific JVM options