### PR TITLE
[log] Fix the 'Destination buffer is too small' error while decompress data in ZstdArrowCompressionCodec

### DIFF
--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version> 1.5.7-1</version>
+            <version>1.5.7-1</version>
         </dependency>
 
         <!-- RocksDB dependencies -->

--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.4.9-1</version>
+            <version> 1.5.7-1</version>
         </dependency>
 
         <!-- RocksDB dependencies -->

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
@@ -54,11 +54,10 @@ public class ZstdArrowCompressionCodec extends AbstractCompressionCodec {
                 compressedBuffer.nioBuffer(
                         CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, (int) maxSize);
 
-        // The reason why we use Zstd.compressDirectByteBuffer(ByteBuffer dst, int dstOffset, int
-        // dstSize, ByteBuffer src, int srcOffset, int srcSize, int level) instead of
-        // Zstd.compressUnsafe(long dst, long dstSize, long src, long srcSize, int level) used in
-        // arrow-java here is that compressUnsafe() may encounter occasional data corruption issues
-        // when dealing with large volumes of data, and the cause has not yet been determined.
+        // The reason why we use Zstd.compressDirectByteBuffer instead of Zstd.compressUnsafe used
+        // in arrow-java here is that compressUnsafe() may encounter occasional data corruption
+        // issues when dealing with large volumes of data, and the cause has not yet been
+        // determined.
         long bytesWritten =
                 Zstd.compressDirectByteBuffer(
                         compressedDirectBuffer,

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/ZstdArrowCompressionCodec.java
@@ -24,6 +24,8 @@ import com.alibaba.fluss.shaded.arrow.org.apache.arrow.vector.compression.Compre
 
 import com.github.luben.zstd.Zstd;
 
+import java.nio.ByteBuffer;
+
 /* This file is based on source code of Apache Arrow-java Project (https://github.com/apache/arrow-java), licensed by
  * the Apache Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership. */
@@ -34,7 +36,7 @@ public class ZstdArrowCompressionCodec extends AbstractCompressionCodec {
     private final int compressionLevel;
 
     public ZstdArrowCompressionCodec() {
-        this.compressionLevel = DEFAULT_COMPRESSION_LEVEL;
+        this(DEFAULT_COMPRESSION_LEVEL);
     }
 
     public ZstdArrowCompressionCodec(int compressionLevel) {
@@ -44,20 +46,34 @@ public class ZstdArrowCompressionCodec extends AbstractCompressionCodec {
     @Override
     protected ArrowBuf doCompress(BufferAllocator allocator, ArrowBuf uncompressedBuffer) {
         long maxSize = Zstd.compressBound(uncompressedBuffer.writerIndex());
-        long dstSize = CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH + maxSize;
-        ArrowBuf compressedBuffer = allocator.buffer(dstSize);
+        ByteBuffer uncompressedDirectBuffer = uncompressedBuffer.nioBuffer();
+
+        long compressedSize = CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH + maxSize;
+        ArrowBuf compressedBuffer = allocator.buffer(compressedSize);
+        ByteBuffer compressedDirectBuffer =
+                compressedBuffer.nioBuffer(
+                        CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, (int) maxSize);
+
+        // The reason why we use Zstd.compressDirectByteBuffer(ByteBuffer dst, int dstOffset, int
+        // dstSize, ByteBuffer src, int srcOffset, int srcSize, int level) instead of
+        // Zstd.compressUnsafe(long dst, long dstSize, long src, long srcSize, int level) used in
+        // arrow-java here is that compressUnsafe() may encounter occasional data corruption issues
+        // when dealing with large volumes of data, and the cause has not yet been determined.
         long bytesWritten =
-                Zstd.compressUnsafe(
-                        compressedBuffer.memoryAddress()
-                                + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH,
-                        dstSize,
-                        /*src*/ uncompressedBuffer.memoryAddress(),
-                        /*srcSize=*/ uncompressedBuffer.writerIndex(),
-                        /*level=*/ this.compressionLevel);
+                Zstd.compressDirectByteBuffer(
+                        compressedDirectBuffer,
+                        0,
+                        (int) maxSize,
+                        uncompressedDirectBuffer,
+                        0,
+                        (int) uncompressedBuffer.writerIndex(),
+                        compressionLevel);
+
         if (Zstd.isError(bytesWritten)) {
             compressedBuffer.close();
             throw new RuntimeException("Error compressing: " + Zstd.getErrorName(bytesWritten));
         }
+
         compressedBuffer.writerIndex(CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH + bytesWritten);
         return compressedBuffer;
     }
@@ -65,20 +81,28 @@ public class ZstdArrowCompressionCodec extends AbstractCompressionCodec {
     @Override
     protected ArrowBuf doDecompress(BufferAllocator allocator, ArrowBuf compressedBuffer) {
         long decompressedLength = readUncompressedLength(compressedBuffer);
+
+        ByteBuffer compressedDirectBuffer = compressedBuffer.nioBuffer();
         ArrowBuf uncompressedBuffer = allocator.buffer(decompressedLength);
+        ByteBuffer uncompressedDirectBuffer =
+                uncompressedBuffer.nioBuffer(0, (int) decompressedLength);
+
         long decompressedSize =
-                Zstd.decompressUnsafe(
-                        uncompressedBuffer.memoryAddress(),
-                        decompressedLength,
-                        /*src=*/ compressedBuffer.memoryAddress()
-                                + CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH,
-                        compressedBuffer.writerIndex()
-                                - CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH);
+                Zstd.decompressDirectByteBuffer(
+                        uncompressedDirectBuffer,
+                        0,
+                        (int) decompressedLength,
+                        compressedDirectBuffer,
+                        (int) CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH,
+                        (int)
+                                (compressedBuffer.writerIndex()
+                                        - CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH));
         if (Zstd.isError(decompressedSize)) {
             uncompressedBuffer.close();
             throw new RuntimeException(
                     "Error decompressing: " + Zstd.getErrorName(decompressedSize));
         }
+
         if (decompressedLength != decompressedSize) {
             uncompressedBuffer.close();
             throw new RuntimeException(


### PR DESCRIPTION
<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue:  https://github.com/alibaba/fluss/issues/462

<!-- What is the purpose of the change -->

Currently, if we define a String in the table and stream write a very large size of data, such as a single row size 5k, the ZstdArrowCompressionCodec will definitely throw a RuntimeException with the message 'Destination buffer is too small' during decompression.

This pr is aims to fix this error.  Through investigation, we found that if we replace the compression way using `Zstd.compressUnsafe(long dst, long dstSize, long src, long srcSize, int level)` with memory copy methods like `Zstd.compressDirectByteBuffer(ByteBuffer dst, int dstOffset, int dstSize, ByteBuffer src, int srcOffset, int srcSize, int level)`, or switch to using `ZstdOutputStreamNoFinalizer`, the error no longer occurs. The possible reason is that the `compressUnsafe` way has some memory operation anomalies that are not being handled correctly.

Why we use `Zstd.compressDirectByteBuffer()` here is that the stream output way `ZstdOutputStreamNoFinalizer` will consume more cpu than previous way.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
