### PR TITLE
[hotfix] Pass datalake related args run paimon tiering service in FlussLakehouseCli

### DIFF
--- a/fluss-lakehouse/fluss-lakehouse-cli/src/main/java/com/alibaba/fluss/lakehouse/cli/FlussLakehouseCli.java
+++ b/fluss-lakehouse/fluss-lakehouse-cli/src/main/java/com/alibaba/fluss/lakehouse/cli/FlussLakehouseCli.java
@@ -75,15 +75,8 @@ public class FlussLakehouseCli {
                     GlobalConfiguration.loadConfiguration(
                             configDirAndDynamicConfig.f0, configDirAndDynamicConfig.f1);
 
-            // validate datalake format
-            DataLakeFormat datalakeFormat = globalConfiguration.get(ConfigOptions.DATALAKE_FORMAT);
-            if (datalakeFormat == null) {
-                throw new IllegalArgumentException(
-                        "The datalake format is not set,"
-                                + " please set the configuration "
-                                + ConfigOptions.DATALAKE_FORMAT.key());
-            }
-
+            // get config for lake storage
+            Map<String, String> lakeStorageConfig = getLakeStorageConfig(globalConfiguration);
             // get config for fluss source, now only bootstrap server is required
             String flussBootstrapServer = getFlussBootStrapServers(globalConfiguration);
 
@@ -100,7 +93,14 @@ public class FlussLakehouseCli {
             flinkConfig.set(PipelineOptions.NAME, DEFAULT_PIPELINE_NAME);
 
             // now, start execute
-            retCode = run(runAction, jarFile, flussBootstrapServer, flinkConfig, dynamicConfigs);
+            retCode =
+                    run(
+                            runAction,
+                            jarFile,
+                            flussBootstrapServer,
+                            lakeStorageConfig,
+                            flinkConfig,
+                            dynamicConfigs);
         } catch (Throwable t) {
             t.printStackTrace(System.err);
         }
@@ -125,6 +125,7 @@ public class FlussLakehouseCli {
             String runAction,
             String jarFile,
             String flussBootstrapServer,
+            Map<String, String> lakeStorageConfig,
             org.apache.flink.configuration.Configuration flinkConfig,
             Map<String, String> dynamicConfigs) {
         List<CustomCommandLine> customCommandLines = new ArrayList<>();
@@ -139,12 +140,35 @@ public class FlussLakehouseCli {
                                 jarFile,
                                 "--" + ConfigOptions.BOOTSTRAP_SERVERS.key(),
                                 flussBootstrapServer));
+        for (Map.Entry<String, String> entry : lakeStorageConfig.entrySet()) {
+            arguments.add("--" + entry.getKey());
+            arguments.add(entry.getValue());
+        }
         for (Map.Entry<String, String> entry : dynamicConfigs.entrySet()) {
             arguments.add("--" + entry.getKey());
             arguments.add(entry.getValue());
         }
         String[] newArgs = arguments.toArray(new String[0]);
         return cliFrontend.parseAndRun(newArgs);
+    }
+
+    private static Map<String, String> getLakeStorageConfig(Configuration configuration) {
+        // validate datalake format
+        DataLakeFormat datalakeFormat = configuration.get(ConfigOptions.DATALAKE_FORMAT);
+        if (datalakeFormat == null) {
+            throw new IllegalArgumentException(
+                    "The datalake format is not set,"
+                            + " please set the configuration "
+                            + ConfigOptions.DATALAKE_FORMAT.key());
+        }
+        String datalakeConfigPrefix = "datalake." + datalakeFormat + ".";
+        Map<String, String> lakeStorageConfig = new HashMap<>();
+        for (Map.Entry<String, String> entry : configuration.toMap().entrySet()) {
+            if (entry.getKey().startsWith(datalakeConfigPrefix)) {
+                lakeStorageConfig.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return lakeStorageConfig;
     }
 
     private static String getFlussBootStrapServers(Configuration configuration) {


### PR DESCRIPTION
To pass datalake related args to run paimon tiering service in FlussLakehouseCli..
In #362 , we [miss-remove](https://github.com/alibaba/fluss/commit/7a4d71e36ad874969a74525545f7bc4e62ffd52b#diff-a8d1793ca21749941c4c05a5be11a5f5859be4738a48d4114422f289b5c9cc25L78) the datalake related args to run paimon tiering service.. This pr is to add them back..