### PR TITLE
[connector] Support multiple versions of Flink

### DIFF
--- a/fluss-connectors/fluss-connector-flink/pom.xml
+++ b/fluss-connectors/fluss-connector-flink/pom.xml
@@ -32,6 +32,7 @@
     <properties>
         <scala.binary.version>2.12</scala.binary.version>
         <flink.major.version>1.20</flink.major.version>
+        <flink.minor.version>1.20.1</flink.minor.version>
     </properties>
 
     <dependencies>
@@ -46,21 +47,21 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-core</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-runtime</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -68,7 +69,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-base</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
         </dependency>
 
         <!-- Paimon -->
@@ -82,7 +83,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-files</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -104,7 +105,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-test-utils</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -127,7 +128,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-table-common</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>test</scope>
             <type>test-jar</type>
         </dependency>
@@ -135,7 +136,7 @@
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-test-utils</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.minor.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -154,6 +155,23 @@
         </dependency>
 
     </dependencies>
+
+    <profiles>
+        <profile>
+            <id>flink-1.18</id>
+            <properties>
+                <flink.major.version>1.18</flink.major.version>
+                <flink.minor.version>1.18.1</flink.minor.version>
+            </properties>
+        </profile>
+        <profile>
+            <id>flink-1.19</id>
+            <properties>
+                <flink.major.version>1.19</flink.major.version>
+                <flink.minor.version>1.19.2</flink.minor.version>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/sink/FlinkSink.java
@@ -54,7 +54,6 @@ class FlinkSink implements Sink<RowData> {
         return flinkSinkWriter;
     }
 
-    @Override
     public SinkWriter<RowData> createWriter(WriterInitContext context) throws IOException {
         FlinkSinkWriter flinkSinkWriter = builder.createWriter();
         flinkSinkWriter.initialize(InternalSinkWriterMetricGroup.wrap(context.metricGroup()));

--- a/fluss-connectors/fluss-connector-flink/src/main/java/org/apache/flink/api/connector/sink2/WriterInitContext.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/org/apache/flink/api/connector/sink2/WriterInitContext.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.connector.sink2;
+
+/** Placeholder class to resolve compatibility issues. */
+public interface WriterInitContext extends org.apache.flink.api.connector.sink2.Sink.InitContext {}

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
@@ -26,6 +26,7 @@ import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TablePath;
 
+import org.apache.flink.api.common.JobID;
 import org.apache.flink.api.common.JobInfo;
 import org.apache.flink.api.common.TaskInfo;
 import org.apache.flink.api.common.operators.MailboxExecutor;
@@ -185,14 +186,32 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
             return OptionalLong.empty();
         }
 
-        @Override
         public JobInfo getJobInfo() {
             fail(UNEXPECTED_METHOD_CALL_MESSAGE);
             return null;
         }
 
-        @Override
         public TaskInfo getTaskInfo() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return null;
+        }
+
+        public int getSubtaskId() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return 0;
+        }
+
+        public int getNumberOfParallelSubtasks() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return 0;
+        }
+
+        public int getAttemptNumber() {
+            fail(UNEXPECTED_METHOD_CALL_MESSAGE);
+            return 0;
+        }
+
+        public JobID getJobId() {
             fail(UNEXPECTED_METHOD_CALL_MESSAGE);
             return null;
         }

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkTableSinkITCase.java
@@ -454,12 +454,13 @@ class FlinkTableSinkITCase {
         String sourceName = isPrimaryKeyTable ? "source_primary_key_table" : "source_log_table";
         org.apache.flink.table.api.Table cdcSourceData =
                 tEnv.fromChangelogStream(
-                        env.fromData(
-                                Row.ofKind(RowKind.INSERT, 1, 3501L, "Tim"),
-                                Row.ofKind(RowKind.DELETE, 1, 3501L, "Tim"),
-                                Row.ofKind(RowKind.INSERT, 2, 3502L, "Fabian"),
-                                Row.ofKind(RowKind.UPDATE_BEFORE, 2, 3502L, "Fabian"),
-                                Row.ofKind(RowKind.UPDATE_AFTER, 3, 3503L, "coco")));
+                        env.fromCollection(
+                                Arrays.asList(
+                                        Row.ofKind(RowKind.INSERT, 1, 3501L, "Tim"),
+                                        Row.ofKind(RowKind.DELETE, 1, 3501L, "Tim"),
+                                        Row.ofKind(RowKind.INSERT, 2, 3502L, "Fabian"),
+                                        Row.ofKind(RowKind.UPDATE_BEFORE, 2, 3502L, "Fabian"),
+                                        Row.ofKind(RowKind.UPDATE_AFTER, 3, 3503L, "coco"))));
         tEnv.createTemporaryView(String.format("%s", sourceName), cdcSourceData);
 
         tEnv.executeSql(

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceFailOverITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/source/FlinkTableSourceFailOverITCase.java
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.CheckpointingOptions;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.MemorySize;
 import org.apache.flink.configuration.StateBackendOptions;
-import org.apache.flink.configuration.StateRecoveryOptions;
 import org.apache.flink.core.execution.SavepointFormatType;
 import org.apache.flink.runtime.testutils.MiniClusterResourceConfiguration;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -195,7 +194,7 @@ class FlinkTableSourceFailOverITCase {
                                     SavepointFormatType.CANONICAL)
                             .get();
 
-            tEnv.getConfig().set(StateRecoveryOptions.SAVEPOINT_PATH, savepointPath);
+            tEnv.getConfig().set("execution.savepoint.path", savepointPath);
             insertResult =
                     tEnv.executeSql("insert into result_table select * from test_partitioned");
             // append a new row again to check if the source can restore the state correctly

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConversionsTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/utils/FlinkConversionsTest.java
@@ -164,12 +164,11 @@ class FlinkConversionsTest {
         options.put("k1", "v1");
         options.put("k2", "v2");
         CatalogTable flinkTable =
-                CatalogTable.newBuilder()
-                        .schema(Schema.newBuilder().fromResolvedSchema(schema).build())
-                        .comment("test comment")
-                        .partitionKeys(Collections.emptyList())
-                        .options(options)
-                        .build();
+                CatalogTable.of(
+                        Schema.newBuilder().fromResolvedSchema(schema).build(),
+                        "test comment",
+                        Collections.emptyList(),
+                        options);
 
         // check the converted table
         TableDescriptor flussTable =

--- a/fluss-connectors/fluss-connector-flink/src/test/java/org/apache/flink/api/common/JobInfo.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/org/apache/flink/api/common/JobInfo.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2024 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.api.common;
+
+/** Placeholder class to resolve compatibility issues. */
+public interface JobInfo {}


### PR DESCRIPTION
### Purpose

Linked issue: close #499

Support multiple versions of Flink including Flink 1.18, 1.19 and 1.20.

### Brief change log

Placeholder class to resolve compatibility issues among Flink 1.18, 1.19 and 1.20.

### Tests

- Local test with profile `flink-1.18` and `flink-1.19`.
```
mvn clean install -Pflink-1.18  -pl fluss-connectors/fluss-connector-flink
mvn clean install -Pflink-1.19  -pl fluss-connectors/fluss-connector-flink
```
- CI.

### API and Format

No.

### Documentation

No.