### PR TITLE
[Website] Version aware reverse sort

### DIFF
--- a/website/build_versioned_docs.sh
+++ b/website/build_versioned_docs.sh
@@ -41,7 +41,7 @@ cd "$TEMP_DIR" || { echo "Failed to enter temporary directory"; exit 1; }
 
 # Match branches in the format "release-x.y"
 regex='release-[0-9]+\.[0-9]+$'                          # Regular expression to match release-x.y
-branches=$(git branch -a | grep -E "$regex"| sort -r)    # Filter branches that match the criteria
+branches=$(git branch -a | grep -E "$regex"| sort -V -r) # Filter branches that match the criteria
 
 # Exit the script if no matching branches are found
 if [ -z "$branches" ]; then


### PR DESCRIPTION
### Purpose

Fixes the Version bug for the website pointing to an older version claiming the latest, rather than the actual latest version.

### Brief change log

Currently, the documents point back to version (0.5) as the latest, whereas we have released version 0.6, changing the branches sorting technique in build_versioned_docs.sh to be version-aware.

### Tests

I tried running locally generating the versions.json via ./build_versioned_docs.sh, generating the versions.json containing array as [0.6, 05]

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation
It will change the top margin, which shows the warning, in case you are not on the latest doc

