### PR TITLE
[flink] Bump Flink version from 1.20.0 to 1.20.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <curator.version>5.4.0</curator.version>
         <netty.version>4.1.104</netty.version>
         <arrow.version>15.0.0</arrow.version>
-        <flink.version>1.20.0</flink.version>
+        <flink.version>1.20.1</flink.version>
         <paimon.version>1.0.1</paimon.version>
 
         <fluss.hadoop.version>2.10.2</fluss.hadoop.version>

--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -36,7 +36,7 @@ Fluss only supports Apache Flink's Table API.
 Flink runs on all UNIX-like environments, i.e. Linux, Mac OS X, and Cygwin (for Windows).
 If you haven’t downloaded Flink, you can download [the binary release](https://flink.apache.org/downloads.html) of Flink, then extract the archive with the following command.
 ```shell
-tar -xzf flink-1.20.0-bin-scala_2.12.tgz
+tar -xzf flink-1.20.1-bin-scala_2.12.tgz
 ```
 - **Copy Fluss Connector Jar**
 

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -116,8 +116,8 @@ The Docker Compose environment consists of the following containers:
 - **Fluss Cluster:** a Fluss `CoordinatorServer`, a Fluss `TabletServer` and a `ZooKeeper` server.
 - **Flink Cluster**: a Flink `JobManager` and a Flink `TaskManager` container to execute queries.
 
-**Note:** The `fluss/quickstart-flink` image is based on [flink:1.20.0-java17](https://hub.docker.com/layers/library/flink/1.20-java17/images/sha256-381ed7399c95b6b03a7b5ee8baca91fd84e24def9965ce9d436fb22773d66717) and
-includes the [fluss-connector-flink](engine-flink/getting-started.md), [paimon-flink](https://paimon.apache.org/docs/0.8/flink/quick-start/) and
+**Note:** The `fluss/quickstart-flink` image is based on [flink:1.20.1-java17](https://hub.docker.com/layers/library/flink/1.20-java17/images/sha256:bf1af6406c4f4ad8faa46efe2b3d0a0bf811d1034849c42c1e3484712bc83505) and
+includes the [fluss-connector-flink](engine-flink/getting-started.md), [paimon-flink](https://paimon.apache.org/docs/1.0/flink/quick-start/) and
 [flink-connector-faker](https://flink-packages.org/packages/flink-faker) to simplify this guide.
 
 3. To start all containers, run:
@@ -135,7 +135,7 @@ to check whether all containers are running properly.
 You can also visit http://localhost:8083/ to see if Flink is running normally.
 
 :::note 
-- If you want to run with your own Flink environment, remember to download the [fluss-connector-flink](/downloads), [flink-connector-faker](https://github.com/knaufk/flink-faker/releases), [paimon-flink](https://paimon.apache.org/docs/0.8/flink/quick-start/) connector jars and then put them to `FLINK_HOME/lib/`.
+- If you want to run with your own Flink environment, remember to download the [fluss-connector-flink](/downloads), [flink-connector-faker](https://github.com/knaufk/flink-faker/releases), [paimon-flink](https://paimon.apache.org/docs/1.0/flink/quick-start/) connector jars and then put them to `FLINK_HOME/lib/`.
 - All the following commands involving `docker compose` should be executed in the created working directory that contains the `docker-compose.yml` file.
 :::
 


### PR DESCRIPTION
### Purpose

Linked issue: close #449

Bump Flink version from 1.20.0 to 1.20.1.

### Tests

No.

### API and Format

No.

### Documentation

`flink.md` and `getting-started.md` bump Flink version from 1.20.0 to 1.20.1.