### PR TITLE
[tests] Fix FlinkSinkWriterTest.testSinkMetrics and FlinkMetricsITCase.testMetricsReport is unstable

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metrics/WriterMetricGroup.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metrics/WriterMetricGroup.java
@@ -42,9 +42,8 @@ public class WriterMetricGroup extends AbstractMetricGroup {
     private final Histogram bytesPerBatch;
     private final Histogram recordPerBatch;
 
-    private volatile long sendLatencyInMs;
-
-    private volatile long batchQueueTimeMs;
+    private volatile long sendLatencyInMs = -1;
+    private volatile long batchQueueTimeMs = -1;
 
     public WriterMetricGroup(ClientMetricGroup parent) {
         super(parent.getMetricRegistry(), makeScope(parent, name), parent);

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/metrics/FlinkMetricsITCase.java
@@ -127,8 +127,8 @@ class FlinkMetricsITCase extends FlinkTestBase {
         assertThat(metricsList).hasSize(1);
         Metric sendLatencyMetrics = metricsList.get(0).f2;
         assertThat(sendLatencyMetrics).isInstanceOf(Gauge.class);
-        // just check send latency is greater than 0
-        assertThat((Long) ((Gauge<?>) sendLatencyMetrics).getValue()).isGreaterThan(0);
+        // the default send latency is -1, so check it is >= 0, as the latency maybe very small 0ms
+        assertThat((Long) ((Gauge<?>) sendLatencyMetrics).getValue()).isGreaterThanOrEqualTo(0);
 
         // test scan
         tableResult = tEnv.executeSql("select * from test");

--- a/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
+++ b/fluss-connectors/fluss-connector-flink/src/test/java/com/alibaba/fluss/connector/flink/sink/FlinkSinkWriterTest.java
@@ -106,7 +106,8 @@ public class FlinkSinkWriterTest extends FlinkTestBase {
 
         Metric currentSendTime = interceptingOperatorMetricGroup.get(MetricNames.CURRENT_SEND_TIME);
         assertThat(currentSendTime).isInstanceOf(Gauge.class);
-        assertThat(((Gauge<Long>) currentSendTime).getValue()).isGreaterThan(0);
+        // the default send latency is -1, so check it is >= 0, as the latency maybe very small 0ms
+        assertThat(((Gauge<Long>) currentSendTime).getValue()).isGreaterThanOrEqualTo(0);
 
         Metric numRecordSend = interceptingOperatorMetricGroup.get(MetricNames.NUM_RECORDS_SEND);
         assertThat(numRecordSend).isInstanceOf(Counter.class);


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #549

<!-- What is the purpose of the change -->

The reason is the duration of `ProduceLog` RPC is too short and the `sendLatencyInMs` maybe small as 0 ms.


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

1. change the default `sendLatencyInMs` to `-1`
2. change the test comparison from `isGreaterThan(0)` to `isGreaterThanOrEqualTo(0)`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
