### PR TITLE
[core] Add FlushConsolidationHandler to RPC Sever to optimize syscalls

### DIFF
--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -20,6 +20,7 @@ import com.alibaba.fluss.rpc.netty.NettyLogger;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelInitializer;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import com.alibaba.fluss.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import com.alibaba.fluss.shaded.netty4.io.netty.handler.flush.FlushConsolidationHandler;
 import com.alibaba.fluss.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
@@ -47,6 +48,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
         if (nettyLogger.getLoggingHandler() != null) {
             ch.pipeline().addLast("loggingHandler", nettyLogger.getLoggingHandler());
         }
+        ch.pipeline().addLast("consolidation", new FlushConsolidationHandler(1024, true));
         ch.pipeline()
                 .addLast(
                         "frameDecoder",


### PR DESCRIPTION
### Purpose

When we are writing/reading a lot of small entries, one of the main bottleneck in server becomes the CPU usage. A big part of it is caused by the syscall overhead when writing to the socket.

The reason is that we have many independent (and small) operations happening on the connection and each time we call writeAndFlush() on each of them, causing many write() calls on the socket.

### Tests

NONE


### Documentation
