### PR TITLE
[common] Bump zstd-jni version from 1.4.9-1 to 1.5.7-1

### DIFF
--- a/fluss-common/pom.xml
+++ b/fluss-common/pom.xml
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>com.github.luben</groupId>
             <artifactId>zstd-jni</artifactId>
-            <version>1.4.9-1</version>
+            <version>1.5.7-1</version>
         </dependency>
 
         <!-- RocksDB dependencies -->


### PR DESCRIPTION
### Purpose

Linked issue: close #475

Bump zstd-jni version from 1.4.9-1 to 1.5.7-1.

Backport https://github.com/apache/spark/pull/50057.

### Tests

No.

### API and Format

No.

### Documentation

No.