### PR TITLE
[docs] Fix typo

### DIFF
--- a/fluss-common/src/test/java/com/alibaba/fluss/memory/TestingMemorySegmentPool.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/memory/TestingMemorySegmentPool.java
@@ -54,12 +54,12 @@ public class TestingMemorySegmentPool implements MemorySegmentPool {
 
     @Override
     public void returnPage(MemorySegment segment) {
-        // do noting.
+        // do nothing.
     }
 
     @Override
     public void returnAll(List<MemorySegment> memory) {
-        // do noting.
+        // do nothing.
     }
 
     @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/RpcGatewayManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/RpcGatewayManager.java
@@ -104,7 +104,7 @@ public class RpcGatewayManager<T extends RpcGateway> implements AutoCloseable {
 
     @Override
     public void close() throws Exception {
-        // do noting.
+        // do nothing.
     }
 
     private class ServerRpcGateway {


### PR DESCRIPTION
`do noting` should be `do nothing`.