### PR TITLE
Introduce authenticate in Fluss.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -278,23 +278,27 @@ public class MetadataUpdater {
         List<InetSocketAddress> inetSocketAddresses =
                 ClientUtils.parseAndValidateAddresses(conf.get(ConfigOptions.BOOTSTRAP_SERVERS));
         Cluster cluster = null;
-        Exception exception = null;
+        Exception lastException = null;
         for (InetSocketAddress address : inetSocketAddresses) {
             try {
                 cluster = tryToInitializeCluster(rpcClient, address);
                 break;
             } catch (Exception e) {
-                exception = e;
+                LOG.error(
+                        "Failed to initialize fluss client connection to bootstrap server: {}",
+                        address,
+                        e);
+                lastException = e;
             }
         }
 
-        if (cluster == null && exception != null) {
+        if (cluster == null && lastException != null) {
             String errorMsg =
                     "Failed to initialize fluss client connection to server because no "
                             + "bootstrap server is validate. bootstrap servers: "
                             + inetSocketAddresses;
             LOG.error(errorMsg);
-            throw new IllegalStateException(errorMsg, exception);
+            throw new IllegalStateException(errorMsg, lastException);
         }
 
         return cluster;

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -28,7 +28,9 @@ import com.alibaba.fluss.utils.ArrayUtils;
 import java.time.Duration;
 import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static com.alibaba.fluss.config.ConfigBuilder.key;
 import static com.alibaba.fluss.config.ConfigOptions.CompactionStyle.FIFO;
@@ -276,6 +278,16 @@ public class ConfigOptions {
                     .withDescription(
                             "The external RPC port where the TabletServer is exposed."
                                     + "This option is deprecated. Please use bind.listeners instead, which provides a more flexible configuration for multiple ports");
+
+    public static final ConfigOption<Map<String, String>> SERVER_SECURITY_PROTOCOL_MAP =
+            key("security.protocol.map")
+                    .mapType()
+                    .defaultValue(Collections.emptyMap())
+                    .withDescription(
+                            "A map defining the authentication protocol for each listener. "
+                                    + "The format is 'listenerName1:protocol1,listenerName2:protocol2', e.g., 'INTERNAL:PLAINTEXT,CLIENT:GSSAPI'. "
+                                    + "Each listener can be associated with a specific authentication protocol. "
+                                    + "Listeners not included in the map will use PLAINTEXT by default, which does not require authentication.");
 
     public static final ConfigOption<Integer> TABLET_SERVER_ID =
             key("tablet-server.id")
@@ -868,6 +880,13 @@ public class ConfigOptions {
                                     + "Note that this config doesn't impact the underlying fetching behavior. "
                                     + "The Scanner will cache the records from each fetch request and returns "
                                     + "them incrementally from each poll.");
+
+    public static final ConfigOption<String> CLIENT_SECURITY_PROTOCOL =
+            key("client.security.protocol")
+                    .stringType()
+                    .defaultValue("PLAINTEXT")
+                    .withDescription(
+                            "The authentication protocol used to authenticate the client.");
 
     public static final ConfigOption<MemorySize> CLIENT_SCANNER_LOG_FETCH_MAX_BYTES =
             key("client.scanner.log.fetch.max-bytes")

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/Configuration.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/Configuration.java
@@ -460,6 +460,15 @@ public class Configuration implements Serializable, ReadableConfig {
         }
     }
 
+    /**
+     * Returns the value associated with the given config option as a map.
+     *
+     * @param configOption The configuration option
+     * @return the (default) value associated with the given config option
+     */
+    public Map<String, String> getMap(ConfigOption<Map<String, String>> configOption) {
+        return getOptional(configOption).orElseGet(configOption::defaultValue);
+    }
     // --------------------------------------------------------------------------------------------
 
     /**

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
@@ -28,6 +28,7 @@ public class FlussConfigUtils {
 
     public static final Map<String, ConfigOption<?>> TABLE_OPTIONS;
     public static final Map<String, ConfigOption<?>> CLIENT_OPTIONS;
+    public static final String CLIENT_SECURITY_PREFIX = "client.security.";
 
     static {
         TABLE_OPTIONS = extractConfigOptions("table.");

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/FlussConfigUtils.java
@@ -28,6 +28,7 @@ public class FlussConfigUtils {
 
     public static final Map<String, ConfigOption<?>> TABLE_OPTIONS;
     public static final Map<String, ConfigOption<?>> CLIENT_OPTIONS;
+    public static final String CLIENT_PREFIX = "client.";
     public static final String CLIENT_SECURITY_PREFIX = "client.security.";
 
     static {

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/AuthenticationException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/AuthenticationException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/**
+ * This exception is thrown if authentication fails.
+ *
+ * @since 0.7
+ */
+public class AuthenticationException extends ApiException {
+    private static final long serialVersionUID = 1L;
+
+    public AuthenticationException(String message) {
+        super(message);
+    }
+
+    public AuthenticationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
@@ -1,0 +1,183 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.ValidationException;
+import com.alibaba.fluss.plugin.PluginManager;
+import com.alibaba.fluss.plugin.PluginUtils;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/**
+ * A manager responsible for loading and configuring client and server authenticators based on the
+ * provided configuration.
+ *
+ * <p>This class discovers authentication plugins via the classpath and configured plugins, and
+ * creates suppliers for authenticators using plugin-specific configurations.
+ *
+ * <p>Key functionalities include:
+ *
+ * <ul>
+ *   <li>Loading client authenticators based on {@link ConfigOptions#CLIENT_SECURITY_PROTOCOL}.
+ *   <li>Loading server authenticators for multiple endpoints, using listener-specific protocols
+ *       defined in {@link ConfigOptions#SERVER_SECURITY_PROTOCOL_MAP}.
+ *   <li>Discovering plugins through {@link ServiceLoader} and custom {@link PluginManager} for
+ *       extensibility.
+ * </ul>
+ *
+ * @since 0.7
+ */
+public class AuthenticationFactory {
+    private static final String CLIENT_AUTHENTICATOR_PREFIX = "client.security.";
+    private static final String SERVER_AUTHENTICATOR_PREFIX = "security.";
+
+    /**
+     * Loads a supplier for a client authenticator based on the configuration.
+     *
+     * @param configuration The configuration containing authentication settings and protocol
+     *     definitions.
+     * @return A supplier for creating the client authenticator.
+     */
+    public static Supplier<ClientAuthenticator> loadClientAuthenticatorSupplier(
+            Configuration configuration) {
+        String clientAuthenticateProtocol =
+                configuration.getString(ConfigOptions.CLIENT_SECURITY_PROTOCOL);
+        ClientAuthenticationPlugin authenticatorPlugin =
+                discoverPlugin(
+                        configuration,
+                        clientAuthenticateProtocol,
+                        ClientAuthenticationPlugin.class);
+
+        Map<String, String> allConfig = configuration.toMap();
+        Map<String, String> authConfig = new HashMap<>();
+        String prefix = CLIENT_AUTHENTICATOR_PREFIX + clientAuthenticateProtocol + ".";
+        allConfig
+                .keySet()
+                .forEach(
+                        key -> {
+                            if (key.startsWith(prefix)) {
+                                authConfig.put(key.substring(prefix.length()), allConfig.get(key));
+                            }
+                        });
+
+        return () ->
+                authenticatorPlugin.createClientAuthenticator(Configuration.fromMap(authConfig));
+    }
+
+    /**
+     * Loads suppliers for server authenticators for each endpoint, based on listener-specific
+     * protocols.
+     *
+     * @param configuration The configuration containing authentication settings and protocol
+     *     definitions.
+     * @return A map mapping listener names to suppliers for their corresponding server
+     *     authenticators.
+     */
+    public static Map<String, Supplier<ServerAuthenticator>> loadServerAuthenticatorSuppliers(
+            Configuration configuration) {
+
+        Map<String, Supplier<ServerAuthenticator>> serverAuthenticators = new HashMap<>();
+        Map<String, String> protocolMap =
+                configuration.getMap(ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP);
+        Map<String, String> allConfigMap = configuration.toMap();
+
+        for (Map.Entry<String, String> protocolEntry : protocolMap.entrySet()) {
+
+            String serverAuthenticateProtocol = protocolEntry.getValue();
+            ServerAuthenticationPlugin serverAuthenticatorPlugin =
+                    discoverPlugin(
+                            configuration,
+                            serverAuthenticateProtocol,
+                            ServerAuthenticationPlugin.class);
+
+            // get the protocol config.
+            Map<String, String> authConfigMap = new HashMap<>();
+            String prefix = SERVER_AUTHENTICATOR_PREFIX + serverAuthenticateProtocol + ".";
+            allConfigMap
+                    .keySet()
+                    .forEach(
+                            key -> {
+                                if (key.startsWith(prefix)) {
+                                    authConfigMap.put(
+                                            key.substring(prefix.length()), allConfigMap.get(key));
+                                }
+                            });
+            Configuration authConfig = Configuration.fromMap(authConfigMap);
+            serverAuthenticators.put(
+                    protocolEntry.getKey(),
+                    () -> serverAuthenticatorPlugin.createServerAuthenticator(authConfig));
+        }
+        return serverAuthenticators;
+    }
+
+    /**
+     * Discovers an authentication plugin of the specified type and protocol from the classpath and
+     * configured plugins.
+     *
+     * @param configuration The configuration used to initialize the plugin manager.
+     * @param protocol The protocol name (e.g., "PLAINTEXT", "SASL_PLAIN") to match the plugin's
+     *     {@link AuthenticationPlugin#authProtocol()}.
+     * @return The discovered plugin instance.
+     * @throws ValidationException If no plugin or multiple plugins match the given protocol and
+     *     interface.
+     */
+    @SuppressWarnings("unchecked")
+    private static <T extends AuthenticationPlugin> T discoverPlugin(
+            Configuration configuration, String protocol, Class<T> pluginInterface) {
+        PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
+        Collection<Supplier<Iterator<AuthenticationPlugin>>> pluginSuppliers = new ArrayList<>(2);
+        pluginSuppliers.add(() -> ServiceLoader.load(AuthenticationPlugin.class).iterator());
+        pluginSuppliers.add(() -> pluginManager.load(AuthenticationPlugin.class));
+
+        List<T> matchingPlugins = new ArrayList<>();
+        for (Supplier<Iterator<AuthenticationPlugin>> pluginIteratorsSupplier : pluginSuppliers) {
+            final Iterator<AuthenticationPlugin> foundPlugins = pluginIteratorsSupplier.get();
+            while (foundPlugins.hasNext()) {
+                AuthenticationPlugin plugin = foundPlugins.next();
+                if (plugin.authProtocol().equals(protocol)
+                        && pluginInterface.isAssignableFrom(plugin.getClass())) {
+                    matchingPlugins.add((T) plugin);
+                }
+            }
+        }
+        if (matchingPlugins.size() != 1) {
+            throw new ValidationException(
+                    String.format(
+                            "Could not find same authenticator plugin for protocol '%s' in the classpath.\n\n"
+                                    + "Available factory protocols are:\n\n"
+                                    + "%s",
+                            protocol,
+                            matchingPlugins.stream()
+                                    .map(f -> f.getClass().getName())
+                                    .distinct()
+                                    .sorted()
+                                    .collect(Collectors.joining("\n"))));
+        }
+
+        return matchingPlugins.get(0);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
@@ -68,11 +68,7 @@ public class AuthenticationFactory {
         String clientAuthenticateProtocol =
                 configuration.getString(ConfigOptions.CLIENT_SECURITY_PROTOCOL);
         ClientAuthenticationPlugin authenticatorPlugin =
-                discoverPlugin(
-                        configuration,
-                        clientAuthenticateProtocol,
-                        ClientAuthenticationPlugin.class,
-                        null);
+                discoverPlugin(clientAuthenticateProtocol, ClientAuthenticationPlugin.class, null);
         return () -> authenticatorPlugin.createClientAuthenticator(configuration);
     }
 
@@ -87,17 +83,14 @@ public class AuthenticationFactory {
      */
     public static Map<String, Supplier<ServerAuthenticator>> loadServerAuthenticatorSuppliers(
             Configuration configuration) {
-
         PluginManager pluginManager = PluginUtils.createPluginManagerFromRootFolder(configuration);
         Map<String, Supplier<ServerAuthenticator>> serverAuthenticators = new HashMap<>();
         Map<String, String> protocolMap =
                 configuration.getMap(ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP);
         for (Map.Entry<String, String> protocolEntry : protocolMap.entrySet()) {
-
             String serverAuthenticateProtocol = protocolEntry.getValue();
             ServerAuthenticationPlugin serverAuthenticatorPlugin =
                     discoverPlugin(
-                            configuration,
                             serverAuthenticateProtocol,
                             ServerAuthenticationPlugin.class,
                             pluginManager);
@@ -113,7 +106,6 @@ public class AuthenticationFactory {
      * Discovers an authentication plugin of the specified type and protocol from the classpath and
      * configured plugins.
      *
-     * @param configuration The configuration used to initialize the plugin manager.
      * @param protocol The protocol name (e.g., "PLAINTEXT", "SASL_PLAIN") to match the plugin's
      *     {@link AuthenticationPlugin#authProtocol()}.
      * @return The discovered plugin instance.
@@ -122,10 +114,7 @@ public class AuthenticationFactory {
      */
     @SuppressWarnings("unchecked")
     private static <T extends AuthenticationPlugin> T discoverPlugin(
-            Configuration configuration,
-            String protocol,
-            Class<T> pluginInterface,
-            @Nullable PluginManager pluginManager) {
+            String protocol, Class<T> pluginInterface, @Nullable PluginManager pluginManager) {
 
         Collection<Supplier<Iterator<AuthenticationPlugin>>> pluginSuppliers = new ArrayList<>(2);
         pluginSuppliers.add(() -> ServiceLoader.load(AuthenticationPlugin.class).iterator());
@@ -138,7 +127,7 @@ public class AuthenticationFactory {
             final Iterator<AuthenticationPlugin> foundPlugins = pluginIteratorsSupplier.get();
             while (foundPlugins.hasNext()) {
                 AuthenticationPlugin plugin = foundPlugins.next();
-                if (plugin.authProtocol().equals(protocol)
+                if (plugin.authProtocol().equalsIgnoreCase(protocol)
                         && pluginInterface.isAssignableFrom(plugin.getClass())) {
                     matchingPlugins.add((T) plugin);
                 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationPlugin.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.plugin.Plugin;
+
+/**
+ * The AuthenticationPlugin interface defines a contract for authentication mechanisms in the Fluss
+ * RPC system. Implementations of this interface provide specific authentication protocols (e.g.,
+ * PLAINTEXT, AK-SK) and must be registered via the Service Provider Interface (SPI) mechanism to be
+ * discoverable by the system.
+ *
+ * @since 0.7
+ */
+public interface AuthenticationPlugin extends Plugin {
+    /**
+     * Returns the authentication protocol identifier for this plugin (e.g., "PLAINTEXT", "AK-SK").
+     * This identifier is used by the system to match plugins with configuration settings and select
+     * the appropriate authentication mechanism.
+     *
+     * <p>It is typically configured via:
+     *
+     * <ul>
+     *   <li>{@link com.alibaba.fluss.config.ConfigOptions#CLIENT_SECURITY_PROTOCOL} for client-side
+     *       authentication.
+     *   <li>{@link com.alibaba.fluss.config.ConfigOptions#SERVER_SECURITY_PROTOCOL_MAP} for server
+     *       listener-specific authentication.
+     * </ul>
+     *
+     * @return The protocol name (e.g., "PLAINTEXT").
+     */
+    String authProtocol();
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticationPlugin.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+
+/**
+ * Defines the client-side authentication plugin interface for implementing protocol-specific
+ * identity validation logic.
+ *
+ * <p>The protocol type is specified via {@link
+ * com.alibaba.fluss.config.ConfigOptions#CLIENT_SECURITY_PROTOCOL}, and configuration parameters
+ * must be prefixed with {@code client.security.${protocol}}.
+ */
+public interface ClientAuthenticationPlugin extends AuthenticationPlugin {
+    /**
+     * Creates a client-side authenticator instance for this authentication protocol.
+     *
+     * @return A new client authenticator instance implementing the protocol defined by {@link
+     *     #authProtocol()}
+     */
+    ClientAuthenticator createClientAuthenticator(Configuration configuration);
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+/** Authenticator for client side. */
+public interface ClientAuthenticator {
+
+    String protocol();
+
+    byte[] authenticate(byte[] data);
+
+    boolean isComplete();
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
@@ -16,12 +16,65 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.exception.AuthenticationException;
+
+import javax.annotation.Nullable;
+
 /** Authenticator for client side. */
 public interface ClientAuthenticator {
 
+    /**
+     * The protocol name of the authenticator, which will send in the AuthenticateRequest.
+     *
+     * @return
+     */
     String protocol();
 
-    byte[] authenticate(byte[] data);
+    /**
+     * * Generates the initial token or calculates a token based on the server's challenge, then
+     * sends it back to the server. This method sets the client authentication status as complete if
+     * the authentication succeeds. <br>
+     * If this method returns `null`, it indicates that both the client and server have completed
+     * authentication, and no further token exchange is required.
+     *
+     * <p>Below are examples illustrating the design rationale:
+     *
+     * <p>1. **Username and Password Authentication (One-Way Authentication):** <br>
+     * - Client → Server: Sends an initial token containing the username and password, marking the
+     * client authentication as complete. <br>
+     * - Server verifies the token and sets its status as complete. <br>
+     * - Server → Client: Responds with success or failure.
+     *
+     * <p>2. **GSS-KRB5 Authentication (Two-Way Authentication with a Third-Party Authentication
+     * Server):** <br>
+     * - Client → Server: Sends an initial token calculated using the client's ticket. <br>
+     * - Server verifies the client's ticket and generates a challenge based on the client's token
+     * and the server's ticket. <br>
+     * - Server → Client: Sends the challenge. <br>
+     * - Client verifies the server's ticket, sets its status as complete, and calculates a response
+     * token. <br>
+     * - Client → Server: Sends the response token. <br>
+     * - Server verifies the token, sets its status as complete, and responds with success or
+     * failure.
+     *
+     * <p>3. **SCRAM-SHA-256 Authentication (Two-Way Authentication without a Third-Party
+     * Authentication Server):** <br>
+     * - Client → Server: Sends an initial token containing a random string. <br>
+     * - Server verifies the token format and responds with a salt value. <br>
+     * - Server → Client: Sends the salt value. <br>
+     * - Client → Server: Encrypts the password with the salt and sends the result. <br>
+     * - Server verifies the token, sets its status as complete, and sends a signature challenge.
+     * <br>
+     * - Server → Client: Sends the server's signature. <br>
+     * - Client verifies the signature, sets its status as complete, and returns `null` to indicate
+     * no further token exchange is needed.
+     *
+     * @param data The initial token or server's challenge.
+     * @return The token to send back to the server, or `null` if authentication is complete.
+     */
+    @Nullable
+    byte[] authenticate(byte[] data) throws AuthenticationException;
 
-    boolean isComplete();
+    /** Checks if the authentication from client side is completed. */
+    boolean isCompleted();
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
@@ -23,11 +23,7 @@ import javax.annotation.Nullable;
 /** Authenticator for client side. */
 public interface ClientAuthenticator {
 
-    /**
-     * The protocol name of the authenticator, which will send in the AuthenticateRequest.
-     *
-     * @return
-     */
+    /** The protocol name of the authenticator, which will send in the AuthenticateRequest. */
     String protocol();
 
     /**

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+
+/** Authentication Plugin for PLAINTEXT which not need to do authentication. */
+public class PlainTextAuthenticationPlugin
+        implements ServerAuthenticationPlugin, ClientAuthenticationPlugin {
+    private static final String AUTH_PROTOCOL = "PLAINTEXT";
+
+    @Override
+    public String authProtocol() {
+        return AUTH_PROTOCOL;
+    }
+
+    @Override
+    public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        return new PlainTextClientAuthenticator();
+    }
+
+    @Override
+    public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
+        return new PlainTextServerAuthenticator();
+    }
+
+    /** Client Authenticator for PLAINTEXT which not need to do authentication. */
+    public static class PlainTextClientAuthenticator implements ClientAuthenticator {
+        @Override
+        public String protocol() {
+            return AUTH_PROTOCOL;
+        }
+
+        @Override
+        public byte[] authenticate(byte[] data) {
+            return null;
+        }
+
+        @Override
+        public boolean isComplete() {
+            return true;
+        }
+    }
+
+    /** Server Authenticator for PLAINTEXT which not need to do authentication. */
+    public static class PlainTextServerAuthenticator implements ServerAuthenticator {
+
+        @Override
+        public String protocol() {
+            return AUTH_PROTOCOL;
+        }
+
+        @Override
+        public byte[] evaluateResponse(byte[] token) {
+            return new byte[0];
+        }
+
+        @Override
+        public boolean isComplete() {
+            return true;
+        }
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.security.auth;
 
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
 
 /** Authentication Plugin for PLAINTEXT which not need to do authentication. */
 public class PlainTextAuthenticationPlugin
@@ -46,12 +47,12 @@ public class PlainTextAuthenticationPlugin
         }
 
         @Override
-        public byte[] authenticate(byte[] data) {
+        public byte[] authenticate(byte[] data) throws AuthenticationException {
             return null;
         }
 
         @Override
-        public boolean isComplete() {
+        public boolean isCompleted() {
             return true;
         }
     }
@@ -70,7 +71,7 @@ public class PlainTextAuthenticationPlugin
         }
 
         @Override
-        public boolean isComplete() {
+        public boolean isCompleted() {
             return true;
         }
     }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+
+/**
+ * Defines the server-side authentication plugin interface for implementing protocol-specific
+ * identity validation logic.
+ *
+ * <p>The protocol type is specified via {@link
+ * com.alibaba.fluss.config.ConfigOptions#SERVER_SECURITY_PROTOCOL_MAP}, and configuration
+ * parameters must be prefixed with {@code security.${protocol}}.
+ */
+public interface ServerAuthenticationPlugin extends AuthenticationPlugin {
+
+    /**
+     * Creates a server-side authenticator instance for this authentication protocol.
+     *
+     * @return A new server authenticator instance implementing the protocol defined by {@link
+     *     #authProtocol()}
+     */
+    ServerAuthenticator createServerAuthenticator(Configuration configuration);
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.exception.AuthenticationException;
+
+/** Authenticator for server side. */
+public interface ServerAuthenticator {
+
+    String protocol();
+
+    byte[] evaluateResponse(byte[] token) throws AuthenticationException;
+
+    boolean isComplete();
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
@@ -23,7 +23,47 @@ public interface ServerAuthenticator {
 
     String protocol();
 
+    /**
+     * * Generates the challenge based on the client's token, then sends it back to the client. This
+     * method sets the server authentication status as complete if the authentication succeeds.
+     *
+     * <p>Below are examples illustrating the design rationale:
+     *
+     * <p>1. **Username and Password Authentication (One-Way Authentication):** <br>
+     * - Client → Server: Sends an initial token containing the username and password, marking the
+     * client authentication as complete. <br>
+     * - Server verifies the token and sets its status as complete. <br>
+     * - Server → Client: Responds with success or failure.
+     *
+     * <p>2. **GSS-KRB5 Authentication (Two-Way Authentication with a Third-Party Authentication
+     * Server):** <br>
+     * - Client → Server: Sends an initial token calculated using the client's ticket. <br>
+     * - Server verifies the client's ticket and generates a challenge based on the client's token
+     * and the server's ticket. <br>
+     * - Server → Client: Sends the challenge. <br>
+     * - Client verifies the server's ticket, sets its status as complete, and calculates a response
+     * token. <br>
+     * - Client → Server: Sends the response token. <br>
+     * - Server verifies the token, sets its status as complete, and responds with success or
+     * failure.
+     *
+     * <p>3. **SCRAM-SHA-256 Authentication (Two-Way Authentication without a Third-Party
+     * Authentication Server):** <br>
+     * - Client → Server: Sends an initial token containing a random string. <br>
+     * - Server verifies the token format and responds with a salt value. <br>
+     * - Server → Client: Sends the salt value. <br>
+     * - Client → Server: Encrypts the password with the salt and sends the result. <br>
+     * - Server verifies the token, sets its status as complete, and sends a signature challenge.
+     * <br>
+     * - Server → Client: Sends the server's signature. <br>
+     * - Client verifies the signature, sets its status as complete, and returns `null` to indicate
+     * no further token exchange is needed.
+     *
+     * @param token the token sent by the client.
+     * @return The challenge to send back to the server.
+     */
     byte[] evaluateResponse(byte[] token) throws AuthenticationException;
 
-    boolean isComplete();
+    /** Checks if the authentication from server side is completed. */
+    boolean isCompleted();
 }

--- a/fluss-common/src/main/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
+++ b/fluss-common/src/main/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+com.alibaba.fluss.security.auth.PlainTextAuthenticationPlugin

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/AuthenticationFactoryTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/AuthenticationFactoryTest.java
@@ -18,9 +18,12 @@ package com.alibaba.fluss.security.auth;
 
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metadata.ValidationException;
+import com.alibaba.fluss.security.auth.TestIdentifierAuthenticationPlugin.TestIdentifierClientAuthenticator;
+import com.alibaba.fluss.security.auth.TestIdentifierAuthenticationPlugin.TestIdentifierServerAuthenticator;
 
 import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link AuthenticationFactory}. */
@@ -61,5 +64,34 @@ public class AuthenticationFactoryTest {
                         () -> AuthenticationFactory.loadServerAuthenticatorSuppliers(configuration))
                 .isExactlyInstanceOf(ValidationException.class)
                 .hasMessageContaining(errorMsg);
+    }
+
+    @Test
+    void testIdentifierCaseInsensitive() {
+        Configuration configuration = new Configuration();
+        configuration.setString("client.security.protocol", "SSL_TEST");
+        configuration.setString("security.protocol.map", "FLUSS:SSL_TEST");
+        assertThat(AuthenticationFactory.loadClientAuthenticatorSupplier(configuration).get())
+                .isInstanceOf(TestIdentifierClientAuthenticator.class);
+        assertThat(
+                        AuthenticationFactory.loadServerAuthenticatorSuppliers(configuration)
+                                .values().stream()
+                                .findAny()
+                                .get()
+                                .get())
+                .isInstanceOf(TestIdentifierServerAuthenticator.class);
+
+        Configuration configuration2 = new Configuration();
+        configuration2.setString("client.security.protocol", "ssl_test");
+        configuration2.setString("security.protocol.map", "FLUSS:ssl_test");
+        assertThat(AuthenticationFactory.loadClientAuthenticatorSupplier(configuration2).get())
+                .isInstanceOf(TestIdentifierClientAuthenticator.class);
+        assertThat(
+                        AuthenticationFactory.loadServerAuthenticatorSuppliers(configuration)
+                                .values().stream()
+                                .findAny()
+                                .get()
+                                .get())
+                .isInstanceOf(TestIdentifierServerAuthenticator.class);
     }
 }

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/AuthenticationFactoryTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/AuthenticationFactoryTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.ValidationException;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link AuthenticationFactory}. */
+public class AuthenticationFactoryTest {
+
+    @Test
+    void testConflictingAuthenticationPlugin() {
+        Configuration configuration = new Configuration();
+        configuration.setString("client.security.protocol", "conflicting");
+        configuration.setString("security.protocol.map", "FLUSS:conflicting");
+        String errorMsg =
+                "Multiple plugins for the same protocol 'conflicting' are found in the classpath.\n\n"
+                        + "Available plugins are:\n\n"
+                        + "com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin1\n"
+                        + "com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin2";
+        assertThatThrownBy(
+                        () -> AuthenticationFactory.loadClientAuthenticatorSupplier(configuration))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining(errorMsg);
+        assertThatThrownBy(
+                        () -> AuthenticationFactory.loadServerAuthenticatorSuppliers(configuration))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining(errorMsg);
+    }
+
+    @Test
+    void testNoAuthenticationPlugin() {
+        Configuration configuration = new Configuration();
+        configuration.setString("client.security.protocol", "no_authentication");
+        configuration.setString("security.protocol.map", "FLUSS:no_authentication");
+        String errorMsg =
+                "No plugin for the protocol 'no_authentication' is found in the classpath.";
+        assertThatThrownBy(
+                        () -> AuthenticationFactory.loadClientAuthenticatorSupplier(configuration))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining(errorMsg);
+        assertThatThrownBy(
+                        () -> AuthenticationFactory.loadServerAuthenticatorSuppliers(configuration))
+                .isExactlyInstanceOf(ValidationException.class)
+                .hasMessageContaining(errorMsg);
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestConflictingAuthenticationPlugin1.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestConflictingAuthenticationPlugin1.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+
+/**
+ * A {@link AuthenticationPlugin} that is conflicting with the {@link
+ * TestConflictingAuthenticationPlugin2}.
+ */
+public class TestConflictingAuthenticationPlugin1
+        implements ClientAuthenticationPlugin, ServerAuthenticationPlugin {
+
+    public String authProtocol() {
+        return "conflicting";
+    }
+
+    @Override
+    public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
+        return null;
+    }
+
+    public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        return null;
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestConflictingAuthenticationPlugin2.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestConflictingAuthenticationPlugin2.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+/**
+ * A {@link AuthenticationPlugin} that is conflicting with the {@link
+ * TestConflictingAuthenticationPlugin1}.
+ */
+public class TestConflictingAuthenticationPlugin2 extends TestConflictingAuthenticationPlugin1 {}

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestIdentifierAuthenticationPlugin.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestIdentifierAuthenticationPlugin.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.security.auth;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
+
+import javax.annotation.Nullable;
+
+/** A {@link AuthenticationPlugin} that is used to test authentication plugin identifier. */
+public class TestIdentifierAuthenticationPlugin
+        implements ClientAuthenticationPlugin, ServerAuthenticationPlugin {
+
+    public String authProtocol() {
+        return "SSL_TEST";
+    }
+
+    @Override
+    public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
+        return new TestIdentifierServerAuthenticator();
+    }
+
+    public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        return new TestIdentifierClientAuthenticator();
+    }
+
+    /** A {@link ClientAuthenticator} that is used to test authentication plugin identifier. */
+    public static class TestIdentifierClientAuthenticator implements ClientAuthenticator {
+
+        @Override
+        public String protocol() {
+            return "SSL_TEST";
+        }
+
+        @Nullable
+        @Override
+        public byte[] authenticate(byte[] data) throws AuthenticationException {
+            return null;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return true;
+        }
+    }
+
+    /** A {@link ServerAuthenticator} that is used to test authentication plugin identifier. */
+    public static class TestIdentifierServerAuthenticator implements ServerAuthenticator {
+        @Override
+        public String protocol() {
+            return "SSL_TEST";
+        }
+
+        @Override
+        public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
+            return null;
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return true;
+        }
+    }
+}

--- a/fluss-common/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
+++ b/fluss-common/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2025 Alibaba Group Holding Ltd.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-com.alibaba.fluss.rpc.netty.authenticate.UsernamePasswordAuthenticationPlugin
-com.alibaba.fluss.rpc.netty.authenticate.MutualAuthenticationPlugin
+com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin1
+com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin2

--- a/fluss-common/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
+++ b/fluss-common/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
@@ -14,3 +14,4 @@
 
 com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin1
 com.alibaba.fluss.security.auth.TestConflictingAuthenticationPlugin2
+com.alibaba.fluss.security.auth.TestIdentifierAuthenticationPlugin

--- a/fluss-flink/fluss-flink-1.18/pom.xml
+++ b/fluss-flink/fluss-flink-1.18/pom.xml
@@ -115,6 +115,14 @@
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba.fluss</groupId>
+            <artifactId>fluss-rpc</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- for curator TestingServer  -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/fluss-flink/fluss-flink-1.19/pom.xml
+++ b/fluss-flink/fluss-flink-1.19/pom.xml
@@ -108,6 +108,14 @@
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba.fluss</groupId>
+            <artifactId>fluss-rpc</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- for curator TestingServer  -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/fluss-flink/fluss-flink-1.20/pom.xml
+++ b/fluss-flink/fluss-flink-1.20/pom.xml
@@ -107,6 +107,14 @@
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba.fluss</groupId>
+            <artifactId>fluss-rpc</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- for curator TestingServer  -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/fluss-flink/fluss-flink-common/pom.xml
+++ b/fluss-flink/fluss-flink-common/pom.xml
@@ -124,6 +124,14 @@
             <type>test-jar</type>
         </dependency>
 
+        <dependency>
+            <groupId>com.alibaba.fluss</groupId>
+            <artifactId>fluss-rpc</artifactId>
+            <scope>test</scope>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+        </dependency>
+
         <!-- for curator TestingServer  -->
         <dependency>
             <groupId>org.apache.curator</groupId>

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalog.java
@@ -94,18 +94,20 @@ public class FlinkCatalog implements Catalog {
     protected final String bootstrapServers;
     protected Connection connection;
     protected Admin admin;
-
     private volatile @Nullable LakeCatalog lakeCatalog;
+    private final Map<String, String> securityConfigs;
 
     public FlinkCatalog(
             String name,
             @Nullable String defaultDatabase,
             String bootstrapServers,
-            ClassLoader classLoader) {
+            ClassLoader classLoader,
+            Map<String, String> securityConfigs) {
         this.catalogName = name;
         this.defaultDatabase = defaultDatabase;
         this.bootstrapServers = bootstrapServers;
         this.classLoader = classLoader;
+        this.securityConfigs = securityConfigs;
     }
 
     @Override
@@ -115,9 +117,11 @@ public class FlinkCatalog implements Catalog {
 
     @Override
     public void open() throws CatalogException {
-        Configuration flussConfigs = new Configuration();
-        flussConfigs.setString(ConfigOptions.BOOTSTRAP_SERVERS.key(), bootstrapServers);
-        connection = ConnectionFactory.createConnection(flussConfigs);
+        Map<String, String> flussConfigs = new HashMap<>();
+        flussConfigs.put(ConfigOptions.BOOTSTRAP_SERVERS.key(), bootstrapServers);
+        flussConfigs.putAll(securityConfigs);
+
+        connection = ConnectionFactory.createConnection(Configuration.fromMap(flussConfigs));
         admin = connection.getAdmin();
     }
 
@@ -282,6 +286,7 @@ public class FlinkCatalog implements Catalog {
             // add bootstrap servers option
             Map<String, String> newOptions = new HashMap<>(catalogTable.getOptions());
             newOptions.put(BOOTSTRAP_SERVERS.key(), bootstrapServers);
+            newOptions.putAll(securityConfigs);
             return catalogTable.copy(newOptions);
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalog.java
@@ -92,10 +92,10 @@ public class FlinkCatalog implements Catalog {
     protected final String catalogName;
     protected final @Nullable String defaultDatabase;
     protected final String bootstrapServers;
+    private final Map<String, String> securityConfigs;
     protected Connection connection;
     protected Admin admin;
     private volatile @Nullable LakeCatalog lakeCatalog;
-    private final Map<String, String> securityConfigs;
 
     public FlinkCatalog(
             String name,

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalogFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalogFactory.java
@@ -23,7 +23,11 @@ import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+
+import static com.alibaba.fluss.config.FlussConfigUtils.CLIENT_SECURITY_PREFIX;
 
 /** Factory for {@link FlinkCatalog}. */
 public class FlinkCatalogFactory implements CatalogFactory {
@@ -49,12 +53,21 @@ public class FlinkCatalogFactory implements CatalogFactory {
     public FlinkCatalog createCatalog(Context context) {
         final FactoryUtil.CatalogFactoryHelper helper =
                 FactoryUtil.createCatalogFactoryHelper(this, context);
-        helper.validate();
+        helper.validateExcept(CLIENT_SECURITY_PREFIX);
+        Map<String, String> options = context.getOptions();
+        Map<String, String> securityConfigs = new HashMap<>();
+        options.forEach(
+                (key, value) -> {
+                    if (key.startsWith(CLIENT_SECURITY_PREFIX)) {
+                        securityConfigs.put(key, value);
+                    }
+                });
 
         return new FlinkCatalog(
                 context.getName(),
                 helper.getOptions().get(FlinkCatalogOptions.DEFAULT_DATABASE),
                 helper.getOptions().get(FlinkConnectorOptions.BOOTSTRAP_SERVERS),
-                context.getClassLoader());
+                context.getClassLoader(),
+                securityConfigs);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalogFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkCatalogFactory.java
@@ -23,11 +23,11 @@ import org.apache.flink.table.factories.CatalogFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import static com.alibaba.fluss.config.FlussConfigUtils.CLIENT_SECURITY_PREFIX;
+import static com.alibaba.fluss.utils.PropertiesUtils.extractPrefix;
 
 /** Factory for {@link FlinkCatalog}. */
 public class FlinkCatalogFactory implements CatalogFactory {
@@ -55,13 +55,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
                 FactoryUtil.createCatalogFactoryHelper(this, context);
         helper.validateExcept(CLIENT_SECURITY_PREFIX);
         Map<String, String> options = context.getOptions();
-        Map<String, String> securityConfigs = new HashMap<>();
-        options.forEach(
-                (key, value) -> {
-                    if (key.startsWith(CLIENT_SECURITY_PREFIX)) {
-                        securityConfigs.put(key, value);
-                    }
-                });
+        Map<String, String> securityConfigs = extractPrefix(options, CLIENT_SECURITY_PREFIX);
 
         return new FlinkCatalog(
                 context.getName(),

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkTableFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/catalog/FlinkTableFactory.java
@@ -18,7 +18,6 @@ package com.alibaba.fluss.flink.catalog;
 
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.config.FlussConfigUtils;
 import com.alibaba.fluss.flink.FlinkConnectorOptions;
 import com.alibaba.fluss.flink.lakehouse.LakeTableFactory;
 import com.alibaba.fluss.flink.sink.FlinkTableSink;
@@ -54,7 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static com.alibaba.fluss.config.FlussConfigUtils.CLIENT_SECURITY_PREFIX;
+import static com.alibaba.fluss.config.FlussConfigUtils.CLIENT_PREFIX;
 import static com.alibaba.fluss.flink.catalog.FlinkCatalog.LAKE_TABLE_SPLITTER;
 import static com.alibaba.fluss.flink.utils.FlinkConnectorOptionsUtils.getBucketKeyIndexes;
 import static com.alibaba.fluss.flink.utils.FlinkConnectorOptionsUtils.getBucketKeys;
@@ -214,8 +213,7 @@ public class FlinkTableFactory implements DynamicTableSourceFactory, DynamicTabl
         // forward all client configs
         tableOptions.forEach(
                 (key, value) -> {
-                    if (FlussConfigUtils.CLIENT_OPTIONS.containsKey(key)
-                            || key.startsWith(CLIENT_SECURITY_PREFIX)) {
+                    if (key.startsWith(CLIENT_PREFIX)) {
                         flussConfig.setString(key, value);
                     }
                 });

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.flink.catalog;
 
+import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metadata.TablePath;
@@ -46,6 +47,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.alibaba.fluss.config.ConfigOptions.DEFAULT_LISTENER_NAME;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BUCKET_KEY;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BUCKET_NUMBER;
@@ -75,7 +77,8 @@ abstract class FlinkCatalogITCase {
                         CATALOG_NAME,
                         DEFAULT_DB,
                         bootstrapServers,
-                        Thread.currentThread().getContextClassLoader());
+                        Thread.currentThread().getContextClassLoader(),
+                        Collections.emptyMap());
         catalog.open();
         // create table environment
         tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
@@ -419,6 +422,69 @@ abstract class FlinkCatalogITCase {
                 .cause()
                 .isInstanceOf(ValidationException.class)
                 .hasMessageContaining("Unsupported options found for 'fluss'");
+    }
+
+    @Test
+    void testAuthentication() throws Exception {
+        String clientListenerName = "CLIENT";
+        Configuration serverConfig = new Configuration();
+        serverConfig.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:username_password");
+        serverConfig.setString("security.username_password.username", "root");
+        serverConfig.setString("security.username_password.password", "password");
+        FlussClusterExtension flussClusterExtension =
+                FlussClusterExtension.builder()
+                        .setCoordinatorServerListeners(
+                                String.format(
+                                        "%s://localhost:0, %s://localhost:0",
+                                        DEFAULT_LISTENER_NAME, clientListenerName))
+                        .setTabletServerListeners(
+                                String.format(
+                                        "%s://localhost:0, %s://localhost:0",
+                                        DEFAULT_LISTENER_NAME, clientListenerName))
+                        .setClusterConf(serverConfig)
+                        .build();
+        Catalog authenticateCatalog = null;
+        try {
+            flussClusterExtension.start();
+            ServerNode coordinatorServerNode =
+                    flussClusterExtension.getCoordinatorServerNode(clientListenerName);
+            String bootstrapServers =
+                    String.format(
+                            "%s:%d", coordinatorServerNode.host(), coordinatorServerNode.port());
+            authenticateCatalog =
+                    new FlinkCatalog(
+                            CATALOG_NAME,
+                            DEFAULT_DB,
+                            bootstrapServers,
+                            Thread.currentThread().getContextClassLoader(),
+                            Collections.emptyMap());
+            Catalog finalAuthenticateCatalog = authenticateCatalog;
+            assertThatThrownBy(finalAuthenticateCatalog::open)
+                    .cause()
+                    .hasMessageContaining("The connection has not completed authentication yet.");
+
+            Map<String, String> clientConfig = new HashMap<>();
+            clientConfig.put(ConfigOptions.CLIENT_SECURITY_PROTOCOL.key(), "username_password");
+            clientConfig.put("client.security.username_password.username", "root");
+            clientConfig.put("client.security.username_password.password", "password");
+            authenticateCatalog =
+                    new FlinkCatalog(
+                            CATALOG_NAME,
+                            DEFAULT_DB,
+                            bootstrapServers,
+                            Thread.currentThread().getContextClassLoader(),
+                            clientConfig);
+            authenticateCatalog.open();
+            assertThat(authenticateCatalog.listDatabases())
+                    .containsExactlyInAnyOrderElementsOf(Collections.singletonList(DEFAULT_DB));
+
+        } finally {
+            if (authenticateCatalog != null) {
+                authenticateCatalog.close();
+            }
+            flussClusterExtension.close();
+        }
     }
 
     private static void assertOptionsEqual(

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -462,7 +462,8 @@ abstract class FlinkCatalogITCase {
             Catalog finalAuthenticateCatalog = authenticateCatalog;
             assertThatThrownBy(finalAuthenticateCatalog::open)
                     .cause()
-                    .hasMessageContaining("The connection has not completed authentication yet.");
+                    .hasMessageContaining(
+                            "The connection has not completed authentication yet. This may be caused by a missing or incorrect configuration of 'client.security.protocol' on the client side.");
 
             Map<String, String> clientConfig = new HashMap<>();
             clientConfig.put(ConfigOptions.CLIENT_SECURITY_PROTOCOL.key(), "username_password");

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogTest.java
@@ -112,7 +112,8 @@ class FlinkCatalogTest {
                         CATALOG_NAME,
                         DEFAULT_DB,
                         String.join(",", flussConf.get(ConfigOptions.BOOTSTRAP_SERVERS)),
-                        Thread.currentThread().getContextClassLoader());
+                        Thread.currentThread().getContextClassLoader(),
+                        Collections.emptyMap());
         catalog.open();
     }
 

--- a/fluss-kafka/pom.xml
+++ b/fluss-kafka/pom.xml
@@ -82,5 +82,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>fluss-rpc</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/fluss-kafka/src/test/java/com/alibaba/fluss/kafka/KafkaRequestHandlerTest.java
+++ b/fluss-kafka/src/test/java/com/alibaba/fluss/kafka/KafkaRequestHandlerTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.kafka;
 
+import com.alibaba.fluss.rpc.TestingTabletGatewayService;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelHandlerContext;

--- a/fluss-kafka/src/test/java/com/alibaba/fluss/kafka/KafkaRequestITCase.java
+++ b/fluss-kafka/src/test/java/com/alibaba/fluss/kafka/KafkaRequestITCase.java
@@ -21,6 +21,7 @@ import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metrics.groups.MetricGroup;
 import com.alibaba.fluss.metrics.util.NOPMetricsGroup;
+import com.alibaba.fluss.rpc.TestingTabletGatewayService;
 import com.alibaba.fluss.rpc.netty.server.NettyServer;
 import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
 

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGateway.java
@@ -18,8 +18,11 @@ package com.alibaba.fluss.rpc;
 
 import com.alibaba.fluss.rpc.messages.ApiVersionsRequest;
 import com.alibaba.fluss.rpc.messages.ApiVersionsResponse;
+import com.alibaba.fluss.rpc.messages.AuthenticateRequest;
+import com.alibaba.fluss.rpc.messages.AuthenticateResponse;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.RPC;
+import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelHandlerContext;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -29,4 +32,25 @@ public interface RpcGateway {
     /** Returns the APIs and Versions of the RPC Gateway supported. */
     @RPC(api = ApiKeys.API_VERSIONS)
     CompletableFuture<ApiVersionsResponse> apiVersions(ApiVersionsRequest request);
+
+    /**
+     * This method just to registers the AUTHENTICATE API in the API manager for client-side
+     * request/response object generation.
+     *
+     * <p>This method does not handle the authentication logic itself. Instead, the {@link
+     * AuthenticateRequest} is processed preemptively by {@link
+     * com.alibaba.fluss.rpc.netty.server.NettyServerHandler} during the initial connection
+     * handshake. The client uses this method definition to generate corresponding request/response
+     * objects for API version compatibility.
+     *
+     * @param request The authenticate request (not used in this method's implementation).
+     * @return Always returns {@code null} since the actual authentication handling occurs in {@link
+     *     com.alibaba.fluss.rpc.netty.server.NettyServerHandler}.
+     * @see com.alibaba.fluss.rpc.netty.server.NettyServerHandler#channelRead(ChannelHandlerContext,
+     *     Object) For authentication processing implementation.
+     */
+    @RPC(api = ApiKeys.AUTHENTICATE)
+    default CompletableFuture<AuthenticateResponse> authenticate(AuthenticateRequest request) {
+        return CompletableFuture.completedFuture(new AuthenticateResponse());
+    }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGateway.java
@@ -51,6 +51,6 @@ public interface RpcGateway {
      */
     @RPC(api = ApiKeys.AUTHENTICATE)
     default CompletableFuture<AuthenticateResponse> authenticate(AuthenticateRequest request) {
-        return CompletableFuture.completedFuture(new AuthenticateResponse());
+        throw new UnsupportedOperationException("This method should not be called directly.");
     }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/ServerConnection.java
@@ -23,12 +23,15 @@ import com.alibaba.fluss.exception.NetworkException;
 import com.alibaba.fluss.rpc.messages.ApiMessage;
 import com.alibaba.fluss.rpc.messages.ApiVersionsRequest;
 import com.alibaba.fluss.rpc.messages.ApiVersionsResponse;
+import com.alibaba.fluss.rpc.messages.AuthenticateRequest;
+import com.alibaba.fluss.rpc.messages.AuthenticateResponse;
 import com.alibaba.fluss.rpc.metrics.ClientMetricGroup;
 import com.alibaba.fluss.rpc.metrics.ConnectionMetricGroup;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
 import com.alibaba.fluss.rpc.protocol.ApiMethod;
 import com.alibaba.fluss.rpc.protocol.MessageCodec;
+import com.alibaba.fluss.security.auth.ClientAuthenticator;
 import com.alibaba.fluss.shaded.netty4.io.netty.bootstrap.Bootstrap;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
@@ -62,6 +65,7 @@ final class ServerConnection {
     private final Map<Integer, InflightRequest> inflightRequests = MapUtils.newConcurrentHashMap();
     private final CompletableFuture<Void> closeFuture = new CompletableFuture<>();
     private final ConnectionMetricGroup connectionMetricGroup;
+    private final ClientAuthenticator authenticator;
 
     private final Object lock = new Object();
 
@@ -83,13 +87,18 @@ final class ServerConnection {
     @GuardedBy("lock")
     private ServerApiVersions serverApiVersions;
 
-    ServerConnection(Bootstrap bootstrap, ServerNode node, ClientMetricGroup clientMetricGroup) {
+    ServerConnection(
+            Bootstrap bootstrap,
+            ServerNode node,
+            ClientMetricGroup clientMetricGroup,
+            ClientAuthenticator authenticator) {
         this.node = node;
         this.state = ConnectionState.CONNECTING;
-        this.connectionMetricGroup = clientMetricGroup.createConnectionMetricGroup(node.uid());
         bootstrap
                 .connect(node.host(), node.port())
                 .addListener((ChannelFutureListener) this::establishConnection);
+        this.connectionMetricGroup = clientMetricGroup.createConnectionMetricGroup(node.uid());
+        this.authenticator = authenticator;
     }
 
     public ServerNode getServerNode() {
@@ -123,7 +132,8 @@ final class ServerConnection {
                 // the connection has been closed/closing.
                 return closeFuture;
             }
-            state = ConnectionState.DISCONNECTED;
+
+            switchState(ConnectionState.DISCONNECTED);
 
             // when the remote server shutdowns, the exception may be
             // AnnotatedConnectException/ClosedChannelException/
@@ -245,7 +255,7 @@ final class ServerConnection {
                 channel.pipeline()
                         .addLast("handler", new NettyClientHandler(new ResponseCallback()));
                 // start checking api versions
-                state = ConnectionState.CHECKING_API_VERSIONS;
+                switchState(ConnectionState.CHECKING_API_VERSIONS);
                 // TODO: set correct client software name and version, used for metrics in server
                 ApiVersionsRequest request =
                         new ApiVersionsRequest()
@@ -356,7 +366,43 @@ final class ServerConnection {
         synchronized (lock) {
             serverApiVersions =
                     new ServerApiVersions(((ApiVersionsResponse) response).getApiVersionsList());
-            state = ConnectionState.READY;
+            LOG.info("Begin to authenticate with protocol {}", authenticator.protocol());
+            sendAuthenticate(new byte[0]);
+        }
+    }
+
+    private void sendAuthenticate(byte[] challenge) {
+        byte[] token;
+        if (authenticator.isComplete() || (token = authenticator.authenticate(challenge)) == null) {
+            switchState(ConnectionState.READY);
+        } else {
+            switchState(ConnectionState.AUTHENTICATING);
+            AuthenticateRequest request =
+                    new AuthenticateRequest().setToken(token).setProtocol(authenticator.protocol());
+            doSend(ApiKeys.AUTHENTICATE, request, new CompletableFuture<>(), true)
+                    .whenComplete(this::handleAuthenticateResponse);
+        }
+    }
+
+    private void handleAuthenticateResponse(ApiMessage response, Throwable cause) {
+        if (cause != null) {
+            close(cause);
+            return;
+        }
+        if (!(response instanceof AuthenticateResponse)) {
+            close(new IllegalStateException("Unexpected response type " + response.getClass()));
+            return;
+        }
+
+        synchronized (lock) {
+            sendAuthenticate(((AuthenticateResponse) response).getChallenge());
+        }
+    }
+
+    private void switchState(ConnectionState targetState) {
+        LOG.info("switch state form {} to {}", state, targetState);
+        state = targetState;
+        if (targetState == ConnectionState.READY) {
             // process pending requests
             PendingRequest pending;
             while ((pending = pendingRequests.pollFirst()) != null) {
@@ -384,6 +430,7 @@ final class ServerConnection {
     private enum ConnectionState {
         CONNECTING,
         CHECKING_API_VERSIONS,
+        AUTHENTICATING,
         READY,
         DISCONNECTED;
 
@@ -392,7 +439,7 @@ final class ServerConnection {
         }
 
         public boolean isEstablished() {
-            return this == CHECKING_API_VERSIONS || this == READY;
+            return this == CHECKING_API_VERSIONS || this == AUTHENTICATING || this == READY;
         }
 
         public boolean isReady() {

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.netty.server;
+
+import com.alibaba.fluss.annotation.VisibleForTesting;
+import com.alibaba.fluss.cluster.ServerType;
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.rpc.RpcGatewayService;
+import com.alibaba.fluss.rpc.protocol.ApiManager;
+import com.alibaba.fluss.rpc.protocol.NetworkProtocolPlugin;
+import com.alibaba.fluss.security.auth.AuthenticationFactory;
+import com.alibaba.fluss.security.auth.PlainTextAuthenticationPlugin;
+import com.alibaba.fluss.security.auth.ServerAuthenticator;
+import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelHandler;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/** Build-in protocol plugin for Fluss. */
+public class FlussProtocolPlugin implements NetworkProtocolPlugin {
+    public static final String FLUSS_PROTOCOL_NAME = "FLUSS";
+    private final Map<String, Supplier<ServerAuthenticator>> authenticatorSuppliers;
+    private final ApiManager apiManager;
+    private final long maxIdleTimeSeconds;
+    private final List<String> listeners;
+    private final RequestsMetrics requestsMetrics;
+
+    public FlussProtocolPlugin(
+            Configuration conf,
+            ServerType serverType,
+            List<String> listeners,
+            RequestsMetrics requestsMetrics) {
+        authenticatorSuppliers = AuthenticationFactory.loadServerAuthenticatorSuppliers(conf);
+        apiManager = new ApiManager(serverType);
+        maxIdleTimeSeconds = conf.get(ConfigOptions.NETTY_CONNECTION_MAX_IDLE_TIME).getSeconds();
+        this.listeners = listeners;
+        this.requestsMetrics = requestsMetrics;
+    }
+
+    @Override
+    public String name() {
+        return FLUSS_PROTOCOL_NAME;
+    }
+
+    @Override
+    public List<String> listenerNames(Configuration conf) {
+        return listeners;
+    }
+
+    @Override
+    public ChannelHandler createChannelHandler(
+            RequestChannel[] requestChannels, String listenerName) {
+        return new ServerChannelInitializer(
+                requestChannels,
+                apiManager,
+                listenerName,
+                requestsMetrics,
+                maxIdleTimeSeconds,
+                Optional.ofNullable(authenticatorSuppliers.get(listenerName))
+                        .orElse(PlainTextAuthenticationPlugin.PlainTextServerAuthenticator::new));
+    }
+
+    @Override
+    public RequestHandler<?> createRequestHandler(RpcGatewayService service) {
+        return new FlussRequestHandler(service);
+    }
+
+    @VisibleForTesting
+    ApiManager getApiManager() {
+        return apiManager;
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
@@ -47,8 +47,8 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin {
             ServerType serverType,
             List<String> listeners,
             RequestsMetrics requestsMetrics) {
-        authenticatorSuppliers = AuthenticationFactory.loadServerAuthenticatorSuppliers(conf);
-        apiManager = new ApiManager(serverType);
+        this.authenticatorSuppliers = AuthenticationFactory.loadServerAuthenticatorSuppliers(conf);
+        this.apiManager = new ApiManager(serverType);
         maxIdleTimeSeconds = conf.get(ConfigOptions.NETTY_CONNECTION_MAX_IDLE_TIME).getSeconds();
         this.listeners = listeners;
         this.requestsMetrics = requestsMetrics;

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
@@ -17,15 +17,19 @@
 package com.alibaba.fluss.rpc.netty.server;
 
 import com.alibaba.fluss.annotation.VisibleForTesting;
+import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.exception.NetworkException;
 import com.alibaba.fluss.record.send.Send;
 import com.alibaba.fluss.rpc.messages.ApiMessage;
+import com.alibaba.fluss.rpc.messages.AuthenticateRequest;
+import com.alibaba.fluss.rpc.messages.AuthenticateResponse;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.protocol.ApiError;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
 import com.alibaba.fluss.rpc.protocol.ApiMethod;
 import com.alibaba.fluss.rpc.protocol.MessageCodec;
+import com.alibaba.fluss.security.auth.ServerAuthenticator;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelFutureListener;
@@ -45,7 +49,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.alibaba.fluss.rpc.protocol.MessageCodec.encodeErrorResponse;
 import static com.alibaba.fluss.rpc.protocol.MessageCodec.encodeServerFailure;
@@ -66,19 +69,25 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
     private final ApiManager apiManager;
     private final String listenerName;
     private final RequestsMetrics requestsMetrics;
-    private final AtomicBoolean isActive = new AtomicBoolean(true);
     private volatile ChannelHandlerContext ctx;
     private SocketAddress remoteAddress;
+
+    private final ServerAuthenticator authenticator;
+
+    private volatile ConnectionState state;
 
     public NettyServerHandler(
             RequestChannel requestChannel,
             ApiManager apiManager,
             String listenerName,
-            RequestsMetrics requestsMetrics) {
+            RequestsMetrics requestsMetrics,
+            ServerAuthenticator authenticator) {
         this.requestChannel = requestChannel;
         this.apiManager = apiManager;
         this.listenerName = listenerName;
         this.requestsMetrics = requestsMetrics;
+        this.authenticator = authenticator;
+        this.state = ConnectionState.START;
     }
 
     @Override
@@ -125,9 +134,13 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
                     inflightResponseMap.computeIfAbsent(apiKey, k -> new ArrayDeque<>());
             inflightResponses.addLast(request);
             future.whenCompleteAsync((r, t) -> sendResponse(ctx, apiKey), ctx.executor());
-            requestChannel.putRequest(request);
+            if (state.isAuthenticating() && apiKey != ApiKeys.API_VERSIONS.id) {
+                handleAuthenticateRequest(apiKey, requestMessage, future);
+            } else {
+                requestChannel.putRequest(request);
+            }
 
-            if (!isActive.get()) {
+            if (!state.isActive()) {
                 LOG.warn("Received a request on an inactive channel: {}", remoteAddress);
                 request.fail(new NetworkException("Channel is inactive"));
                 needRelease = true;
@@ -148,7 +161,11 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
         super.channelActive(ctx);
         this.ctx = ctx;
         this.remoteAddress = ctx.channel().remoteAddress();
-        isActive.set(true);
+        switchState(
+                authenticator.isComplete()
+                        ? ConnectionState.READY
+                        : ConnectionState.AUTHENTICATING);
+
         // TODO: connection metrics (count, client tags, receive request avg idle time, etc.)
     }
 
@@ -179,13 +196,14 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
                     ctx.channel().remoteAddress(),
                     ExceptionUtils.stringifyException(cause));
         }
+
         ByteBuf byteBuf = encodeServerFailure(ctx.alloc(), ApiError.fromThrowable(cause));
         ctx.writeAndFlush(byteBuf).addListener(ChannelFutureListener.CLOSE);
         close();
     }
 
     private void close() {
-        isActive.set(false);
+        switchState(ConnectionState.CLOSE);
         ctx.close();
         LOG.warn(
                 "Close channel {} with {} pending requests.",
@@ -213,7 +231,7 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
             }
 
             inflightResponses.pollFirst();
-            if (isActive.get()) {
+            if (state.isActive()) {
                 try {
                     ApiMessage response = f.join();
                     sendSuccessResponse(ctx, request, response);
@@ -289,5 +307,63 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
     @VisibleForTesting
     Deque<FlussRequest> inflightResponses(short apiKey) {
         return inflightResponseMap.get(apiKey);
+    }
+
+    private void handleAuthenticateRequest(
+            short apiKey, ApiMessage requestMessage, CompletableFuture<ApiMessage> future) {
+        if (apiKey != ApiKeys.AUTHENTICATE.id) {
+            LOG.warn(
+                    "Connection is still in the authentication process. Unable to handle API key: {}.",
+                    apiKey);
+            future.completeExceptionally(
+                    new AuthenticationException(
+                            "The connection has not completed authentication yet."));
+            return;
+        }
+
+        AuthenticateRequest authenticateRequest = (AuthenticateRequest) requestMessage;
+        if (!authenticator.protocol().equals(authenticateRequest.getProtocol())) {
+            future.completeExceptionally(
+                    new AuthenticationException(
+                            String.format(
+                                    "Authenticate protocol not match: protocol of server is %s while protocol of client is %s",
+                                    authenticator.protocol(), authenticateRequest.getProtocol())));
+            return;
+        }
+
+        AuthenticateResponse authenticateResponse = new AuthenticateResponse();
+        if (!authenticator.isComplete()) {
+            byte[] token = authenticateRequest.getToken();
+            byte[] response =
+                    !authenticator.isComplete()
+                            ? authenticator.evaluateResponse(token)
+                            : new byte[0];
+            authenticateResponse.setChallenge(response);
+        }
+        future.complete(authenticateResponse);
+
+        if (authenticator.isComplete()) {
+            switchState(ConnectionState.READY);
+        }
+    }
+
+    private void switchState(ConnectionState targetState) {
+        LOG.info("switch state form {} to {}", state, targetState);
+        state = targetState;
+    }
+
+    private enum ConnectionState {
+        START,
+        AUTHENTICATING,
+        READY,
+        CLOSE;
+
+        public boolean isActive() {
+            return this == AUTHENTICATING || this == READY;
+        }
+
+        public boolean isAuthenticating() {
+            return this == AUTHENTICATING;
+        }
     }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RequestProcessorPool.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/RequestProcessorPool.java
@@ -114,7 +114,6 @@ final class RequestProcessorPool {
                         .max()
                         .orElseThrow(() -> new IllegalStateException("No response type found."));
         RequestHandler<?>[] requestHandlers = new RequestHandler[maxRequestTypeId + 1];
-        requestHandlers[RequestType.FLUSS.id] = new FlussRequestHandler(service);
         for (NetworkProtocolPlugin protocol : protocolPlugins) {
             RequestHandler<?> requestHandler = protocol.createRequestHandler(service);
             int id = requestHandler.requestType().id;

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -18,11 +18,17 @@ package com.alibaba.fluss.rpc.netty.server;
 
 import com.alibaba.fluss.rpc.netty.NettyLogger;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
+import com.alibaba.fluss.security.auth.ServerAuthenticator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelInitializer;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.SocketChannel;
 import com.alibaba.fluss.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import com.alibaba.fluss.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
 import com.alibaba.fluss.utils.MathUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
 
@@ -31,12 +37,14 @@ import static com.alibaba.fluss.utils.Preconditions.checkArgument;
  * will be used by the server to handle the init request for the client.
  */
 final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
+    private static final Logger LOG = LoggerFactory.getLogger(ServerChannelInitializer.class);
 
     private final int maxIdleTimeSeconds;
     private final RequestChannel[] requestChannels;
     private final ApiManager apiManager;
     private final String endpointListenerName;
     private final RequestsMetrics requestsMetrics;
+    private final Supplier<ServerAuthenticator> authenticatorSupplier;
 
     private static final NettyLogger nettyLogger = new NettyLogger();
 
@@ -45,13 +53,15 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
             ApiManager apiManager,
             String endpointListenerName,
             RequestsMetrics requestsMetrics,
-            long maxIdleTimeSeconds) {
+            long maxIdleTimeSeconds,
+            Supplier<ServerAuthenticator> authenticatorSupplier) {
         checkArgument(maxIdleTimeSeconds <= Integer.MAX_VALUE, "maxIdleTimeSeconds too large");
         this.requestChannels = requestChannels;
         this.apiManager = apiManager;
         this.endpointListenerName = endpointListenerName;
         this.requestsMetrics = requestsMetrics;
         this.maxIdleTimeSeconds = (int) maxIdleTimeSeconds;
+        this.authenticatorSupplier = authenticatorSupplier;
     }
 
     @Override
@@ -70,6 +80,12 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
                         // initialBytesToStrip=0 to include the frame size field after decoding
                         new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 0));
         ch.pipeline().addLast("idle", new IdleStateHandler(0, 0, maxIdleTimeSeconds));
+        ServerAuthenticator serverAuthenticator = authenticatorSupplier.get();
+        LOG.info(
+                "initial a channel for listener {} with protocol {}",
+                endpointListenerName,
+                serverAuthenticator.protocol());
+
         ch.pipeline()
                 .addLast(
                         "handler",
@@ -77,6 +93,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
                                 requestChannels[channelIndex],
                                 apiManager,
                                 endpointListenerName,
-                                requestsMetrics));
+                                requestsMetrics,
+                                serverAuthenticator));
     }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -81,7 +81,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
                         new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 0));
         ch.pipeline().addLast("idle", new IdleStateHandler(0, 0, maxIdleTimeSeconds));
         ServerAuthenticator serverAuthenticator = authenticatorSupplier.get();
-        LOG.info(
+        LOG.debug(
                 "initial a channel for listener {} with protocol {}",
                 endpointListenerName,
                 serverAuthenticator.protocol());

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -64,7 +64,8 @@ public enum ApiKeys {
     PREFIX_LOOKUP(1034, 0, 0, PUBLIC),
     GET_DATABASE_INFO(1035, 0, 0, PUBLIC),
     CREATE_PARTITION(1036, 0, 0, PUBLIC),
-    DROP_PARTITION(1037, 0, 0, PUBLIC);
+    DROP_PARTITION(1037, 0, 0, PUBLIC),
+    AUTHENTICATE(1038, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiManager.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiManager.java
@@ -102,6 +102,13 @@ public class ApiManager {
         return enabledApis;
     }
 
+    @VisibleForTesting
+    public void registerApiMethod(ApiKeys api, Method method, ServerType providerType) {
+        id2Api.put(api.id, createApiMethod(api, method, providerType));
+        enabledApis.addAll(
+                id2Api.values().stream().map(ApiMethod::getApiKey).collect(Collectors.toList()));
+    }
+
     // ----------------------------------------------------------------------------------------
     // Internal Utilities
     // ----------------------------------------------------------------------------------------

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.rpc.protocol;
 
 import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.exception.CorruptMessageException;
 import com.alibaba.fluss.exception.CorruptRecordException;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
@@ -190,7 +191,8 @@ public enum Errors {
             "There is no currently available leader for the given partition.",
             LeaderNotAvailableException::new),
     PARTITION_MAX_NUM_EXCEPTION(
-            45, "Exceed the maximum number of partitions.", TooManyPartitionsException::new);
+            45, "Exceed the maximum number of partitions.", TooManyPartitionsException::new),
+    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -743,3 +743,13 @@ message PbPartitionInfo {
 message PbPartitionSpec {
   repeated PbKeyValue partition_key_values = 1;
 }
+
+message AuthenticateRequest {
+  required string protocol = 1;
+  required bytes token = 2;
+}
+
+message AuthenticateResponse {
+  optional bytes challenge = 1;
+}
+

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -472,6 +472,15 @@ message PbNotifyLakeTableOffsetReqForBucket {
 message NotifyLakeTableOffsetResponse {
 }
 
+message AuthenticateRequest {
+  required string protocol = 1;
+  required bytes token = 2;
+}
+
+message AuthenticateResponse {
+  optional bytes challenge = 1;
+}
+
 // --------------- Inner classes ----------------
 message PbApiVersion {
   required int32 api_key = 1;
@@ -744,12 +753,5 @@ message PbPartitionSpec {
   repeated PbKeyValue partition_key_values = 1;
 }
 
-message AuthenticateRequest {
-  required string protocol = 1;
-  required bytes token = 2;
-}
 
-message AuthenticateResponse {
-  optional bytes challenge = 1;
-}
 

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
@@ -1,26 +1,23 @@
 /*
- *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
  *      http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
-package com.alibaba.fluss.kafka;
+package com.alibaba.fluss.rpc;
 
 import com.alibaba.fluss.cluster.ServerType;
-import com.alibaba.fluss.rpc.RpcGatewayService;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
-import com.alibaba.fluss.rpc.messages.ApiVersionsRequest;
-import com.alibaba.fluss.rpc.messages.ApiVersionsResponse;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsRequest;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsResponse;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
@@ -79,7 +76,8 @@ import com.alibaba.fluss.rpc.messages.UpdateMetadataResponse;
 import java.util.concurrent.CompletableFuture;
 
 /** A testing implementation of the {@link TabletServerGateway} interface. */
-public class TestingTabletGatewayService extends RpcGatewayService implements TabletServerGateway {
+public class TestingTabletGatewayService extends TestingGatewayService
+        implements TabletServerGateway {
     @Override
     public ServerType providerType() {
         return null;
@@ -89,9 +87,6 @@ public class TestingTabletGatewayService extends RpcGatewayService implements Ta
     public String name() {
         return "";
     }
-
-    @Override
-    public void shutdown() {}
 
     @Override
     public CompletableFuture<NotifyLeaderAndIsrResponse> notifyLeaderAndIsr(
@@ -236,11 +231,6 @@ public class TestingTabletGatewayService extends RpcGatewayService implements Ta
     @Override
     public CompletableFuture<GetLatestLakeSnapshotResponse> getLatestLakeSnapshot(
             GetLatestLakeSnapshotRequest request) {
-        return null;
-    }
-
-    @Override
-    public CompletableFuture<ApiVersionsResponse> apiVersions(ApiVersionsRequest request) {
         return null;
     }
 }

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
@@ -1,0 +1,212 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.netty.authenticate;
+
+import com.alibaba.fluss.cluster.Endpoint;
+import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.cluster.ServerType;
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.metrics.groups.MetricGroup;
+import com.alibaba.fluss.metrics.util.NOPMetricsGroup;
+import com.alibaba.fluss.rpc.TestingGatewayService;
+import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
+import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
+import com.alibaba.fluss.rpc.metrics.TestingClientMetricGroup;
+import com.alibaba.fluss.rpc.netty.client.NettyClient;
+import com.alibaba.fluss.rpc.netty.server.NettyServer;
+import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
+import com.alibaba.fluss.rpc.protocol.ApiKeys;
+import com.alibaba.fluss.rpc.protocol.RPC;
+import com.alibaba.fluss.utils.NetUtils;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.concurrent.CompletableFuture;
+
+import static com.alibaba.fluss.utils.NetUtils.getAvailablePort;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for authentication. */
+public class AuthenticationTest {
+    private NettyServer nettyServer;
+    private ServerNode serverNode;
+
+    @BeforeEach
+    public void setup() throws Exception {
+        buildNettyServer();
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        if (nettyServer != null) {
+            nettyServer.close();
+        }
+    }
+
+    @Test
+    void testNormalAuthenticate() throws Exception {
+        Configuration clientConfig = new Configuration();
+        clientConfig.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "username_password");
+        clientConfig.setString("client.security.username_password.username", "root");
+        clientConfig.setString("client.security.username_password.password", "password");
+        try (NettyClient nettyClient =
+                new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
+            ListDatabasesRequest request = new ListDatabasesRequest();
+            ListDatabasesResponse listDatabasesResponse =
+                    (ListDatabasesResponse)
+                            nettyClient
+                                    .sendRequest(serverNode, ApiKeys.LIST_DATABASES, request)
+                                    .get();
+
+            assertThat(listDatabasesResponse.getDatabaseNamesList())
+                    .isEqualTo(Collections.singletonList("test-database"));
+        }
+    }
+
+    @Test
+    void testClientLackAuthenticateProtocol() throws Exception {
+        Configuration clientConfig = new Configuration();
+        try (NettyClient nettyClient =
+                new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
+            ListDatabasesRequest request = new ListDatabasesRequest();
+            assertThatThrownBy(
+                            () ->
+                                    nettyClient
+                                            .sendRequest(
+                                                    serverNode, ApiKeys.LIST_DATABASES, request)
+                                            .get())
+                    .cause()
+                    .isExactlyInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("The connection has not completed authentication yet.");
+        }
+    }
+
+    @Test
+    void testWrongPassword() throws Exception {
+        Configuration clientConfig = new Configuration();
+        clientConfig.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "username_password");
+        clientConfig.setString("client.security.username_password.username", "root");
+        clientConfig.setString("client.security.username_password.password", "password2");
+        try (NettyClient nettyClient =
+                new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
+            ListDatabasesRequest request = new ListDatabasesRequest();
+            assertThatThrownBy(
+                            () ->
+                                    nettyClient
+                                            .sendRequest(
+                                                    serverNode, ApiKeys.LIST_DATABASES, request)
+                                            .get())
+                    .cause()
+                    .isExactlyInstanceOf(AuthenticationException.class)
+                    .hasMessageContaining("username or password is incorrect");
+        }
+    }
+
+    @Test
+    void testMultiClientsWithSameProtocol() throws Exception {
+        Configuration clientConfig = new Configuration();
+        clientConfig.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "username_password");
+        clientConfig.setString("client.security.username_password.username", "root");
+        clientConfig.setString("client.security.username_password.password", "password");
+
+        try (NettyClient nettyClient =
+                new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
+            ListDatabasesRequest request = new ListDatabasesRequest();
+            ListDatabasesResponse listDatabasesResponse =
+                    (ListDatabasesResponse)
+                            nettyClient
+                                    .sendRequest(serverNode, ApiKeys.LIST_DATABASES, request)
+                                    .get();
+            assertThat(listDatabasesResponse.getDatabaseNamesList())
+                    .isEqualTo(Collections.singletonList("test-database"));
+            // client2 with wrong password after client1 successes to authenticate.
+            clientConfig.setString("client.security.username_password.password", "password2");
+            try (NettyClient nettyClient2 =
+                    new NettyClient(clientConfig, TestingClientMetricGroup.newInstance())) {
+                assertThatThrownBy(
+                                () ->
+                                        nettyClient2
+                                                .sendRequest(
+                                                        serverNode, ApiKeys.LIST_DATABASES, request)
+                                                .get())
+                        .cause()
+                        .isExactlyInstanceOf(AuthenticationException.class)
+                        .hasMessageContaining("username or password is incorrect");
+            }
+        }
+    }
+
+    private void buildNettyServer() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:username_password");
+        configuration.setString("security.username_password.username", "root");
+        configuration.setString("security.username_password.password", "password");
+        // 3 worker threads is enough for this test
+        configuration.setString(ConfigOptions.NETTY_SERVER_NUM_WORKER_THREADS.key(), "3");
+        MetricGroup metricGroup = NOPMetricsGroup.newInstance();
+        TestingAuthenticateGatewayService service = new TestingAuthenticateGatewayService();
+        try (NetUtils.Port availablePort1 = getAvailablePort();
+                NetUtils.Port availablePort2 = getAvailablePort()) {
+            this.nettyServer =
+                    new NettyServer(
+                            configuration,
+                            Arrays.asList(
+                                    new Endpoint("localhost", availablePort1.getPort(), "INTERNAL"),
+                                    new Endpoint("localhost", availablePort2.getPort(), "CLIENT")),
+                            service,
+                            metricGroup,
+                            RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup));
+            // override method of LIST_DATABASES for test request required authentication before,
+            nettyServer
+                    .getApiManager()
+                    .registerApiMethod(
+                            ApiKeys.LIST_DATABASES,
+                            TestingAuthenticateGatewayService.class.getMethod(
+                                    "listDatabases", ListDatabasesRequest.class),
+                            ServerType.COORDINATOR);
+            nettyServer.start();
+
+            // use client listener to connect to server
+            serverNode =
+                    new ServerNode(
+                            2, "localhost", availablePort2.getPort(), ServerType.COORDINATOR);
+        }
+    }
+
+    /**
+     * A testing gateway service which apply a non API_VERSIONS request which requires
+     * authentication.
+     */
+    public static class TestingAuthenticateGatewayService extends TestingGatewayService {
+
+        @RPC(api = ApiKeys.LIST_DATABASES)
+        public CompletableFuture<ListDatabasesResponse> listDatabases(
+                ListDatabasesRequest request) {
+            return CompletableFuture.completedFuture(
+                    new ListDatabasesResponse()
+                            .addAllDatabaseNames(Collections.singleton("test-database")));
+        }
+    }
+}

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
@@ -147,7 +147,7 @@ public class AuthenticationTest {
                     .cause()
                     .isExactlyInstanceOf(AuthenticationException.class)
                     .hasMessageContaining(
-                            "Authenticate protocol not match: protocol of server is username_password while protocol of client is mutual");
+                            "Authenticate protocol not match: protocol of server is 'username_password' while protocol of client is 'mutual'");
         }
     }
 

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.netty.authenticate;
+
+import com.alibaba.fluss.config.ConfigOption;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.auth.ClientAuthenticationPlugin;
+import com.alibaba.fluss.security.auth.ClientAuthenticator;
+import com.alibaba.fluss.security.auth.ServerAuthenticationPlugin;
+import com.alibaba.fluss.security.auth.ServerAuthenticator;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import static com.alibaba.fluss.config.ConfigBuilder.key;
+
+/**
+ * An {@link com.alibaba.fluss.security.auth.AuthenticationPlugin} to mock mutual authentication.
+ */
+public class MutualAuthenticationPlugin
+        implements ServerAuthenticationPlugin, ClientAuthenticationPlugin {
+
+    private static final String MUTUAL_AUTH_PROTOCOL = "mutual";
+    private static final ConfigOption<ErrorType> ERROR_TYPE =
+            key("client.security.mutual.error-type")
+                    .enumType(ErrorType.class)
+                    .defaultValue(ErrorType.NONE);
+
+    @Override
+    public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        return new ClientAuthenticatorImpl(configuration);
+    }
+
+    @Override
+    public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
+        return new ServerAuthenticatorImpl();
+    }
+
+    @Override
+    public String authProtocol() {
+        return MUTUAL_AUTH_PROTOCOL;
+    }
+
+    private static class ClientAuthenticatorImpl implements ClientAuthenticator {
+        private boolean isCompleted = false;
+        private int initialSalt;
+        private final byte errorType;
+
+        public ClientAuthenticatorImpl(Configuration configuration) {
+            this.errorType = configuration.get(ERROR_TYPE).code;
+        }
+
+        @Override
+        public String protocol() {
+            return MUTUAL_AUTH_PROTOCOL;
+        }
+
+        @Override
+        public byte[] authenticate(byte[] data) throws AuthenticationException {
+            if (isCompleted) {
+                return null;
+            }
+
+            // Initial token
+            if (data.length == 0) {
+                initialSalt = generateInitialSalt();
+                return String.valueOf(
+                                isError(
+                                                errorType,
+                                                ErrorType.SERVER_NO_CHALLENGE,
+                                                ErrorType.SERVER_ERROR_CHALLENGE)
+                                        ? errorType
+                                        : initialSalt)
+                        .getBytes();
+            }
+
+            int challenge = parseToken(data);
+            if (challenge == initialSalt + 1) {
+                isCompleted = true;
+                return String.valueOf(
+                                isError(errorType, ErrorType.CLIENT_ERROR_SECOND_TOKEN)
+                                        ? errorType
+                                        : challenge + 1)
+                        .getBytes();
+            }
+
+            throw new AuthenticationException(
+                    "Invalid challenge value: expected "
+                            + (initialSalt + 1)
+                            + ", but got "
+                            + challenge);
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return isCompleted;
+        }
+    }
+
+    private static class ServerAuthenticatorImpl implements ServerAuthenticator {
+        private boolean isCompleted = false;
+        private boolean firstAuthRequest = true;
+        private int initialSalt;
+
+        @Override
+        public String protocol() {
+            return MUTUAL_AUTH_PROTOCOL;
+        }
+
+        @Override
+        public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
+            int tokenValue = parseToken(token);
+
+            // If mock error, return null.
+            if (isError((byte) tokenValue, ErrorType.SERVER_NO_CHALLENGE)) {
+                return null;
+            }
+            if (isError((byte) tokenValue, ErrorType.SERVER_ERROR_CHALLENGE)) {
+                return "-1".getBytes();
+            }
+
+            if (firstAuthRequest) {
+                initialSalt = tokenValue + 1;
+                firstAuthRequest = false;
+                return String.valueOf(initialSalt).getBytes();
+            }
+
+            if (tokenValue == initialSalt + 1) {
+                isCompleted = true;
+                return new byte[0];
+            }
+
+            throw new IllegalArgumentException(
+                    "Invalid token value: expected "
+                            + (initialSalt + 1)
+                            + ", but got "
+                            + tokenValue);
+        }
+
+        @Override
+        public boolean isCompleted() {
+            return isCompleted;
+        }
+    }
+
+    private static int parseToken(byte[] token) {
+        if (token == null || token.length == 0) {
+            throw new IllegalArgumentException("Token cannot be null or empty.");
+        }
+        return Integer.parseInt(new String(token));
+    }
+
+    private static int generateInitialSalt() {
+        return ThreadLocalRandom.current().nextInt(0, Integer.MAX_VALUE);
+    }
+
+    private static boolean isError(byte errorType, ErrorType... errorTypes) {
+        for (ErrorType type : errorTypes) {
+            if (errorType == type.code) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    enum ErrorType {
+        NONE((byte) -1),
+        SERVER_NO_CHALLENGE((byte) -2),
+        SERVER_ERROR_CHALLENGE((byte) -3),
+        CLIENT_ERROR_SECOND_TOKEN((byte) -4);
+
+        final byte code;
+
+        ErrorType(byte code) {
+            this.code = code;
+        }
+    }
+}

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.netty.authenticate;
+
+import com.alibaba.fluss.config.ConfigOption;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.auth.ClientAuthenticationPlugin;
+import com.alibaba.fluss.security.auth.ClientAuthenticator;
+import com.alibaba.fluss.security.auth.ServerAuthenticationPlugin;
+import com.alibaba.fluss.security.auth.ServerAuthenticator;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import static com.alibaba.fluss.config.ConfigBuilder.key;
+
+/** A test authentication plugin which need username and password. */
+public class UsernamePasswordAuthenticationPlugin
+        implements ServerAuthenticationPlugin, ClientAuthenticationPlugin {
+
+    private static final ConfigOption<String> USERNAME =
+            key("username").stringType().noDefaultValue();
+
+    private static final ConfigOption<String> PASSWORD =
+            key("password").stringType().noDefaultValue();
+
+    private static final String AUTH_PROTOCOL = "username_password";
+
+    @Override
+    public String authProtocol() {
+        return AUTH_PROTOCOL;
+    }
+
+    @Override
+    public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
+        String username = configuration.getString(USERNAME);
+        String password = configuration.getString(PASSWORD);
+        if (username == null || password == null) {
+            throw new AuthenticationException("username and password shouldn't be null.");
+        }
+        return new ClientAuthenticator() {
+            volatile boolean isComplete = false;
+
+            @Override
+            public String protocol() {
+                return AUTH_PROTOCOL;
+            }
+
+            @Override
+            public byte[] authenticate(byte[] data) {
+                isComplete = true;
+                return serializeToken(username, password);
+            }
+
+            @Override
+            public boolean isComplete() {
+                return isComplete;
+            }
+        };
+    }
+
+    @Override
+    public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
+        String expectedUsername = configuration.getString(USERNAME);
+        String expectedPassword = configuration.getString(PASSWORD);
+        if (expectedPassword == null || expectedUsername == null) {
+            throw new AuthenticationException("username and password shouldn't be null.");
+        }
+        return new ServerAuthenticator() {
+            volatile boolean isComplete = false;
+
+            @Override
+            public String protocol() {
+                return AUTH_PROTOCOL;
+            }
+
+            @Override
+            public byte[] evaluateResponse(byte[] token) {
+                byte[] expectedToken = serializeToken(expectedUsername, expectedPassword);
+                if (!Arrays.equals(token, expectedToken)) {
+                    throw new AuthenticationException("username or password is incorrect.");
+                }
+
+                isComplete = true;
+
+                return new byte[0];
+            }
+
+            @Override
+            public boolean isComplete() {
+                return isComplete;
+            }
+        };
+    }
+
+    private byte[] serializeToken(String username, String password) {
+        return (username + "," + password).getBytes(StandardCharsets.UTF_8);
+    }
+}

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
@@ -33,11 +33,17 @@ import static com.alibaba.fluss.config.ConfigBuilder.key;
 public class UsernamePasswordAuthenticationPlugin
         implements ServerAuthenticationPlugin, ClientAuthenticationPlugin {
 
-    private static final ConfigOption<String> USERNAME =
-            key("username").stringType().noDefaultValue();
+    private static final ConfigOption<String> CLIENT_USERNAME =
+            key("client.security.username_password.username").stringType().noDefaultValue();
 
-    private static final ConfigOption<String> PASSWORD =
-            key("password").stringType().noDefaultValue();
+    private static final ConfigOption<String> CLIENT_PASSWORD =
+            key("client.security.username_password.password").stringType().noDefaultValue();
+
+    private static final ConfigOption<String> SERVER_USERNAME =
+            key("security.username_password.username").stringType().noDefaultValue();
+
+    private static final ConfigOption<String> SERVER_PASSWORD =
+            key("security.username_password.password").stringType().noDefaultValue();
 
     private static final String AUTH_PROTOCOL = "username_password";
 
@@ -48,8 +54,8 @@ public class UsernamePasswordAuthenticationPlugin
 
     @Override
     public ClientAuthenticator createClientAuthenticator(Configuration configuration) {
-        String username = configuration.getString(USERNAME);
-        String password = configuration.getString(PASSWORD);
+        String username = configuration.getString(CLIENT_USERNAME);
+        String password = configuration.getString(CLIENT_PASSWORD);
         if (username == null || password == null) {
             throw new AuthenticationException("username and password shouldn't be null.");
         }
@@ -62,13 +68,13 @@ public class UsernamePasswordAuthenticationPlugin
             }
 
             @Override
-            public byte[] authenticate(byte[] data) {
+            public byte[] authenticate(byte[] data) throws AuthenticationException {
                 isComplete = true;
                 return serializeToken(username, password);
             }
 
             @Override
-            public boolean isComplete() {
+            public boolean isCompleted() {
                 return isComplete;
             }
         };
@@ -76,8 +82,8 @@ public class UsernamePasswordAuthenticationPlugin
 
     @Override
     public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
-        String expectedUsername = configuration.getString(USERNAME);
-        String expectedPassword = configuration.getString(PASSWORD);
+        String expectedUsername = configuration.getString(SERVER_USERNAME);
+        String expectedPassword = configuration.getString(SERVER_PASSWORD);
         if (expectedPassword == null || expectedUsername == null) {
             throw new AuthenticationException("username and password shouldn't be null.");
         }
@@ -90,7 +96,7 @@ public class UsernamePasswordAuthenticationPlugin
             }
 
             @Override
-            public byte[] evaluateResponse(byte[] token) {
+            public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
                 byte[] expectedToken = serializeToken(expectedUsername, expectedPassword);
                 if (!Arrays.equals(token, expectedToken)) {
                     throw new AuthenticationException("username or password is incorrect.");
@@ -102,7 +108,7 @@ public class UsernamePasswordAuthenticationPlugin
             }
 
             @Override
-            public boolean isComplete() {
+            public boolean isCompleted() {
                 return isComplete;
             }
         };

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandlerTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandlerTest.java
@@ -30,6 +30,7 @@ import com.alibaba.fluss.rpc.messages.PbValue;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
 import com.alibaba.fluss.rpc.protocol.MessageCodec;
+import com.alibaba.fluss.security.auth.PlainTextAuthenticationPlugin;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.Channel;
@@ -59,7 +60,7 @@ final class NettyServerHandlerTest {
     private ChannelHandlerContext ctx;
 
     @BeforeEach
-    void beforeEach() {
+    void beforeEach() throws Exception {
         this.requestChannel = new TestingRequestChannel(100);
         MetricGroup metricGroup = NOPMetricsGroup.newInstance();
         this.serverHandler =
@@ -67,8 +68,10 @@ final class NettyServerHandlerTest {
                         requestChannel,
                         new ApiManager(ServerType.TABLET_SERVER),
                         "CLIENT",
-                        RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup));
+                        RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup),
+                        new PlainTextAuthenticationPlugin.PlainTextServerAuthenticator());
         this.ctx = mockChannelHandlerContext();
+        serverHandler.channelActive(ctx);
     }
 
     @Test

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
@@ -30,6 +30,7 @@ import com.alibaba.fluss.rpc.netty.server.FlussRequest;
 import com.alibaba.fluss.rpc.netty.server.NettyServerHandler;
 import com.alibaba.fluss.rpc.netty.server.RequestChannel;
 import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
+import com.alibaba.fluss.security.auth.PlainTextAuthenticationPlugin;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBufAllocator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.Channel;
@@ -67,7 +68,8 @@ class MessageCodecTest {
                         requestChannel,
                         new ApiManager(ServerType.TABLET_SERVER),
                         "CLIENT",
-                        RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup));
+                        RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup),
+                        new PlainTextAuthenticationPlugin.PlainTextServerAuthenticator());
         this.ctx = mockChannelHandlerContext();
     }
 

--- a/fluss-rpc/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
+++ b/fluss-rpc/src/test/resources/META-INF/services/com.alibaba.fluss.security.auth.AuthenticationPlugin
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.fluss.rpc.netty.authenticate.UsernamePasswordAuthenticationPlugin

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -126,6 +126,9 @@ public class CoordinatorServer extends ServerBase {
     }
 
     public static void main(String[] args) {
+        System.out.println("-----");
+        System.out.println(args);
+        System.out.println(args.length);
         Configuration configuration =
                 loadConfiguration(args, CoordinatorServer.class.getSimpleName());
         CoordinatorServer coordinatorServer = new CoordinatorServer(configuration);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -126,9 +126,6 @@ public class CoordinatorServer extends ServerBase {
     }
 
     public static void main(String[] args) {
-        System.out.println("-----");
-        System.out.println(args);
-        System.out.println(args.length);
         Configuration configuration =
                 loadConfiguration(args, CoordinatorServer.class.getSimpleName());
         CoordinatorServer coordinatorServer = new CoordinatorServer(configuration);


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #484 . This Pr is depended on #531 .

<!-- What is the purpose of the change -->

### Brief change log

 Introduce authenticate in Fluss.



### Tests
com.alibaba.fluss.rpc.netty.authenticate.AuthenticationTest

### API and Format

#### Config
* `server.authenticate.protocol.map`: A map defining the authentication protocol for each listener. The format is 'listenerName1:protocol1,listenerName2:protocol2', e.g., 'INTERNAL:PLAINTEXT,CLIENT:GSSAPI'. Each listener can be associated with a specific authentication protocol. Listeners not included in the map will use PLAINTEXT by default, which does not require authentication.
* client.authenticate.protocol:The authentication protocol used to authenticate the client.

The config of one protocol:
* `client.authenticate.${protocol}.xxx`
* `server.authenticate.${protocol}.xxx`

#### Interface
AuthenticationPlugin for client and server:
```java
/**
 * The AuthenticationPlugin interface defines a contract for authentication mechanisms in the Fluss
 * RPC system. Implementations of this interface provide specific authentication protocols (e.g.,
 * PLAINTEXT, AK-SK) and must be registered via the Service Provider Interface (SPI) mechanism to be
 * discoverable by the system.
 *
 * <p>Authentication plugins are used by {@link AuthenticatorLoader} to create client and server
 * authenticators based on configuration settings such as {@link
 * com.alibaba.fluss.config.ConfigOptions#CLIENT_AUTHENTICATE_PROTOCOL} and {@link
 * com.alibaba.fluss.config.ConfigOptions#SERVER_AUTHENTICATE_PROTOCOL_MAP}.
 *
 * <p>To implement this interface:
 *
 * <ol>
 *   <li>Define the supported authentication protocol via {@link #authProtocol()}.
 *   <li>Implement the required logic for client/server authentication (via subclasses like {@link
 *       ClientAuthenticationPlugin}).
 *   <li>Register the plugin implementation in {@code
 *       META-INF/services/com.alibaba.fluss.rpc.authenticate.AuthenticationPlugin}.
 * </ol>
 *
 * @since 0.1
 */
public interface AuthenticationPlugin extends Plugin {
    /**
     * Returns the authentication protocol identifier for this plugin (e.g., "PLAINTEXT", "AK-SK").
     * This identifier is used by the system to match plugins with configuration settings and select
     * the appropriate authentication mechanism.
     *
     * <p>It is typically configured via:
     *
     * <ul>
     *   <li>{@link com.alibaba.fluss.config.ConfigOptions#CLIENT_AUTHENTICATE_PROTOCOL} for
     *       client-side authentication.
     *   <li>{@link com.alibaba.fluss.config.ConfigOptions#SERVER_AUTHENTICATE_PROTOCOL_MAP} for
     *       server listener-specific authentication.
     * </ul>
     *
     * @return The protocol name (e.g., "PLAINTEXT").
     */
    String authProtocol();
}


public interface ClientAuthenticationPlugin extends AuthenticationPlugin {

    ClientAuthenticator createClientAuthenticator(Configuration configuration);
}

public interface ServerAuthenticationPlugin extends AuthenticationPlugin {

    ServerAuthenticator createServerAuthenticator(Configuration configuration);
}

```

Authenticator for client and server:
```java
public interface ServerAuthenticator {

    String protocol();

    byte[] evaluateResponse(byte[] token) throws AuthenticationException;

    /**
     * Create principal from authenticated token for later authorization.(this can only invoke if is
     * complete).
     */
    FlussPrincipal createPrincipal();

    boolean isComplete();
}
```
```java
public interface ClientAuthenticator {

    String protocol();

    byte[] authenticate(byte[] data);

    boolean isComplete();
}

```


Principal to identify user:
```java
/**
 * Represents a security principal in Fluss, defined by a {@code name} and {@code type}.
 *
 * <p>The principal type indicates the category of the principal (e.g., "User", "Group", "Role"),
 * while the name identifies the specific entity within that category. By default, the simple
 * authorizer uses "User" as the principal type, but custom authorizers can extend this to support
 * role-based or group-based access control lists (ACLs).
 *
 * <p>Example usage:
 *
 * <ul>
 *   <li>{@code new FlussPrincipal("admin", "User")} – A standard user principal.
 *   <li>{@code new FlussPrincipal("admins", "Group")} – A group-based principal for authorization.
 * </ul>
 *
 * @since 0.1
 */
public class FlussPrincipal implements Principal {
    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", "User");

    private final String name;
    private final String type;

    public FlussPrincipal(String name, String type) {
        this.name = name;
        this.type = type;
    }

    @Override
    public String getName() {
        return name;
    }

    public String getType() {
        return type;
    }

    @Override
    public boolean equals(Object o) {
        if (o == null || getClass() != o.getClass()) {
            return false;
        }
        FlussPrincipal that = (FlussPrincipal) o;
        return Objects.equals(name, that.name) && Objects.equals(type, that.type);
    }

    @Override
    public int hashCode() {
        return Objects.hash(name, type);
    }
}

```




### Documentation

<!-- Does this change introduce a new feature -->
