### PR TITLE
[connector] flink read support for fluss primary key table changelog auxiliary table/ cdc events

### DIFF
--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkTableFactory.java
@@ -51,6 +51,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import static com.alibaba.fluss.connector.flink.catalog.FlinkCatalog.CHANGELOG_TABLE_SPLITTER;
 import static com.alibaba.fluss.connector.flink.catalog.FlinkCatalog.LAKE_TABLE_SPLITTER;
 import static com.alibaba.fluss.connector.flink.utils.FlinkConversions.toFlinkOption;
 
@@ -68,6 +69,10 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
             tableName = tableName.substring(0, tableName.indexOf(LAKE_TABLE_SPLITTER));
             lakeTableFactory = mayInitLakeTableFactory();
             return lakeTableFactory.createDynamicTableSource(context, tableName);
+        }
+        boolean isChangelog = false;
+        if (tableName.contains(CHANGELOG_TABLE_SPLITTER)) {
+            isChangelog = true;
         }
 
         FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
@@ -129,7 +134,8 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
                 cache,
                 partitionDiscoveryIntervalMs,
                 tableOptions.get(toFlinkOption(ConfigOptions.TABLE_DATALAKE_ENABLED)),
-                tableOptions.get(toFlinkOption(ConfigOptions.TABLE_MERGE_ENGINE)));
+                tableOptions.get(toFlinkOption(ConfigOptions.TABLE_MERGE_ENGINE)),
+                isChangelog);
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkSource.java
@@ -55,6 +55,7 @@ public class FlinkSource implements Source<RowData, SourceSplitBase, SourceEnume
     private final OffsetsInitializer offsetsInitializer;
     private final long scanPartitionDiscoveryIntervalMs;
     private final boolean streaming;
+    private boolean isChangelog;
 
     public FlinkSource(
             Configuration flussConf,
@@ -65,7 +66,8 @@ public class FlinkSource implements Source<RowData, SourceSplitBase, SourceEnume
             @Nullable int[] projectedFields,
             OffsetsInitializer offsetsInitializer,
             long scanPartitionDiscoveryIntervalMs,
-            boolean streaming) {
+            boolean streaming,
+            boolean isChangelog) {
         this.flussConf = flussConf;
         this.tablePath = tablePath;
         this.hasPrimaryKey = hasPrimaryKey;
@@ -75,6 +77,7 @@ public class FlinkSource implements Source<RowData, SourceSplitBase, SourceEnume
         this.offsetsInitializer = offsetsInitializer;
         this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
         this.streaming = streaming;
+        this.isChangelog = isChangelog;
     }
 
     @Override
@@ -136,6 +139,7 @@ public class FlinkSource implements Source<RowData, SourceSplitBase, SourceEnume
                 sourceOutputType,
                 context,
                 projectedFields,
-                flinkSourceReaderMetrics);
+                flinkSourceReaderMetrics,
+                isChangelog);
     }
 }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/FlinkTableSource.java
@@ -96,6 +96,7 @@ public class FlinkTableSource
     // will be empty if no partition key
     private final int[] partitionKeyIndexes;
     private final boolean streaming;
+    private final boolean isChangelog;
     private final FlinkConnectorOptionsUtils.StartupOptions startupOptions;
 
     // options for lookup source
@@ -137,7 +138,8 @@ public class FlinkTableSource
             @Nullable LookupCache cache,
             long scanPartitionDiscoveryIntervalMs,
             boolean isDataLakeEnabled,
-            @Nullable MergeEngineType mergeEngineType) {
+            @Nullable MergeEngineType mergeEngineType,
+            boolean isChangelog) {
         this.tablePath = tablePath;
         this.flussConfig = flussConfig;
         this.tableOutputType = tableOutputType;
@@ -155,6 +157,7 @@ public class FlinkTableSource
         this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
         this.isDataLakeEnabled = isDataLakeEnabled;
         this.mergeEngineType = mergeEngineType;
+        this.isChangelog = isChangelog;
     }
 
     @Override
@@ -261,7 +264,8 @@ public class FlinkTableSource
                         projectedFields,
                         offsetsInitializer,
                         scanPartitionDiscoveryIntervalMs,
-                        streaming);
+                        streaming,
+                        isChangelog);
 
         if (!streaming) {
             // return a bounded source provide to make planner happy,
@@ -350,7 +354,8 @@ public class FlinkTableSource
                         cache,
                         scanPartitionDiscoveryIntervalMs,
                         isDataLakeEnabled,
-                        mergeEngineType);
+                        mergeEngineType,
+                        isChangelog);
         source.producedDataType = producedDataType;
         source.projectedFields = projectedFields;
         source.singleRowFilter = singleRowFilter;

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/emitter/FlinkRecordEmitter.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.connector.flink.source.reader.FlinkSourceReader;
 import com.alibaba.fluss.connector.flink.source.reader.RecordAndPos;
 import com.alibaba.fluss.connector.flink.source.split.HybridSnapshotLogSplitState;
 import com.alibaba.fluss.connector.flink.source.split.SourceSplitState;
+import com.alibaba.fluss.connector.flink.utils.ChangelogRowConverter;
 import com.alibaba.fluss.connector.flink.utils.FlussRowToFlinkRowConverter;
 import com.alibaba.fluss.types.RowType;
 
@@ -48,8 +49,12 @@ public class FlinkRecordEmitter implements RecordEmitter<RecordAndPos, RowData, 
 
     private LakeRecordRecordEmitter lakeRecordRecordEmitter;
 
-    public FlinkRecordEmitter(RowType rowType) {
-        this.converter = new FlussRowToFlinkRowConverter(rowType);
+    public FlinkRecordEmitter(RowType rowType, boolean isChangeLogMode) {
+        if (!isChangeLogMode) {
+            this.converter = new FlussRowToFlinkRowConverter(rowType);
+        } else {
+            this.converter = new ChangelogRowConverter(rowType);
+        }
     }
 
     @Override

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReader.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/reader/FlinkSourceReader.java
@@ -48,7 +48,7 @@ import java.util.function.Consumer;
 public class FlinkSourceReader
         extends SingleThreadMultiplexSourceReaderBase<
                 RecordAndPos, RowData, SourceSplitBase, SourceSplitState> {
-
+    // todo take changes for changeloftable columns
     public FlinkSourceReader(
             FutureCompletingBlockingQueue<RecordsWithSplitIds<RecordAndPos>> elementsQueue,
             Configuration flussConfig,
@@ -56,7 +56,8 @@ public class FlinkSourceReader
             RowType sourceOutputType,
             SourceReaderContext context,
             @Nullable int[] projectedFields,
-            FlinkSourceReaderMetrics flinkSourceReaderMetrics) {
+            FlinkSourceReaderMetrics flinkSourceReaderMetrics,
+            boolean isChangelog) {
         super(
                 elementsQueue,
                 new FlinkSourceFetcherManager(
@@ -69,7 +70,9 @@ public class FlinkSourceReader
                                         projectedFields,
                                         flinkSourceReaderMetrics),
                         (ignore) -> {}),
-                new FlinkRecordEmitter(sourceOutputType),
+                // todo should have a special FlussRowToFlinkRowConverter that converts the Fluss
+                // InternalRow into Flink RowData with the additional metadata columns
+                new FlinkRecordEmitter(sourceOutputType, isChangelog),
                 context.getConfiguration(),
                 context);
     }

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/ChangelogRowConverter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/ChangelogRowConverter.java
@@ -1,0 +1,48 @@
+package com.alibaba.fluss.connector.flink.utils;
+
+import com.alibaba.fluss.client.table.scanner.ScanRecord;
+import com.alibaba.fluss.types.RowType;
+
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+
+public class ChangelogRowConverter extends FlussRowToFlinkRowConverter {
+    public ChangelogRowConverter(RowType rowType) {
+        super(rowType);
+    }
+
+    public RowData toFlinkRowData(ScanRecord scanRecord) {
+        RowData baseRowData = super.toFlinkRowData(scanRecord);
+        GenericRowData rowWithMetadata = new GenericRowData(baseRowData.getArity() + 3);
+        rowWithMetadata.setRowKind(baseRowData.getRowKind());
+
+        for (int i = 0; i < baseRowData.getArity(); i++) {
+            rowWithMetadata.setField(i, baseRowData.getRawValue(i));
+        }
+
+        int baseArity = baseRowData.getArity();
+        String changeType;
+        switch (scanRecord.getRowKind()) {
+            case INSERT:
+                changeType = "+I";
+                break;
+            case UPDATE_BEFORE:
+                changeType = "-U";
+                break;
+            case UPDATE_AFTER:
+                changeType = "+U";
+                break;
+            case DELETE:
+                changeType = "-D";
+                break;
+            default:
+                changeType = "+I";
+                break;
+        }
+        rowWithMetadata.setField(baseArity, changeType);
+        rowWithMetadata.setField(baseArity + 1, scanRecord.logOffset());
+        rowWithMetadata.setField(baseArity + 2, scanRecord.timestamp());
+
+        return rowWithMetadata;
+    }
+}

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlussRowToFlinkRowConverter.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/utils/FlussRowToFlinkRowConverter.java
@@ -47,6 +47,7 @@ public class FlussRowToFlinkRowConverter {
     private final FlussDeserializationConverter[] toFlinkFieldConverters;
     private final InternalRow.FieldGetter[] flussFieldGetters;
 
+    // todo converts the Fluss InternalRow into Flink RowData with the additional metadata columns
     public FlussRowToFlinkRowConverter(RowType rowType) {
         this.toFlinkFieldConverters = new FlussDeserializationConverter[rowType.getFieldCount()];
         this.flussFieldGetters = new InternalRow.FieldGetter[rowType.getFieldCount()];


### PR DESCRIPTION

## Contribution Checklist

  - Linked issue: close [GitHub issue](https://github.com/alibaba/fluss/issues/356) 



### Purpose

Enhanced the Flink connector by introducing support for the $changelog auxiliary table. enabling seamless CDC event capture and processing in streaming applications

### Brief change log

* Touched FlinkCatalog GetTable (To support enablement of changelog Table)
* Touched CoordinatorService CreateTable (To add validation of system reserved columns)
* Extended FlussRowToFlinkRowConverter (ChangelogRowConverter to add support for emitting changelog records)
* Touched FlinkRecordEmitter (To add choice of special FlinkRow converter based on Changelog Flag)
* Touched FlinkTableFactory (To add createDynamicSource support for changlog table)
* Touched FlinkSource, FlinkSourceReader, FlinkTableSource (To add flag isChangelog in the source constructor of each class)

### Tests

Yet to write (In progress)

### API and Format

Yes , Flink Source Reader

### Documentation

Yes post feedback need to add changes in the doc to support CDC reads via Flink Connector
