### PR TITLE
[client] Use partition spec in listPartitions

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -40,7 +40,7 @@ import com.alibaba.fluss.metadata.DatabaseDescriptor;
 import com.alibaba.fluss.metadata.DatabaseInfo;
 import com.alibaba.fluss.metadata.PartitionInfo;
 import com.alibaba.fluss.metadata.PartitionSpec;
-import com.alibaba.fluss.metadata.PhysicalTablePath;
+import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.SchemaInfo;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -324,6 +324,8 @@ public interface Admin extends AutoCloseable {
      * </ul>
      *
      * @param tablePath the table path of the table.
+     * @param partitionName the partition name, see {@link ResolvedPartitionSpec#getPartitionName}
+     *     for the format of the partition name.
      */
     CompletableFuture<KvSnapshots> getLatestKvSnapshots(TablePath tablePath, String partitionName);
 
@@ -363,12 +365,26 @@ public interface Admin extends AutoCloseable {
      * List offset for the specified buckets. This operation enables to find the beginning offset,
      * end offset as well as the offset matching a timestamp in buckets.
      *
-     * @param physicalTablePath the physical table path of the buckets.
+     * @param tablePath the table path of the table.
      * @param buckets the buckets to fetch offset.
      * @param offsetSpec the offset spec to fetch.
      */
     ListOffsetsResult listOffsets(
-            PhysicalTablePath physicalTablePath,
+            TablePath tablePath, Collection<Integer> buckets, OffsetSpec offsetSpec);
+
+    /**
+     * List offset for the specified buckets. This operation enables to find the beginning offset,
+     * end offset as well as the offset matching a timestamp in buckets.
+     *
+     * @param tablePath the table path of the table.
+     * @param partitionName the partition name of the partition,see {@link
+     *     ResolvedPartitionSpec#getPartitionName} * for the format of the partition name.
+     * @param buckets the buckets to fetch offset.
+     * @param offsetSpec the offset spec to fetch.
+     */
+    ListOffsetsResult listOffsets(
+            TablePath tablePath,
+            String partitionName,
             Collection<Integer> buckets,
             OffsetSpec offsetSpec);
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -334,6 +334,20 @@ public class FlussAdmin implements Admin {
 
     @Override
     public ListOffsetsResult listOffsets(
+            TablePath tablePath, Collection<Integer> buckets, OffsetSpec offsetSpec) {
+        return listOffsets(PhysicalTablePath.of(tablePath), buckets, offsetSpec);
+    }
+
+    @Override
+    public ListOffsetsResult listOffsets(
+            TablePath tablePath,
+            String partitionName,
+            Collection<Integer> buckets,
+            OffsetSpec offsetSpec) {
+        return listOffsets(PhysicalTablePath.of(tablePath, partitionName), buckets, offsetSpec);
+    }
+
+    private ListOffsetsResult listOffsets(
             PhysicalTablePath physicalTablePath,
             Collection<Integer> buckets,
             OffsetSpec offsetSpec) {

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/PartitionInfo.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/PartitionInfo.java
@@ -29,19 +29,32 @@ import java.util.Objects;
 @PublicEvolving
 public class PartitionInfo {
     private final long partitionId;
-    private final String partitionName;
+    private final ResolvedPartitionSpec partitionSpec;
 
-    public PartitionInfo(long partitionId, String partitionName) {
+    public PartitionInfo(long partitionId, ResolvedPartitionSpec partitionSpec) {
         this.partitionId = partitionId;
-        this.partitionName = partitionName;
+        this.partitionSpec = partitionSpec;
     }
 
+    /** Get the partition id. The id is globally unique in the Fluss cluster. */
     public long getPartitionId() {
         return partitionId;
     }
 
+    /**
+     * Get the partition name. The partition name is like table name to reference the partition. The
+     * format of partition name follows {@link ResolvedPartitionSpec#getPartitionName()}.
+     */
     public String getPartitionName() {
-        return partitionName;
+        return partitionSpec.getPartitionName();
+    }
+
+    public ResolvedPartitionSpec getResolvedPartitionSpec() {
+        return partitionSpec;
+    }
+
+    public PartitionSpec getPartitionSpec() {
+        return partitionSpec.toPartitionSpec();
     }
 
     @Override
@@ -53,16 +66,16 @@ public class PartitionInfo {
             return false;
         }
         PartitionInfo that = (PartitionInfo) o;
-        return partitionId == that.partitionId && Objects.equals(partitionName, that.partitionName);
+        return partitionId == that.partitionId && Objects.equals(partitionSpec, that.partitionSpec);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(partitionId, partitionName);
+        return Objects.hash(partitionId, partitionSpec);
     }
 
     @Override
     public String toString() {
-        return "Partition{name='" + partitionName + '\'' + ", id=" + partitionId + '}';
+        return "Partition{name='" + getPartitionName() + '\'' + ", id=" + partitionId + '}';
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/PartitionSpec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/PartitionSpec.java
@@ -41,7 +41,7 @@ public class PartitionSpec {
         this.partitionSpec = Collections.unmodifiableMap(partitionSpec);
     }
 
-    public Map<String, String> getPartitionSpec() {
+    public Map<String, String> getSpecMap() {
         return partitionSpec;
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/metadata/ResolvedPartitionSpec.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/metadata/ResolvedPartitionSpec.java
@@ -21,8 +21,10 @@ import com.alibaba.fluss.annotation.PublicEvolving;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
 
@@ -40,7 +42,7 @@ public class ResolvedPartitionSpec {
     private final List<String> partitionKeys;
     private final List<String> partitionValues;
 
-    private ResolvedPartitionSpec(List<String> partitionKeys, List<String> partitionValues) {
+    public ResolvedPartitionSpec(List<String> partitionKeys, List<String> partitionValues) {
         checkArgument(
                 partitionKeys.size() == partitionValues.size(),
                 "The number of partition keys and partition values should be the same.");
@@ -71,6 +73,14 @@ public class ResolvedPartitionSpec {
 
     public List<String> getPartitionValues() {
         return partitionValues;
+    }
+
+    public PartitionSpec toPartitionSpec() {
+        Map<String, String> specMap = new HashMap<>();
+        for (int i = 0; i < partitionKeys.size(); i++) {
+            specMap.put(partitionKeys.get(i), partitionValues.get(i));
+        }
+        return new PartitionSpec(specMap);
     }
 
     /**
@@ -121,13 +131,28 @@ public class ResolvedPartitionSpec {
     }
 
     @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResolvedPartitionSpec that = (ResolvedPartitionSpec) o;
+        return Objects.equals(partitionKeys, that.partitionKeys)
+                && Objects.equals(partitionValues, that.partitionValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(partitionKeys, partitionValues);
+    }
+
+    @Override
     public String toString() {
         return getPartitionQualifiedName();
     }
 
     private static List<String> getReorderedPartitionValues(
             List<String> partitionKeys, PartitionSpec partitionSpec) {
-        Map<String, String> partitionSpecMap = partitionSpec.getPartitionSpec();
+        Map<String, String> partitionSpecMap = partitionSpec.getSpecMap();
         List<String> reOrderedPartitionValues = new ArrayList<>(partitionKeys.size());
         partitionKeys.forEach(
                 partitionKey -> reOrderedPartitionValues.add(partitionSpecMap.get(partitionKey)));

--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
@@ -48,7 +48,7 @@ public class PartitionUtils {
 
     public static void validatePartitionSpec(TableInfo tableInfo, PartitionSpec partitionSpec) {
         List<String> partitionKeys = tableInfo.getPartitionKeys();
-        Map<String, String> partitionSpecMap = partitionSpec.getPartitionSpec();
+        Map<String, String> partitionSpecMap = partitionSpec.getSpecMap();
         if (partitionKeys.size() != partitionSpecMap.size()) {
             throw new InvalidPartitionException(
                     String.format(

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/catalog/FlinkCatalog.java
@@ -389,21 +389,11 @@ public class FlinkCatalog implements Catalog {
 
         try {
             TablePath tablePath = toTablePath(objectPath);
-            TableInfo tableInfo = admin.getTableInfo(tablePath).get();
-            List<String> partitionKeys = tableInfo.getPartitionKeys();
-
             List<PartitionInfo> partitionInfos = admin.listPartitionInfos(tablePath).get();
             List<CatalogPartitionSpec> catalogPartitionSpecs = new ArrayList<>();
             for (PartitionInfo partitionInfo : partitionInfos) {
-                String[] partitionValues = partitionInfo.getPartitionName().split("\\$");
-                checkArgument(
-                        partitionKeys.size() == partitionValues.length,
-                        "partition values size not equals to partition keys size");
-                Map<String, String> flinkPartitionSpec = new HashMap<>();
-                for (int i = 0; i < partitionKeys.size(); i++) {
-                    flinkPartitionSpec.put(partitionKeys.get(i), partitionValues[i]);
-                }
-                catalogPartitionSpecs.add(new CatalogPartitionSpec(flinkPartitionSpec));
+                catalogPartitionSpecs.add(
+                        new CatalogPartitionSpec(partitionInfo.getPartitionSpec().getSpecMap()));
             }
             return catalogPartitionSpecs;
         } catch (Exception e) {

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/BucketOffsetsRetrieverImpl.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/BucketOffsetsRetrieverImpl.java
@@ -17,9 +17,9 @@
 package com.alibaba.fluss.connector.flink.source.enumerator.initializer;
 
 import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.client.admin.ListOffsetsResult;
 import com.alibaba.fluss.client.admin.OffsetSpec;
 import com.alibaba.fluss.connector.flink.source.enumerator.initializer.OffsetsInitializer.BucketOffsetsRetriever;
-import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TablePath;
 
 import org.apache.flink.util.FlinkRuntimeException;
@@ -68,11 +68,13 @@ public class BucketOffsetsRetrieverImpl implements BucketOffsetsRetriever {
     private Map<Integer, Long> listOffsets(
             @Nullable String partitionName, Collection<Integer> buckets, OffsetSpec offsetSpec) {
         try {
-            return flussAdmin
-                    .listOffsets(
-                            PhysicalTablePath.of(tablePath, partitionName), buckets, offsetSpec)
-                    .all()
-                    .get();
+            final ListOffsetsResult result;
+            if (partitionName == null) {
+                result = flussAdmin.listOffsets(tablePath, buckets, offsetSpec);
+            } else {
+                result = flussAdmin.listOffsets(tablePath, partitionName, buckets, offsetSpec);
+            }
+            return result.all().get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new FlinkRuntimeException(

--- a/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/OffsetsInitializer.java
+++ b/fluss-connectors/fluss-connector-flink/src/main/java/com/alibaba/fluss/connector/flink/source/enumerator/initializer/OffsetsInitializer.java
@@ -16,10 +16,10 @@
 
 package com.alibaba.fluss.connector.flink.source.enumerator.initializer;
 
-import com.alibaba.fluss.client.admin.FlussAdmin;
+import com.alibaba.fluss.client.admin.Admin;
 import com.alibaba.fluss.client.admin.OffsetSpec;
 import com.alibaba.fluss.connector.flink.source.split.SourceSplitBase;
-import com.alibaba.fluss.metadata.PhysicalTablePath;
+import com.alibaba.fluss.metadata.TablePath;
 
 import javax.annotation.Nullable;
 
@@ -101,7 +101,8 @@ public interface OffsetsInitializer extends Serializable {
      * @param timestamp the timestamp (milliseconds) to start the scan.
      * @return an {@link OffsetsInitializer} which initializes the offsets based on the given
      *     timestamp.
-     * @see FlussAdmin#listOffsets(PhysicalTablePath, Collection, OffsetSpec)
+     * @see Admin#listOffsets(TablePath, Collection, OffsetSpec)
+     * @see Admin#listOffsets(TablePath, String, Collection, OffsetSpec)
      */
     static OffsetsInitializer timestamp(long timestamp) {
         return new TimestampOffsetsInitializer(timestamp);

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/enumerator/FlinkSourceEnumerator.java
@@ -599,7 +599,6 @@ public class FlinkSourceEnumerator
                         removedPartitions.add(p);
                     }
                 });
-        ;
 
         if (!removedPartitions.isEmpty()) {
             LOG.info("Discovered removed partitions: {}", removedPartitions);

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/main/java/com/alibaba/fluss/lakehouse/paimon/source/enumerator/FlinkSourceEnumerator.java
@@ -333,8 +333,8 @@ public class FlinkSourceEnumerator
 
     private void checkPartitionChanges(
             Map<Long, TableInfo> tableInfos, Map<Long, Set<PartitionInfo>> fetchedPartitionInfos) {
-        Map<Long, Collection<PartitionInfo>> newPartitions = new HashMap<>();
-        Map<Long, Collection<PartitionInfo>> removedPartitions = new HashMap<>();
+        Map<Long, Collection<Partition>> newPartitions = new HashMap<>();
+        Map<Long, Collection<Partition>> removedPartitions = new HashMap<>();
         for (Map.Entry<Long, Set<PartitionInfo>> entry : fetchedPartitionInfos.entrySet()) {
             long tableId = entry.getKey();
             Set<PartitionInfo> partitionInfos = entry.getValue();
@@ -384,27 +384,26 @@ public class FlinkSourceEnumerator
     }
 
     private List<SourceSplitBase> initPartitionedSplits(
-            Map<Long, TableInfo> tableInfos, Map<Long, Collection<PartitionInfo>> newPartitions) {
+            Map<Long, TableInfo> tableInfos, Map<Long, Collection<Partition>> newPartitions) {
         List<SourceSplitBase> sourceSplitBases = new ArrayList<>();
-        for (Map.Entry<Long, Collection<PartitionInfo>> entry : newPartitions.entrySet()) {
+        for (Map.Entry<Long, Collection<Partition>> entry : newPartitions.entrySet()) {
             long tableId = entry.getKey();
-            Collection<PartitionInfo> partitionInfos = entry.getValue();
+            Collection<Partition> partitions = entry.getValue();
             TableInfo tableInfo = tableInfos.get(tableId);
             if (tableInfo.hasPrimaryKey()) {
                 sourceSplitBases.addAll(
-                        initPrimaryKeyTablePartitionSplits(
-                                tableId, tableInfo.getTablePath(), partitionInfos));
+                        initPrimaryKeyTablePartitionSplits(tableInfo.getTablePath(), partitions));
             } else {
-                sourceSplitBases.addAll(initLogTablePartitionSplits(tableInfo, partitionInfos));
+                sourceSplitBases.addAll(initLogTablePartitionSplits(tableInfo, partitions));
             }
         }
         return sourceSplitBases;
     }
 
     private List<SourceSplitBase> initLogTablePartitionSplits(
-            TableInfo tableInfo, Collection<PartitionInfo> newPartitions) {
+            TableInfo tableInfo, Collection<Partition> newPartitions) {
         List<SourceSplitBase> splits = new ArrayList<>();
-        for (PartitionInfo partition : newPartitions) {
+        for (Partition partition : newPartitions) {
             splits.addAll(
                     getLogSplits(
                             new TableIdAndPath(tableInfo.getTableId(), tableInfo.getTablePath()),
@@ -416,10 +415,10 @@ public class FlinkSourceEnumerator
     }
 
     private List<SourceSplitBase> initPrimaryKeyTablePartitionSplits(
-            long tableId, TablePath tablePath, Collection<PartitionInfo> newPartitions) {
+            TablePath tablePath, Collection<Partition> newPartitions) {
         List<SourceSplitBase> splits = new ArrayList<>();
-        for (PartitionInfo partitionInfo : newPartitions) {
-            String partitionName = partitionInfo.getPartitionName();
+        for (Partition partition : newPartitions) {
+            String partitionName = partition.getPartitionName();
             // get the table snapshot info
             final KvSnapshots kvSnapshots;
             try {
@@ -433,7 +432,7 @@ public class FlinkSourceEnumerator
             }
             splits.addAll(
                     getHybridSnapshotAndLogSplits(
-                            kvSnapshots, tablePath, partitionInfo.getPartitionName()));
+                            kvSnapshots, tablePath, partition.getPartitionName()));
         }
         return splits;
     }
@@ -568,20 +567,16 @@ public class FlinkSourceEnumerator
     }
 
     private PartitionChange getPartitionChange(Set<PartitionInfo> fetchedPartitionInfos) {
-        final Set<PartitionInfo> removedPartitionIds = new HashSet<>();
+        final Set<Partition> newPartitions =
+                fetchedPartitionInfos.stream()
+                        .map(p -> new Partition(p.getPartitionId(), p.getPartitionName()))
+                        .collect(Collectors.toSet());
+        final Set<Partition> removedPartitions = new HashSet<>();
 
-        Consumer<PartitionInfo> dedupOrMarkAsRemoved =
-                (tp) -> {
-                    if (!fetchedPartitionInfos.remove(tp)) {
-                        removedPartitionIds.add(tp);
-                    }
-                };
-
-        Set<PartitionInfo> assignedOrPendingPartitions = new HashSet<>();
+        Set<Partition> assignedOrPendingPartitions = new HashSet<>();
         assignedPartitions.forEach(
                 (partitionId, partitionName) ->
-                        assignedOrPendingPartitions.add(
-                                new PartitionInfo(partitionId, partitionName)));
+                        assignedOrPendingPartitions.add(new Partition(partitionId, partitionName)));
         pendingSplitAssignment.values().stream()
                 .flatMap(Collection::stream)
                 .forEach(
@@ -595,19 +590,25 @@ public class FlinkSourceEnumerator
                                             split.getPartitionName(),
                                             "partition name shouldn't be null for the splits of partitioned table.");
                             assignedOrPendingPartitions.add(
-                                    new PartitionInfo(partitionId, partitionName));
+                                    new Partition(partitionId, partitionName));
                         });
 
-        assignedOrPendingPartitions.forEach(dedupOrMarkAsRemoved);
+        assignedOrPendingPartitions.forEach(
+                p -> {
+                    if (!newPartitions.remove(p)) {
+                        removedPartitions.add(p);
+                    }
+                });
+        ;
 
-        if (!removedPartitionIds.isEmpty()) {
-            LOG.info("Discovered removed partitions: {}", removedPartitionIds);
+        if (!removedPartitions.isEmpty()) {
+            LOG.info("Discovered removed partitions: {}", removedPartitions);
         }
-        if (!fetchedPartitionInfos.isEmpty()) {
-            LOG.info("Discovered new partitions: {}", fetchedPartitionInfos);
+        if (!newPartitions.isEmpty()) {
+            LOG.info("Discovered new partitions: {}", newPartitions);
         }
 
-        return new PartitionChange(fetchedPartitionInfos, removedPartitionIds);
+        return new PartitionChange(newPartitions, removedPartitions);
     }
 
     private void handleTablesAdd(Collection<TableInfo> addedTables) {
@@ -641,22 +642,22 @@ public class FlinkSourceEnumerator
     }
 
     private void handlePartitionsRemoved(
-            Map<Long, Collection<PartitionInfo>> removedPartitionInfoByTableId) {
+            Map<Long, Collection<Partition>> removedPartitionInfoByTableId) {
         if (removedPartitionInfoByTableId.isEmpty()) {
             return;
         }
 
         Map<Long, Map<Long, String>> removedPartitionsByTableId = new HashMap<>();
 
-        for (Map.Entry<Long, Collection<PartitionInfo>> removedPartitionInfoEntry :
+        for (Map.Entry<Long, Collection<Partition>> removedPartitionInfoEntry :
                 removedPartitionInfoByTableId.entrySet()) {
             long tableId = removedPartitionInfoEntry.getKey();
             Map<Long, String> removedPartitionsMap =
                     removedPartitionInfoEntry.getValue().stream()
                             .collect(
                                     Collectors.toMap(
-                                            PartitionInfo::getPartitionId,
-                                            PartitionInfo::getPartitionName));
+                                            Partition::getPartitionId,
+                                            Partition::getPartitionName));
             // remove from the pending split assignment
             pendingSplitAssignment.forEach(
                     (reader, splits) ->
@@ -767,12 +768,11 @@ public class FlinkSourceEnumerator
     // --------------- private class ---------------
     /** A container class to hold the newly added partitions and removed partitions. */
     private static class PartitionChange {
-        private final Collection<PartitionInfo> newPartitions;
-        private final Collection<PartitionInfo> removedPartitions;
+        private final Collection<Partition> newPartitions;
+        private final Collection<Partition> removedPartitions;
 
         PartitionChange(
-                Collection<PartitionInfo> newPartitions,
-                Collection<PartitionInfo> removedPartitions) {
+                Collection<Partition> newPartitions, Collection<Partition> removedPartitions) {
             this.newPartitions = newPartitions;
             this.removedPartitions = removedPartitions;
         }
@@ -825,6 +825,45 @@ public class FlinkSourceEnumerator
                     + tablePath
                     + '\''
                     + '}';
+        }
+    }
+
+    /** A container class to hold the partition id and partition name. */
+    private static class Partition {
+        final long partitionId;
+        final String partitionName;
+
+        Partition(long partitionId, String partitionName) {
+            this.partitionId = partitionId;
+            this.partitionName = partitionName;
+        }
+
+        public long getPartitionId() {
+            return partitionId;
+        }
+
+        public String getPartitionName() {
+            return partitionName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Partition partition = (Partition) o;
+            return partitionId == partition.partitionId
+                    && Objects.equals(partitionName, partition.partitionName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(partitionId, partitionName);
+        }
+
+        @Override
+        public String toString() {
+            return "Partition{" + "id=" + partitionId + ", name='" + partitionName + '\'' + '}';
         }
     }
 }

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -732,7 +732,7 @@ message PbRemoteLogSegment {
 
 message PbPartitionInfo {
   required int64 partition_id = 1;
-  required string partition_name = 2;
+  required PbPartitionSpec partition_spec = 2;
 }
 
 message PbPartitionSpec {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
@@ -392,8 +392,10 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
             ListPartitionInfosRequest request) {
         TablePath tablePath = toTablePath(request.getTablePath());
         Map<String, Long> partitionNameAndIds = metadataManager.listPartitions(tablePath);
+        TableInfo tableInfo = metadataManager.getTable(tablePath);
+        List<String> partitionKeys = tableInfo.getPartitionKeys();
         return CompletableFuture.completedFuture(
-                RpcMessageUtils.toListPartitionInfosResponse(partitionNameAndIds));
+                RpcMessageUtils.toListPartitionInfosResponse(partitionKeys, partitionNameAndIds));
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

1. The `listPartition` API should return more information about partitions, so change from `partitionName` to `ResolvedPartitionSpec`. 
2. Change `listOffset(PhysicalTablePath ...)` to `listOffset(TablePath, partitionName ...)` to align with other partition related operations, such as `getLatestKvSnapshots`. 


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
