### PR TITLE
[netty] Modify to debug level in NettyServerHandler#exceptionCaught method to avoid to many logs if NLB is mounted

### DIFF
--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
@@ -124,10 +124,15 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
 
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
-        LOG.warn(
-                "Connection [{}] got exception in Netty server pipeline: \n{}",
-                ctx.channel().remoteAddress(),
-                ExceptionUtils.stringifyException(cause));
+        // debug level to avoid too many logs if NLB(Network Load Balancer is mounted, see
+        // more detail in #377
+        // may revert to warn level if we found warn level is necessary
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Connection [{}] got exception in Netty server pipeline: \n{}",
+                    ctx.channel().remoteAddress(),
+                    ExceptionUtils.stringifyException(cause));
+        }
         ByteBuf byteBuf = encodeServerFailure(ctx.alloc(), ApiError.fromThrowable(cause));
         ctx.writeAndFlush(byteBuf).addListener(ChannelFutureListener.CLOSE);
     }


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #377

<!-- What is the purpose of the change -->
Modify to debug level to avoid too many logs if NLB(Network Load Balancer is mounted.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
