### PR TITLE
[hotfix] Fix the typo of the class name FlussLZ4BlockInputStream

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockInputStream.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/FlussLZ4BlockInputStream.java
@@ -43,7 +43,7 @@ import static com.alibaba.fluss.compression.FlussLZ4BlockOutputStream.MAGIC;
  *
  * <p>This class is not thread-safe.
  */
-public class FlussLZ4BlocakInputStream extends InputStream {
+public class FlussLZ4BlockInputStream extends InputStream {
     public static final String PREMATURE_EOS = "Stream ended prematurely";
     public static final String NOT_SUPPORTED = "Stream unsupported (invalid magic bytes)";
     public static final String BLOCK_HASH_MISMATCH = "Block checksum mismatch";
@@ -82,7 +82,7 @@ public class FlussLZ4BlocakInputStream extends InputStream {
      *
      * @param in The byte buffer to decompress
      */
-    public FlussLZ4BlocakInputStream(ByteBuffer in) throws IOException {
+    public FlussLZ4BlockInputStream(ByteBuffer in) throws IOException {
         if (BROKEN_LZ4_EXCEPTION != null) {
             throw BROKEN_LZ4_EXCEPTION;
         }

--- a/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/compression/Lz4ArrowCompressionCodec.java
@@ -78,7 +78,7 @@ public class Lz4ArrowCompressionCodec extends AbstractCompressionCodec {
                                 (compressedBuffer.writerIndex()
                                         - CompressionUtil.SIZE_OF_UNCOMPRESSED_LENGTH));
         ByteArrayOutputStream out = new ByteArrayOutputStream((int) decompressedLength);
-        try (InputStream in = new FlussLZ4BlocakInputStream(inByteBuffer)) {
+        try (InputStream in = new FlussLZ4BlockInputStream(inByteBuffer)) {
             IOUtils.copyBytes(in, out);
         } catch (IOException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

this ia a hotfix to fix the typo of the class name FlussLZ4BlockInputStream

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
