### PR TITLE
[log] Fix Lz4ArrowCompressionCodec gets stuck during compression and is unable to flush data error

### DIFF
--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -62,9 +62,9 @@
 
         <!-- TODO: these two dependencies need to be shaded. -->
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.20</version>
+            <groupId>org.lz4</groupId>
+            <artifactId>lz4-java</artifactId>
+            <version>1.8.0</version>
         </dependency>
 
         <dependency>

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlocakInputStream.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlocakInputStream.java
@@ -1,0 +1,306 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.compression;
+
+import com.alibaba.fluss.compression.FlussLZ4BlockOutputStream.FLG;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Exception;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.lz4.LZ4FrameOutputStream.BD;
+import net.jpountz.lz4.LZ4SafeDecompressor;
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static com.alibaba.fluss.compression.FlussLZ4BlockOutputStream.LZ4_FRAME_INCOMPRESSIBLE_MASK;
+import static com.alibaba.fluss.compression.FlussLZ4BlockOutputStream.MAGIC;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * A partial implementation of the v1.5.1 LZ4 Frame format.
+ *
+ * <p>This class is not thread-safe.
+ */
+public class FlussLZ4BlocakInputStream extends InputStream {
+    public static final String PREMATURE_EOS = "Stream ended prematurely";
+    public static final String NOT_SUPPORTED = "Stream unsupported (invalid magic bytes)";
+    public static final String BLOCK_HASH_MISMATCH = "Block checksum mismatch";
+    public static final String DESCRIPTOR_HASH_MISMATCH = "Stream frame descriptor corrupted";
+
+    private static final LZ4SafeDecompressor DECOMPRESSOR =
+            LZ4Factory.fastestInstance().safeDecompressor();
+    private static final XXHash32 CHECKSUM = XXHashFactory.fastestInstance().hash32();
+
+    private static final RuntimeException BROKEN_LZ4_EXCEPTION;
+    // https://issues.apache.org/jira/browse/KAFKA-9203
+    // detect buggy lz4 libraries on the classpath
+    static {
+        RuntimeException exception = null;
+        try {
+            detectBrokenLz4Version();
+        } catch (RuntimeException e) {
+            exception = e;
+        }
+        BROKEN_LZ4_EXCEPTION = exception;
+    }
+
+    private final ByteBuffer in;
+    private final ByteBuffer decompressionBuffer;
+    // `flg` and `maxBlockSize` are effectively final, they are initialised in the `readHeader`
+    // method that is only invoked from the constructor
+    private FLG flg;
+    private int maxBlockSize;
+
+    // If a block is compressed, this is the same as `decompressionBuffer`. If a block is not
+    // compressed, this is a slice of `in` to avoid unnecessary copies.
+    private ByteBuffer decompressedBuffer;
+    private boolean finished;
+
+    /**
+     * Create a new {@link InputStream} that will decompress data using the LZ4 algorithm.
+     *
+     * @param in The byte buffer to decompress
+     */
+    public FlussLZ4BlocakInputStream(ByteBuffer in) throws IOException {
+        if (BROKEN_LZ4_EXCEPTION != null) {
+            throw BROKEN_LZ4_EXCEPTION;
+        }
+        this.in = in.duplicate().order(ByteOrder.LITTLE_ENDIAN);
+        readHeader();
+        decompressionBuffer = ByteBuffer.allocate(maxBlockSize);
+        decompressionBuffer.order(ByteOrder.LITTLE_ENDIAN);
+        finished = false;
+    }
+
+    /** Reads the magic number and frame descriptor from input buffer. */
+    private void readHeader() throws IOException {
+        // read first 6 bytes into buffer to check magic and FLG/BD descriptor flags
+        if (in.remaining() < 6) {
+            throw new IOException(PREMATURE_EOS);
+        }
+
+        if (MAGIC != in.getInt()) {
+            throw new IOException(NOT_SUPPORTED);
+        }
+        // mark start of data to checksum
+        in.mark();
+
+        flg = FlussLZ4BlockOutputStream.FLG.fromByte(in.get());
+        maxBlockSize = BD.fromByte(in.get()).getBlockMaximumSize();
+
+        if (flg.isContentSizeSet()) {
+            if (in.remaining() < 8) {
+                throw new IOException(PREMATURE_EOS);
+            }
+            in.position(in.position() + 8);
+        }
+
+        int len = in.position() - in.reset().position();
+
+        int hash = CHECKSUM.hash(in, in.position(), len, 0);
+        in.position(in.position() + len);
+        if (in.get() != (byte) ((hash >> 8) & 0xFF)) {
+            throw new IOException(DESCRIPTOR_HASH_MISMATCH);
+        }
+    }
+
+    /**
+     * Decompresses (if necessary) buffered data, optionally computes and validates a XXHash32
+     * checksum, and writes the result to a buffer.
+     */
+    private void readBlock() throws IOException {
+        if (in.remaining() < 4) {
+            throw new IOException(PREMATURE_EOS);
+        }
+
+        int blockSize = in.getInt();
+        boolean compressed = (blockSize & LZ4_FRAME_INCOMPRESSIBLE_MASK) == 0;
+        blockSize &= ~LZ4_FRAME_INCOMPRESSIBLE_MASK;
+
+        // Check for EndMark
+        if (blockSize == 0) {
+            finished = true;
+            if (flg.isContentChecksumSet()) {
+                in.getInt(); // TODO: verify this content checksum
+            }
+            return;
+        } else if (blockSize > maxBlockSize) {
+            throw new IOException(
+                    String.format("Block size %d exceeded max: %d", blockSize, maxBlockSize));
+        }
+
+        if (in.remaining() < blockSize) {
+            throw new IOException(PREMATURE_EOS);
+        }
+
+        if (compressed) {
+            try {
+                final int bufferSize =
+                        DECOMPRESSOR.decompress(
+                                in, in.position(), blockSize, decompressionBuffer, 0, maxBlockSize);
+                decompressionBuffer.position(0);
+                decompressionBuffer.limit(bufferSize);
+                decompressedBuffer = decompressionBuffer;
+            } catch (LZ4Exception e) {
+                throw new IOException(e);
+            }
+        } else {
+            decompressedBuffer = in.slice();
+            decompressedBuffer.limit(blockSize);
+        }
+
+        // verify checksum
+        if (flg.isBlockChecksumSet()) {
+            int hash = CHECKSUM.hash(in, in.position(), blockSize, 0);
+            in.position(in.position() + blockSize);
+            if (hash != in.getInt()) {
+                throw new IOException(BLOCK_HASH_MISMATCH);
+            }
+        } else {
+            in.position(in.position() + blockSize);
+        }
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (finished) {
+            return -1;
+        }
+        if (available() == 0) {
+            readBlock();
+        }
+        if (finished) {
+            return -1;
+        }
+
+        return decompressedBuffer.get() & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        net.jpountz.util.SafeUtils.checkRange(b, off, len);
+        if (finished) {
+            return -1;
+        }
+        if (available() == 0) {
+            readBlock();
+        }
+        if (finished) {
+            return -1;
+        }
+        len = Math.min(len, available());
+
+        decompressedBuffer.get(b, off, len);
+        return len;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        if (finished) {
+            return 0;
+        }
+        if (available() == 0) {
+            readBlock();
+        }
+        if (finished) {
+            return 0;
+        }
+        int skipped = (int) Math.min(n, available());
+        decompressedBuffer.position(decompressedBuffer.position() + skipped);
+        return skipped;
+    }
+
+    @Override
+    public int available() {
+        return decompressedBuffer == null ? 0 : decompressedBuffer.remaining();
+    }
+
+    @Override
+    public void close() {
+        if (decompressionBuffer != null) {
+            decompressionBuffer.clear();
+        }
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        throw new RuntimeException("mark not supported");
+    }
+
+    @Override
+    public void reset() {
+        throw new RuntimeException("reset not supported");
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    /**
+     * Checks whether the version of lz4 on the classpath has the fix for reading from ByteBuffers
+     * with non-zero array offsets.
+     */
+    static void detectBrokenLz4Version() {
+        byte[] source = new byte[] {1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3};
+        final LZ4Compressor compressor = LZ4Factory.fastestInstance().fastCompressor();
+
+        final byte[] compressed = new byte[compressor.maxCompressedLength(source.length)];
+        final int compressedLength =
+                compressor.compress(source, 0, source.length, compressed, 0, compressed.length);
+
+        // allocate an array-backed ByteBuffer with non-zero array-offset containing the compressed
+        // data a buggy decompressor will read the data from the beginning of the underlying array
+        // instead of the beginning of the ByteBuffer, failing to decompress the invalid data.
+        final byte[] zeroes = {0, 0, 0, 0, 0};
+        ByteBuffer nonZeroOffsetBuffer =
+                ByteBuffer.allocate(
+                                zeroes.length
+                                        + compressed
+                                                .length) // allocates the backing array with extra
+                        // space to offset the data
+                        .put(zeroes) // prepend invalid bytes (zeros) before the compressed data
+                        // in the array
+                        .slice() // create a new ByteBuffer sharing the underlying array, offset to
+                        // start on the compressed data
+                        .put(compressed); // write the compressed data at the beginning of this
+        // new buffer
+
+        ByteBuffer dest = ByteBuffer.allocate(source.length);
+        try {
+            DECOMPRESSOR.decompress(
+                    nonZeroOffsetBuffer, 0, compressedLength, dest, 0, source.length);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Kafka has detected detected a buggy lz4-java library (< 1.4.x) on the classpath."
+                            + " If you are using Kafka client libraries, make sure your application does not"
+                            + " accidentally override the version provided by Kafka or include multiple versions"
+                            + " of the library on the classpath. The lz4-java version on the classpath should"
+                            + " match the version the Kafka client libraries depend on. Adding -verbose:class"
+                            + " to your JVM arguments may help understand which lz4-java version is getting loaded.",
+                    e);
+        }
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlocakInputStream.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlocakInputStream.java
@@ -54,8 +54,7 @@ public class FlussLZ4BlocakInputStream extends InputStream {
     private static final XXHash32 CHECKSUM = XXHashFactory.fastestInstance().hash32();
 
     private static final RuntimeException BROKEN_LZ4_EXCEPTION;
-    // https://issues.apache.org/jira/browse/KAFKA-9203
-    // detect buggy lz4 libraries on the classpath
+
     static {
         RuntimeException exception = null;
         try {
@@ -294,11 +293,11 @@ public class FlussLZ4BlocakInputStream extends InputStream {
                     nonZeroOffsetBuffer, 0, compressedLength, dest, 0, source.length);
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Kafka has detected detected a buggy lz4-java library (< 1.4.x) on the classpath."
-                            + " If you are using Kafka client libraries, make sure your application does not"
-                            + " accidentally override the version provided by Kafka or include multiple versions"
+                    "Fluss has detected detected a buggy lz4-java library (< 1.4.x) on the classpath."
+                            + " If you are using Fluss client libraries, make sure your application does not"
+                            + " accidentally override the version provided by Fluss or include multiple versions"
                             + " of the library on the classpath. The lz4-java version on the classpath should"
-                            + " match the version the Kafka client libraries depend on. Adding -verbose:class"
+                            + " match the version the Fluss client libraries depend on. Adding -verbose:class"
                             + " to your JVM arguments may help understand which lz4-java version is getting loaded.",
                     e);
         }

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockOutputStream.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockOutputStream.java
@@ -1,0 +1,387 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.compression;
+
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4Factory;
+import net.jpountz.xxhash.XXHash32;
+import net.jpountz.xxhash.XXHashFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/* This file is based on source code of Apache Kafka Project (https://kafka.apache.org/), licensed by the Apache
+ * Software Foundation (ASF) under the Apache License, Version 2.0. See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership. */
+
+/**
+ * A partial implementation of the v1.5.1 LZ4 Frame format.
+ *
+ * <p>This class is not thread-safe.
+ */
+public class FlussLZ4BlockOutputStream extends OutputStream {
+
+    public static final int MAGIC = 0x184D2204;
+    public static final int LZ4_MAX_HEADER_LENGTH = 19;
+    public static final int LZ4_FRAME_INCOMPRESSIBLE_MASK = 0x80000000;
+
+    public static final String CLOSED_STREAM = "The stream is already closed";
+
+    public static final int BLOCKSIZE_64KB = 4;
+    public static final int BLOCKSIZE_256KB = 5;
+    public static final int BLOCKSIZE_1MB = 6;
+    public static final int BLOCKSIZE_4MB = 7;
+
+    private final LZ4Compressor compressor;
+    private final XXHash32 checksum;
+    private final FLG flg;
+    private final BD bd;
+    private final int maxBlockSize;
+    private OutputStream out;
+    private byte[] buffer;
+    private byte[] compressedBuffer;
+    private int bufferOffset;
+    private boolean finished;
+
+    /**
+     * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+     *
+     * @param out The output stream to compress
+     * @param blockSize Default: 4. The block size used during compression. 4=64kb, 5=256kb, 6=1mb,
+     *     7=4mb. All other values will generate an exception
+     * @param blockChecksum Default: false. When true, a XXHash32 checksum is computed and appended
+     *     to the stream for every block of data FrameDescriptor checksum compatible with older
+     *     kafka clients.
+     */
+    public FlussLZ4BlockOutputStream(OutputStream out, int blockSize, boolean blockChecksum)
+            throws IOException {
+        this.out = out;
+        compressor = LZ4Factory.fastestInstance().fastCompressor();
+        checksum = XXHashFactory.fastestInstance().hash32();
+        bd = new BD(blockSize);
+        flg = new FLG(blockChecksum);
+        bufferOffset = 0;
+        maxBlockSize = bd.getBlockMaximumSize();
+        buffer = new byte[maxBlockSize];
+        compressedBuffer = new byte[compressor.maxCompressedLength(maxBlockSize)];
+        finished = false;
+        writeHeader();
+    }
+
+    /**
+     * Create a new {@link OutputStream} that will compress data using the LZ4 algorithm.
+     *
+     * @param out The output stream to compress
+     */
+    public FlussLZ4BlockOutputStream(OutputStream out) throws IOException {
+        this(out, BLOCKSIZE_64KB, false);
+    }
+
+    public static void writeUnsignedIntLE(byte[] buffer, int offset, int value) {
+        buffer[offset] = (byte) value;
+        buffer[offset + 1] = (byte) (value >>> 8);
+        buffer[offset + 2] = (byte) (value >>> 16);
+        buffer[offset + 3] = (byte) (value >>> 24);
+    }
+
+    /** Writes the magic number and frame descriptor to the underlying {@link OutputStream}. */
+    private void writeHeader() throws IOException {
+        writeUnsignedIntLE(buffer, 0, MAGIC);
+        bufferOffset = 4;
+        buffer[bufferOffset++] = flg.toByte();
+        buffer[bufferOffset++] = bd.toByte();
+        // TODO write uncompressed content size, update flg.validate()
+
+        // compute checksum on all descriptor fields
+        int offset = 4;
+        int len = bufferOffset - offset;
+        byte hash = (byte) ((checksum.hash(buffer, offset, len, 0) >> 8) & 0xFF);
+        buffer[bufferOffset++] = hash;
+
+        // write out frame descriptor
+        out.write(buffer, 0, bufferOffset);
+        bufferOffset = 0;
+    }
+
+    public static void writeUnsignedIntLE(OutputStream out, int value) throws IOException {
+        out.write(value);
+        out.write(value >>> 8);
+        out.write(value >>> 16);
+        out.write(value >>> 24);
+    }
+
+    /**
+     * Compresses buffered data, optionally computes an XXHash32 checksum, and writes the result to
+     * the underlying {@link OutputStream}.
+     */
+    private void writeBlock() throws IOException {
+        if (bufferOffset == 0) {
+            return;
+        }
+
+        int compressedLength = compressor.compress(buffer, 0, bufferOffset, compressedBuffer, 0);
+        byte[] bufferToWrite = compressedBuffer;
+        int compressMethod = 0;
+
+        // Store block uncompressed if compressed length is greater (incompressible)
+        if (compressedLength >= bufferOffset) {
+            bufferToWrite = buffer;
+            compressedLength = bufferOffset;
+            compressMethod = LZ4_FRAME_INCOMPRESSIBLE_MASK;
+        }
+
+        // Write content
+        writeUnsignedIntLE(out, compressedLength | compressMethod);
+        out.write(bufferToWrite, 0, compressedLength);
+
+        // Calculate and write block checksum
+        if (flg.isBlockChecksumSet()) {
+            int hash = checksum.hash(bufferToWrite, 0, compressedLength, 0);
+            writeUnsignedIntLE(out, hash);
+        }
+        bufferOffset = 0;
+    }
+
+    /**
+     * Similar to the {@link #writeBlock()} method. Writes a 0-length block (without block checksum)
+     * to signal the end of the block stream.
+     */
+    private void writeEndMark() throws IOException {
+        writeUnsignedIntLE(out, 0);
+        // TODO implement content checksum, update flg.validate()
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        ensureNotFinished();
+        if (bufferOffset == maxBlockSize) {
+            writeBlock();
+        }
+        buffer[bufferOffset++] = (byte) b;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        net.jpountz.util.SafeUtils.checkRange(b, off, len);
+        ensureNotFinished();
+
+        int bufferRemainingLength = maxBlockSize - bufferOffset;
+        // while b will fill the buffer
+        while (len > bufferRemainingLength) {
+            // fill remaining space in buffer
+            System.arraycopy(b, off, buffer, bufferOffset, bufferRemainingLength);
+            bufferOffset = maxBlockSize;
+            writeBlock();
+            // compute new offset and length
+            off += bufferRemainingLength;
+            len -= bufferRemainingLength;
+            bufferRemainingLength = maxBlockSize;
+        }
+
+        System.arraycopy(b, off, buffer, bufferOffset, len);
+        bufferOffset += len;
+    }
+
+    @Override
+    public void flush() throws IOException {
+        if (!finished) {
+            writeBlock();
+        }
+        if (out != null) {
+            out.flush();
+        }
+    }
+
+    /** A simple state check to ensure the stream is still open. */
+    private void ensureNotFinished() {
+        if (finished) {
+            throw new IllegalStateException(CLOSED_STREAM);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (!finished) {
+                // basically flush the buffer writing the last block
+                writeBlock();
+                // write the end block
+                writeEndMark();
+            }
+        } finally {
+            try {
+                if (out != null) {
+                    try (OutputStream outStream = out) {
+                        outStream.flush();
+                    }
+                }
+            } finally {
+                out = null;
+                buffer = null;
+                compressedBuffer = null;
+                finished = true;
+            }
+        }
+    }
+
+    public static class FLG {
+
+        private static final int VERSION = 1;
+
+        private final int reserved;
+        private final int contentChecksum;
+        private final int contentSize;
+        private final int blockChecksum;
+        private final int blockIndependence;
+        private final int version;
+
+        public FLG() {
+            this(false);
+        }
+
+        public FLG(boolean blockChecksum) {
+            this(0, 0, 0, blockChecksum ? 1 : 0, 1, VERSION);
+        }
+
+        private FLG(
+                int reserved,
+                int contentChecksum,
+                int contentSize,
+                int blockChecksum,
+                int blockIndependence,
+                int version) {
+            this.reserved = reserved;
+            this.contentChecksum = contentChecksum;
+            this.contentSize = contentSize;
+            this.blockChecksum = blockChecksum;
+            this.blockIndependence = blockIndependence;
+            this.version = version;
+            validate();
+        }
+
+        public static FLG fromByte(byte flg) {
+            int reserved = (flg) & 3;
+            int contentChecksum = (flg >>> 2) & 1;
+            int contentSize = (flg >>> 3) & 1;
+            int blockChecksum = (flg >>> 4) & 1;
+            int blockIndependence = (flg >>> 5) & 1;
+            int version = (flg >>> 6) & 3;
+
+            return new FLG(
+                    reserved,
+                    contentChecksum,
+                    contentSize,
+                    blockChecksum,
+                    blockIndependence,
+                    version);
+        }
+
+        public byte toByte() {
+            return (byte)
+                    (((reserved & 3))
+                            | ((contentChecksum & 1) << 2)
+                            | ((contentSize & 1) << 3)
+                            | ((blockChecksum & 1) << 4)
+                            | ((blockIndependence & 1) << 5)
+                            | ((version & 3) << 6));
+        }
+
+        private void validate() {
+            if (reserved != 0) {
+                throw new RuntimeException("Reserved bits must be 0");
+            }
+            if (blockIndependence != 1) {
+                throw new RuntimeException("Dependent block stream is unsupported");
+            }
+            if (version != VERSION) {
+                throw new RuntimeException(String.format("Version %d is unsupported", version));
+            }
+        }
+
+        public boolean isContentChecksumSet() {
+            return contentChecksum == 1;
+        }
+
+        public boolean isContentSizeSet() {
+            return contentSize == 1;
+        }
+
+        public boolean isBlockChecksumSet() {
+            return blockChecksum == 1;
+        }
+
+        public boolean isBlockIndependenceSet() {
+            return blockIndependence == 1;
+        }
+
+        public int getVersion() {
+            return version;
+        }
+    }
+
+    public static class BD {
+
+        private final int reserved2;
+        private final int blockSizeValue;
+        private final int reserved3;
+
+        public BD() {
+            this(0, BLOCKSIZE_64KB, 0);
+        }
+
+        public BD(int blockSizeValue) {
+            this(0, blockSizeValue, 0);
+        }
+
+        private BD(int reserved2, int blockSizeValue, int reserved3) {
+            this.reserved2 = reserved2;
+            this.blockSizeValue = blockSizeValue;
+            this.reserved3 = reserved3;
+            validate();
+        }
+
+        public static BD fromByte(byte bd) {
+            int reserved2 = (bd) & 15;
+            int blockMaximumSize = (bd >>> 4) & 7;
+            int reserved3 = (bd >>> 7) & 1;
+
+            return new BD(reserved2, blockMaximumSize, reserved3);
+        }
+
+        private void validate() {
+            if (reserved2 != 0) {
+                throw new RuntimeException("Reserved2 field must be 0");
+            }
+            if (blockSizeValue < 4 || blockSizeValue > 7) {
+                throw new RuntimeException("Block size value must be between 4 and 7");
+            }
+            if (reserved3 != 0) {
+                throw new RuntimeException("Reserved3 field must be 0");
+            }
+        }
+
+        // 2^(2n+8)
+        public int getBlockMaximumSize() {
+            return 1 << ((2 * blockSizeValue) + 8);
+        }
+
+        public byte toByte() {
+            return (byte)
+                    (((reserved2 & 15)) | ((blockSizeValue & 7) << 4) | ((reserved3 & 1) << 7));
+        }
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockOutputStream.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockOutputStream.java
@@ -64,8 +64,7 @@ public class FlussLZ4BlockOutputStream extends OutputStream {
      * @param blockSize Default: 4. The block size used during compression. 4=64kb, 5=256kb, 6=1mb,
      *     7=4mb. All other values will generate an exception
      * @param blockChecksum Default: false. When true, a XXHash32 checksum is computed and appended
-     *     to the stream for every block of data FrameDescriptor checksum compatible with older
-     *     kafka clients.
+     *     to the stream for every block of data
      */
     public FlussLZ4BlockOutputStream(OutputStream out, int blockSize, boolean blockChecksum)
             throws IOException {

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
@@ -21,16 +21,14 @@ import com.alibaba.fluss.shaded.arrow.org.apache.arrow.memory.ArrowBuf;
 import com.alibaba.fluss.shaded.arrow.org.apache.arrow.memory.BufferAllocator;
 import com.alibaba.fluss.shaded.arrow.org.apache.arrow.vector.compression.AbstractCompressionCodec;
 import com.alibaba.fluss.shaded.arrow.org.apache.arrow.vector.compression.CompressionUtil;
-
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
-import org.apache.commons.compress.utils.IOUtils;
+import com.alibaba.fluss.utils.IOUtils;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
 
@@ -50,8 +48,8 @@ public class Lz4ArrowCompressionCodec extends AbstractCompressionCodec {
         uncompressedBuffer.getBytes(/*index=*/ 0, inBytes);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (InputStream in = new ByteArrayInputStream(inBytes);
-                OutputStream out = new FramedLZ4CompressorOutputStream(baos)) {
-            IOUtils.copy(in, out);
+                OutputStream out = new FlussLZ4BlockOutputStream(baos)) {
+            IOUtils.copyBytes(in, out);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
@@ -73,16 +71,14 @@ public class Lz4ArrowCompressionCodec extends AbstractCompressionCodec {
 
         long decompressedLength = readUncompressedLength(compressedBuffer);
 
-        byte[] inBytes =
-                new byte
-                        [(int)
-                                (compressedBuffer.writerIndex()
-                                        - CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH)];
-        compressedBuffer.getBytes(CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH, inBytes);
+        ByteBuffer inByteBuffer =
+                compressedBuffer.nioBuffer(
+                        CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH,
+                        (int) compressedBuffer.writerIndex()
+                                - (int) CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH);
         ByteArrayOutputStream out = new ByteArrayOutputStream((int) decompressedLength);
-        try (InputStream in =
-                new FramedLZ4CompressorInputStream(new ByteArrayInputStream(inBytes))) {
-            IOUtils.copy(in, out);
+        try (InputStream in = new FlussLZ4BlocakInputStream(inByteBuffer)) {
+            IOUtils.copyBytes(in, out);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
@@ -74,8 +74,9 @@ public class Lz4ArrowCompressionCodec extends AbstractCompressionCodec {
         ByteBuffer inByteBuffer =
                 compressedBuffer.nioBuffer(
                         CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH,
-                        (int) compressedBuffer.writerIndex()
-                                - (int) CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH);
+                        (int)
+                                (compressedBuffer.writerIndex()
+                                        - CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH));
         ByteArrayOutputStream out = new ByteArrayOutputStream((int) decompressedLength);
         try (InputStream in = new FlussLZ4BlocakInputStream(inByteBuffer)) {
             IOUtils.copyBytes(in, out);


### PR DESCRIPTION


<!-- Please specify the module before the PR name: [core] ... or [flink] ... -->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/alibaba/fluss/issues/463

<!-- What is the purpose of the change -->

Currently, if we try to use FRAME_LZ4 codec in flink job to do compress. The `Lz4ArrowCompressionCodec` gets stuck in the `FramedLZ4CompressorOutputStream` during compression and is unable to flush data. 

In this pr, we try to introduce a new compress inputsStream/decompress outputStream way refer to Kafka.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
