### PR TITLE
[server] Fix admin operation cannot be done error when bootstrap server config as one of TabletServer

### DIFF
--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
@@ -557,7 +557,7 @@ class RecordAccumulatorTest {
 
         return new Cluster(
                 aliveTabletServersById,
-                new ServerNode(-1, "localhost", 89, ServerType.COORDINATOR),
+                new ServerNode(0, "localhost", 89, ServerType.COORDINATOR),
                 bucketsByPath,
                 tableIdByPath,
                 Collections.emptyMap(),

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/StickyStaticBucketAssignerTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/StickyStaticBucketAssignerTest.java
@@ -224,7 +224,7 @@ class StickyStaticBucketAssignerTest {
 
         return new Cluster(
                 aliveTabletServersById,
-                new ServerNode(-1, "localhost", 89, ServerType.COORDINATOR),
+                new ServerNode(0, "localhost", 89, ServerType.COORDINATOR),
                 bucketsByPath,
                 tableIdByPath,
                 Collections.emptyMap(),

--- a/fluss-common/src/test/java/com/alibaba/fluss/cluster/ClusterTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/cluster/ClusterTest.java
@@ -46,7 +46,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** Test for {@link Cluster}. */
 class ClusterTest {
     private static final ServerNode COORDINATOR_SERVER =
-            new ServerNode(-1, "localhost", 98, ServerType.COORDINATOR);
+            new ServerNode(0, "localhost", 98, ServerType.COORDINATOR);
     private static final ServerNode[] NODES =
             new ServerNode[] {
                 new ServerNode(0, "localhost", 99, ServerType.TABLET_SERVER),

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -274,10 +274,11 @@ public class CoordinatorEventProcessor implements EventProcessor {
                     .getCoordinatorAddress()
                     .map(
                             coordinatorAddress ->
-                                    // we set id to -1 as the id for the id stored in zk
-                                    // for coordinator server is an uuid now
+                                    // TODO we set id to 0 as that CoordinatorServer don't support
+                                    // HA, if we support HA, we need to set id to the config
+                                    // CoordinatorServer id to avoid node drift.
                                     new ServerNode(
-                                            -1,
+                                            0,
                                             coordinatorAddress.getHost(),
                                             coordinatorAddress.getPort(),
                                             ServerType.COORDINATOR))

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -201,7 +201,7 @@ public class ReplicaTestBase {
     private void initMetadataCache(ServerMetadataCache metadataCache) {
         metadataCache.updateMetadata(
                 new ClusterMetadataInfo(
-                        Optional.of(new ServerNode(-1, "localhost", 1234, ServerType.COORDINATOR)),
+                        Optional.of(new ServerNode(0, "localhost", 1234, ServerType.COORDINATOR)),
                         new HashSet<>(
                                 Arrays.asList(
                                         new ServerNode(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -222,9 +222,9 @@ public final class FlussClusterExtension
                 coordinatorServer = new CoordinatorServer(conf);
                 coordinatorServer.start();
                 coordinatorServerNode =
-                        // we use -1 as coordinator server id
+                        // TODO, Currently, we use 0 as coordinator server id.
                         new ServerNode(
-                                -1, HOST_ADDRESS, availablePort.getPort(), ServerType.COORDINATOR);
+                                0, HOST_ADDRESS, availablePort.getPort(), ServerType.COORDINATOR);
             }
         } else {
             // start the existing coordinator server


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #524 

<!-- What is the purpose of the change -->

This pr is aims to fix the admin operation cannot be done error when `bootstrap server` config as one of `TabletServer`.  The reason for the issue is that the `NettyClient` has a connection cache, and the key for the cache is the `uid` of `ServerNode`, which is in parttern as `'cs' + id` or `'ts' + id`. In pr #456,  the UID of the `bootstrap server` was changed from `'ts--1'` to `'cs--1'`, which conflicted with our default `CoordinatorServer UID`, causing it to be identified as the same connection in the cache. The fix way is to change the default `CoordinatorServer UID` to `'cs-0'`.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
