### PR TITLE
Fluss support ACL authotization

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -46,6 +46,8 @@ import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
 
 import java.util.Collection;
 import java.util.List;
@@ -387,4 +389,39 @@ public interface Admin extends AutoCloseable {
             String partitionName,
             Collection<Integer> buckets,
             OffsetSpec offsetSpec);
+
+    /**
+     * Retrieves ACL entries filtered by principal for the specified resource.
+     *
+     * <p>1. Validates the user has 'describe' permission on the resource. 2. Returns entries
+     * matching the principal if permitted; throws an exception otherwise.
+     *
+     * @return A CompletableFuture containing the filtered ACL entries.
+     */
+    CompletableFuture<Collection<AclBinding>> listAcls(AclBindingFilter aclBindingFilter);
+
+    /**
+     * Creates multiple ACL entries in a single atomic operation.
+     *
+     * <p>1. Validates the user has 'alter' permission on the resource. 2. Creates the ACL entries
+     * if valid and permitted.
+     *
+     * <p>Each entry in {@code aclBindings} must have a valid principal, operation and permission.
+     *
+     * @param aclBindings List of ACL entries to create.
+     * @return A CompletableFuture indicating completion of the operation.
+     */
+    CreateAclsResult createAcls(Collection<AclBinding> aclBindings);
+
+    /**
+     * Removes multiple ACL entries in a single atomic operation.
+     *
+     * <p>1. Validates the user has 'alter' permission on the resource. 2. Removes entries only if
+     * they exactly match the provided entries (principal, operation, permission). 3. Does not
+     * remove entries if any of the ACL entries do not exist.
+     *
+     * @param filters List of ACL entries to remove.
+     * @return A CompletableFuture indicating completion of the operation.
+     */
+    DeleteAclsResult dropAcls(Collection<AclBindingFilter> filters);
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/Admin.java
@@ -423,5 +423,5 @@ public interface Admin extends AutoCloseable {
      * @param filters List of ACL entries to remove.
      * @return A CompletableFuture indicating completion of the operation.
      */
-    DeleteAclsResult dropAcls(Collection<AclBindingFilter> filters);
+    DropAclsResult dropAcls(Collection<AclBindingFilter> filters);
 }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/CreateAclsResult.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/CreateAclsResult.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin;
+
+import com.alibaba.fluss.rpc.messages.PbCreateAclRespInfo;
+import com.alibaba.fluss.rpc.protocol.Errors;
+import com.alibaba.fluss.security.acl.AclBinding;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBinding;
+
+/**
+ * Represents the result of a batch ACL operation, managing asynchronous completion of individual
+ * ACL operations.
+ *
+ * <p>This class tracks the execution status of multiple ACL operations (e.g., create/drop) by
+ * associating each {@link AclBinding} with its corresponding {@link CompletableFuture}. It
+ * processes RPC responses to complete or fail individual futures based on server-side results.
+ *
+ * @since 0.6
+ */
+public class CreateAclsResult {
+    private final Map<AclBinding, CompletableFuture<Void>> futures;
+
+    public CreateAclsResult(Map<AclBinding, CompletableFuture<Void>> futures) {
+        this.futures = futures;
+    }
+
+    public CompletableFuture<Void> all() {
+        return CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0]));
+    }
+
+    /**
+     * Gets the map of ACL bindings to their associated futures.
+     *
+     * @return The map of ACL bindings to futures.
+     */
+    public Map<AclBinding, CompletableFuture<Void>> getFutures() {
+        return futures;
+    }
+
+    /**
+     * Completes individual futures based on RPC response information.
+     *
+     * <p>For each {@link PbCreateAclRespInfo} in the collection, Completes the future with success
+     * or failure based on the response's error code.
+     *
+     * @param pbAclRespInfos Collection of protobuf response messages containing ACL operation
+     *     results.
+     */
+    public void complete(List<PbCreateAclRespInfo> pbAclRespInfos) {
+        pbAclRespInfos.forEach(
+                pbAclRespInfo -> {
+                    AclBinding aclBinding = toAclBinding(pbAclRespInfo.getAcl());
+                    CompletableFuture<Void> future = futures.get(aclBinding);
+                    if (pbAclRespInfo.hasErrorCode()
+                            && pbAclRespInfo.getErrorCode() != Errors.NONE.code()) {
+                        future.completeExceptionally(
+                                Errors.forCode(pbAclRespInfo.getErrorCode())
+                                        .exception(pbAclRespInfo.getErrorMessage()));
+                    } else {
+                        future.complete(null);
+                    }
+                });
+    }
+
+    /**
+     * Marks all futures as exceptionally completed with the provided throwable.
+     *
+     * <p>This method propagates a common exception (e.g., network error) to all tracked futures.
+     *
+     * @param t The throwable to propagate to all futures
+     */
+    public void completeExceptionally(Throwable t) {
+        futures.values().forEach(future -> future.completeExceptionally(t));
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/DeleteAclsResult.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/DeleteAclsResult.java
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.client.admin;
+
+import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.exception.UnknownServerException;
+import com.alibaba.fluss.rpc.messages.DeleteAclsMatchingAcl;
+import com.alibaba.fluss.rpc.messages.DropAclsFilterResult;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.rpc.protocol.Errors;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBinding;
+
+/** Represents the result of a delete ACLs operation. */
+public class DeleteAclsResult {
+
+    /** A class containing either the deleted ACL binding or an exception if the delete failed. */
+    public static class FilterResult {
+        private final AclBinding binding;
+        private final ApiException exception;
+
+        FilterResult(AclBinding binding, ApiException exception) {
+            this.binding = binding;
+            this.exception = exception;
+        }
+
+        /** Return the deleted ACL binding or null if there was an error. */
+        public AclBinding binding() {
+            return binding;
+        }
+
+        /** Return an exception if the ACL delete was not successful or null if it was. */
+        public ApiException exception() {
+            return exception;
+        }
+    }
+
+    /** A class containing the results of the delete ACLs operation. */
+    public static class FilterResults {
+        private final List<FilterResult> values;
+
+        FilterResults(List<FilterResult> values) {
+            this.values = values;
+        }
+
+        /** Return a list of delete ACLs results for a given filter. */
+        public List<FilterResult> values() {
+            return values;
+        }
+    }
+
+    private final Map<AclBindingFilter, CompletableFuture<FilterResults>> futures;
+
+    DeleteAclsResult(Map<AclBindingFilter, CompletableFuture<FilterResults>> futures) {
+        this.futures = futures;
+    }
+
+    /**
+     * Return a future which succeeds only if all the ACLs deletions succeed, and which contains all
+     * the deleted ACLs. Note that it if the filters don't match any ACLs, this is not considered an
+     * error.
+     */
+    public CompletableFuture<Collection<AclBinding>> all() {
+        return CompletableFuture.allOf(futures.values().toArray(new CompletableFuture[0]))
+                .thenApply(v -> getAclBindings(futures));
+    }
+
+    private List<AclBinding> getAclBindings(
+            Map<AclBindingFilter, CompletableFuture<FilterResults>> futures) {
+        List<AclBinding> acls = new ArrayList<>();
+        for (CompletableFuture<FilterResults> value : futures.values()) {
+            FilterResults results;
+            try {
+                results = value.get();
+            } catch (Throwable e) {
+                // This should be unreachable, since the future returned by KafkaFuture#allOf should
+                // have failed if any Future failed.
+                throw new IllegalStateException("DeleteAclsResult#all: internal error", e);
+            }
+            for (FilterResult result : results.values()) {
+                if (result.exception() != null) {
+                    throw result.exception();
+                }
+                acls.add(result.binding());
+            }
+        }
+        return acls;
+    }
+
+    public void completeExceptionally(Throwable t) {
+        futures.values().forEach(future -> future.completeExceptionally(t));
+    }
+
+    public void complete(List<DropAclsFilterResult> results) {
+        Iterator<DropAclsFilterResult> iter = results.iterator();
+        for (AclBindingFilter bindingFilter : futures.keySet()) {
+            CompletableFuture<FilterResults> future = futures.get(bindingFilter);
+            if (!iter.hasNext()) {
+                future.completeExceptionally(
+                        new UnknownServerException(
+                                "The broker reported no deletion result for the given filter."));
+            } else {
+                DropAclsFilterResult filterResult = iter.next();
+                if (filterResult.hasErrorCode()
+                        && filterResult.getErrorCode() != Errors.NONE.code()) {
+                    ApiError apiError =
+                            new ApiError(
+                                    Errors.forCode(filterResult.getErrorCode()),
+                                    filterResult.hasErrorMessage()
+                                            ? filterResult.getErrorMessage()
+                                            : null);
+                    future.completeExceptionally(apiError.exception());
+                } else {
+                    List<FilterResult> filterResults = new ArrayList<>();
+                    for (DeleteAclsMatchingAcl matchingAcl : filterResult.getMatchingAclsList()) {
+                        if (matchingAcl.hasErrorCode()
+                                && matchingAcl.getErrorCode() != Errors.NONE.code()) {
+                            ApiError aclError =
+                                    new ApiError(
+                                            Errors.forCode(filterResult.getErrorCode()),
+                                            filterResult.hasErrorMessage()
+                                                    ? filterResult.getErrorMessage()
+                                                    : null);
+                            AclBinding aclBinding = toAclBinding(matchingAcl.getAcl());
+                            filterResults.add(new FilterResult(aclBinding, aclError.exception()));
+                        } else {
+                            filterResults.add(
+                                    new FilterResult(toAclBinding(matchingAcl.getAcl()), null));
+                        }
+                    }
+                    future.complete(new FilterResults(filterResults));
+                }
+            }
+        }
+    }
+
+    /**
+     * Return a map from acl filters to futures which can be used to check the status of the
+     * deletions by each filter.
+     */
+    private Map<AclBindingFilter, CompletableFuture<FilterResults>> values() {
+        return futures;
+    }
+}

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -38,10 +38,12 @@ import com.alibaba.fluss.rpc.GatewayClientProxy;
 import com.alibaba.fluss.rpc.RpcClient;
 import com.alibaba.fluss.rpc.gateway.AdminGateway;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
+import com.alibaba.fluss.rpc.messages.CreateAclsRequest;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateTableRequest;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsRequest;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsResponse;
+import com.alibaba.fluss.rpc.messages.DropAclsRequest;
 import com.alibaba.fluss.rpc.messages.DropDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.DropTableRequest;
 import com.alibaba.fluss.rpc.messages.GetDatabaseInfoRequest;
@@ -50,6 +52,7 @@ import com.alibaba.fluss.rpc.messages.GetLatestKvSnapshotsRequest;
 import com.alibaba.fluss.rpc.messages.GetLatestLakeSnapshotRequest;
 import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
@@ -60,6 +63,8 @@ import com.alibaba.fluss.rpc.messages.PbListOffsetsRespForBucket;
 import com.alibaba.fluss.rpc.messages.TableExistsRequest;
 import com.alibaba.fluss.rpc.messages.TableExistsResponse;
 import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
 import com.alibaba.fluss.utils.MapUtils;
 
 import javax.annotation.Nullable;
@@ -76,6 +81,10 @@ import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeCreatePar
 import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeDropPartitionRequest;
 import static com.alibaba.fluss.client.utils.ClientRpcMessageUtils.makeListOffsetsRequest;
 import static com.alibaba.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toPbAclBindingFilters;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toPbAclFilter;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toPbAclInfos;
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 
 /**
@@ -370,6 +379,70 @@ public class FlussAdmin implements Admin {
 
         sendListOffsetsRequest(metadataUpdater, client, requestMap, bucketToOffsetMap);
         return new ListOffsetsResult(bucketToOffsetMap);
+    }
+
+    @Override
+    public CompletableFuture<Collection<AclBinding>> listAcls(AclBindingFilter aclBindingFilter) {
+        CompletableFuture<Collection<AclBinding>> future = new CompletableFuture<>();
+        ListAclsRequest listAclsRequest =
+                new ListAclsRequest().setAclFilter(toPbAclFilter(aclBindingFilter));
+
+        gateway.listAcls(listAclsRequest)
+                .whenComplete(
+                        (r, t) -> {
+                            if (t != null) {
+                                future.completeExceptionally(t);
+                            } else {
+                                future.complete(toAclBindings(r.getAclsList()));
+                            }
+                        });
+        return future;
+    }
+
+    @Override
+    public CreateAclsResult createAcls(Collection<AclBinding> aclBindings) {
+        Map<AclBinding, CompletableFuture<Void>> futures = MapUtils.newConcurrentHashMap();
+        aclBindings.forEach(aclBinding -> futures.put(aclBinding, new CompletableFuture<>()));
+        CreateAclsResult result = new CreateAclsResult(futures);
+
+        CreateAclsRequest createAclsRequest =
+                new CreateAclsRequest().addAllAcls(toPbAclInfos(aclBindings));
+
+        gateway.createAcls(createAclsRequest)
+                .whenComplete(
+                        (r, t) -> {
+                            if (t != null) {
+                                result.completeExceptionally(t);
+                            } else {
+                                result.complete(r.getAclResList());
+                            }
+                        });
+        return result;
+    }
+
+    @Override
+    public DeleteAclsResult dropAcls(Collection<AclBindingFilter> filters) {
+        final Map<AclBindingFilter, CompletableFuture<DeleteAclsResult.FilterResults>> futures =
+                MapUtils.newConcurrentHashMap();
+        for (AclBindingFilter filter : filters) {
+            if (!futures.containsKey(filter)) {
+                futures.put(filter, new CompletableFuture<>());
+            }
+        }
+        DeleteAclsResult result = new DeleteAclsResult(futures);
+
+        DropAclsRequest dropAclsRequest =
+                new DropAclsRequest().addAllAclFilters(toPbAclBindingFilters(futures.keySet()));
+        gateway.dropAcls(dropAclsRequest)
+                .whenComplete(
+                        (r, t) -> {
+                            if (t != null) {
+                                result.completeExceptionally(t);
+                            } else {
+                                result.complete(r.getFilterResultsList());
+                            }
+                        });
+        return result;
     }
 
     @Override

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/admin/FlussAdmin.java
@@ -401,10 +401,7 @@ public class FlussAdmin implements Admin {
 
     @Override
     public CreateAclsResult createAcls(Collection<AclBinding> aclBindings) {
-        Map<AclBinding, CompletableFuture<Void>> futures = MapUtils.newConcurrentHashMap();
-        aclBindings.forEach(aclBinding -> futures.put(aclBinding, new CompletableFuture<>()));
-        CreateAclsResult result = new CreateAclsResult(futures);
-
+        CreateAclsResult result = new CreateAclsResult(aclBindings);
         CreateAclsRequest createAclsRequest =
                 new CreateAclsRequest().addAllAcls(toPbAclInfos(aclBindings));
 
@@ -421,18 +418,11 @@ public class FlussAdmin implements Admin {
     }
 
     @Override
-    public DeleteAclsResult dropAcls(Collection<AclBindingFilter> filters) {
-        final Map<AclBindingFilter, CompletableFuture<DeleteAclsResult.FilterResults>> futures =
-                MapUtils.newConcurrentHashMap();
-        for (AclBindingFilter filter : filters) {
-            if (!futures.containsKey(filter)) {
-                futures.put(filter, new CompletableFuture<>());
-            }
-        }
-        DeleteAclsResult result = new DeleteAclsResult(futures);
-
+    public DropAclsResult dropAcls(Collection<AclBindingFilter> filters) {
+        DropAclsResult result = new DropAclsResult(filters);
         DropAclsRequest dropAclsRequest =
-                new DropAclsRequest().addAllAclFilters(toPbAclBindingFilters(futures.keySet()));
+                new DropAclsRequest()
+                        .addAllAclFilters(toPbAclBindingFilters(result.values().keySet()));
         gateway.dropAcls(dropAclsRequest)
                 .whenComplete(
                         (r, t) -> {

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
@@ -21,6 +21,7 @@ import com.alibaba.fluss.client.metadata.MetadataUpdater;
 import com.alibaba.fluss.client.table.scanner.ScanRecord;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthorizationException;
 import com.alibaba.fluss.exception.FetchException;
 import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
 import com.alibaba.fluss.metadata.TableBucket;
@@ -262,6 +263,8 @@ public class LogFetchCollector {
             metadataUpdater.checkAndUpdateMetadata(tablePath, tb);
         } else if (error == Errors.LOG_OFFSET_OUT_OF_RANGE_EXCEPTION) {
             throw new LogOffsetOutOfRangeException(errorMessage);
+        } else if (error == Errors.AUTHORIZATION_EXCEPTION) {
+            throw new AuthorizationException(errorMessage);
         } else if (error == Errors.UNKNOWN_SERVER_ERROR) {
             LOG.warn(
                     "Unknown server error while fetching offset {} for bucket {}: {}",

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
@@ -49,6 +49,7 @@ import com.alibaba.fluss.rpc.messages.PbFetchLogReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbFetchLogReqForTable;
 import com.alibaba.fluss.rpc.messages.PbFetchLogRespForBucket;
 import com.alibaba.fluss.rpc.messages.PbFetchLogRespForTable;
+import com.alibaba.fluss.rpc.protocol.Errors;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.Projection;
 
@@ -328,7 +329,7 @@ public class LogFetcher implements Closeable {
                         } else {
                             LogRecords logRecords = fetchResultForBucket.recordsOrEmpty();
                             if (!MemoryLogRecords.EMPTY.equals(logRecords)
-                                    || fetchResultForBucket.getErrorCode() > 0L) {
+                                    || fetchResultForBucket.getErrorCode() != Errors.NONE.code()) {
                                 // In oder to not signal notEmptyCondition, add completed fetch to
                                 // buffer until log records is not empty.
                                 DefaultCompletedFetch completedFetch =

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
@@ -327,7 +327,8 @@ public class LogFetcher implements Closeable {
                                     fetchResultForBucket.getHighWatermark());
                         } else {
                             LogRecords logRecords = fetchResultForBucket.recordsOrEmpty();
-                            if (!MemoryLogRecords.EMPTY.equals(logRecords)) {
+                            if (!MemoryLogRecords.EMPTY.equals(logRecords)
+                                    || fetchResultForBucket.getErrorCode() > 0L) {
                                 // In oder to not signal notEmptyCondition, add completed fetch to
                                 // buffer until log records is not empty.
                                 DefaultCompletedFetch completedFetch =

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -408,6 +408,9 @@ public class FlussAuthorizationITCase {
                             rpcClient,
                             AdminGateway.class);
 
+            assertThat(guestGateway.metadata(metadataRequest).get().getTableMetadatasList())
+                    .isEmpty();
+
             // if add acl to allow guest read any resource, it will allow to get metadata.
             rootAdmin
                     .createAcls(

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -68,6 +68,7 @@ import static com.alibaba.fluss.record.TestData.DATA1_TABLE_PATH;
 import static com.alibaba.fluss.record.TestData.DATA1_TABLE_PATH_PK;
 import static com.alibaba.fluss.security.acl.AccessControlEntry.WILD_CARD_HOST;
 import static com.alibaba.fluss.security.acl.FlussPrincipal.WILD_CARD_PRINCIPAL;
+import static com.alibaba.fluss.security.acl.OperationType.READ;
 import static com.alibaba.fluss.testutils.DataTestUtils.row;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -456,8 +457,10 @@ public class FlussAuthorizationITCase {
                 assertThatThrownBy(() -> batchScanner.pollBatch(Duration.ofMinutes(1)))
                         .hasMessageContaining(
                                 String.format(
-                                        "Principal %s have no authorization to operate READ on resource Resource{type=TABLE, name='test_db_1.test_non_pk_table_1'}",
-                                        guestPrincipal));
+                                        "No permission to %s table %s in database %s",
+                                        READ,
+                                        DATA1_TABLE_PATH.getTableName(),
+                                        DATA1_TABLE_PATH.getDatabaseName()));
             }
             rootAdmin
                     .createAcls(
@@ -467,7 +470,7 @@ public class FlussAuthorizationITCase {
                                             new AccessControlEntry(
                                                     guestPrincipal,
                                                     "*",
-                                                    OperationType.READ,
+                                                    READ,
                                                     PermissionType.ALLOW))))
                     .all()
                     .get();

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -445,6 +445,8 @@ public class FlussAuthorizationITCase {
                                                 PermissionType.ALLOW))))
                 .all()
                 .get();
+        FLUSS_CLUSTER_EXTENSION.waitUtilTableReady(
+                rootAdmin.getTableInfo(DATA1_TABLE_PATH).get().getTableId());
         try (Table table = guestConn.getTable(DATA1_TABLE_PATH)) {
             AppendWriter appendWriter = table.newAppend().createWriter();
             appendWriter.append(row(1, "a")).get();

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizeTCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizeTCase.java
@@ -1,0 +1,569 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.security.acl;
+
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.client.table.Table;
+import com.alibaba.fluss.client.table.scanner.batch.BatchScanner;
+import com.alibaba.fluss.client.table.writer.AppendWriter;
+import com.alibaba.fluss.client.utils.ClientRpcMessageUtils;
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.config.MemorySize;
+import com.alibaba.fluss.metadata.DataLakeFormat;
+import com.alibaba.fluss.metadata.DatabaseDescriptor;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.row.InternalRow;
+import com.alibaba.fluss.rpc.GatewayClientProxy;
+import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.rpc.gateway.AdminGateway;
+import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
+import com.alibaba.fluss.rpc.messages.GetFileSystemSecurityTokenRequest;
+import com.alibaba.fluss.rpc.messages.InitWriterRequest;
+import com.alibaba.fluss.rpc.messages.MetadataRequest;
+import com.alibaba.fluss.rpc.metrics.TestingClientMetricGroup;
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.AccessControlEntryFilter;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceFilter;
+import com.alibaba.fluss.server.testutils.FlussClusterExtension;
+import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Lists;
+import com.alibaba.fluss.utils.CloseableIterator;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.alibaba.fluss.record.TestData.DATA1_SCHEMA;
+import static com.alibaba.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
+import static com.alibaba.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR_PK;
+import static com.alibaba.fluss.record.TestData.DATA1_TABLE_PATH;
+import static com.alibaba.fluss.record.TestData.DATA1_TABLE_PATH_PK;
+import static com.alibaba.fluss.security.acl.AccessControlEntry.WILD_CARD_HOST;
+import static com.alibaba.fluss.security.acl.FlussPrincipal.WILD_CARD_PRINCIPAL;
+import static com.alibaba.fluss.testutils.DataTestUtils.row;
+import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+/** It case to test authorization of admin operation、read and write operation. */
+public class FlussAuthorizeTCase {
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setNumOfTabletServers(3)
+                    .setCoordinatorServerListeners("FLUSS://localhost:0, CLIENT://localhost:0")
+                    .setTabletServerListeners("FLUSS://localhost:0, CLIENT://localhost:0")
+                    .setClusterConf(initConfig())
+                    .build();
+
+    private Connection rootConn;
+    private Admin rootAdmin;
+    private Connection guestConn;
+    private Admin guestAdmin;
+    private Configuration guestConf;
+
+    @BeforeEach
+    protected void setup() throws Exception {
+        Configuration conf = FLUSS_CLUSTER_EXTENSION.getClientConfig("CLIENT");
+        conf.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "username_password");
+        Configuration rootConf = new Configuration(conf);
+        rootConf.setString("client.security.username_password.username", "root");
+        rootConf.setString("client.security.username_password.password", "password");
+        rootConn = ConnectionFactory.createConnection(rootConf);
+        rootAdmin = rootConn.getAdmin();
+
+        guestConf = new Configuration(conf);
+        guestConf.setString("client.security.username_password.username", "guest");
+        guestConf.setString("client.security.username_password.password", "password2");
+        guestConn = ConnectionFactory.createConnection(guestConf);
+        guestAdmin = guestConn.getAdmin();
+
+        // prepare default database and table
+        rootAdmin
+                .createDatabase(
+                        DATA1_TABLE_PATH_PK.getDatabaseName(), DatabaseDescriptor.EMPTY, true)
+                .get();
+        rootAdmin.createTable(DATA1_TABLE_PATH_PK, DATA1_TABLE_DESCRIPTOR_PK, true).get();
+    }
+
+    @AfterEach
+    protected void teardown() throws Exception {
+        if (rootAdmin != null) {
+            rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
+            rootAdmin.close();
+            rootAdmin = null;
+        }
+
+        if (rootConn != null) {
+            rootConn.close();
+            rootConn = null;
+        }
+
+        if (guestAdmin != null) {
+            guestAdmin.close();
+            guestAdmin = null;
+        }
+
+        if (guestConn != null) {
+            guestConn.close();
+            guestConn = null;
+        }
+    }
+
+    @Test
+    void testAclOperation() throws Exception {
+        // test whether have authorization to operate list acls.
+        assertThatThrownBy(() -> guestAdmin.listAcls(AclBindingFilter.ANY).get())
+                .hasMessageContaining(
+                        "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate DESCRIBE on resource Resource{type=CLUSTER, name='fluss-cluster'}");
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.cluster(),
+                                        new AccessControlEntry(
+                                                WILD_CARD_PRINCIPAL,
+                                                WILD_CARD_HOST,
+                                                OperationType.DESCRIBE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        assertThat(guestAdmin.listAcls(AclBindingFilter.ANY).get()).hasSize(1);
+
+        // test whether have authorization to operate create and drop acls.
+        FlussPrincipal user1 = new FlussPrincipal("USER", "test_ufu");
+        AclBinding user1AclBinding =
+                new AclBinding(
+                        Resource.table("test_db", "person"),
+                        new AccessControlEntry(
+                                user1, "*", OperationType.CREATE, PermissionType.ALLOW));
+        List<AclBinding> aclBindings =
+                Arrays.asList(
+                        user1AclBinding,
+                        new AclBinding(
+                                Resource.database("test_db2"),
+                                new AccessControlEntry(
+                                        new FlussPrincipal("ROLE", "test_role"),
+                                        "127.0.0.1",
+                                        OperationType.DROP,
+                                        PermissionType.ANY)),
+                        new AclBinding(
+                                Resource.cluster(),
+                                new AccessControlEntry(
+                                        new FlussPrincipal("ROLE", "test_role"),
+                                        "127.0.0.1",
+                                        OperationType.DROP,
+                                        PermissionType.ALLOW)));
+        assertThatThrownBy(() -> guestAdmin.createAcls(aclBindings).all().get())
+                .hasMessageContaining(
+                        "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate ALTER on resource Resource{type=CLUSTER, name='fluss-cluster'}");
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.cluster(),
+                                        new AccessControlEntry(
+                                                WILD_CARD_PRINCIPAL,
+                                                WILD_CARD_HOST,
+                                                OperationType.ALTER,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        guestAdmin.createAcls(aclBindings).all().get();
+
+        assertThat(
+                        guestAdmin
+                                .listAcls(
+                                        new AclBindingFilter(
+                                                ResourceFilter.ANY,
+                                                new AccessControlEntryFilter(
+                                                        user1,
+                                                        null,
+                                                        OperationType.ANY,
+                                                        PermissionType.ALLOW)))
+                                .get())
+                .containsExactlyInAnyOrderElementsOf(Collections.singleton(user1AclBinding));
+
+        Collection<AclBinding> allAclBinds = rootAdmin.listAcls(AclBindingFilter.ANY).get();
+        assertThat(guestAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get())
+                .containsExactlyInAnyOrderElementsOf(allAclBinds);
+        assertThat(rootAdmin.listAcls(AclBindingFilter.ANY).get()).isEmpty();
+    }
+
+    @Test
+    void testAlterDatabase() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                guestAdmin
+                                        .createDatabase(
+                                                "test-database1", DatabaseDescriptor.EMPTY, false)
+                                        .get())
+                .hasMessageContaining(
+                        "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate CREATE on resource Resource{type=CLUSTER, name='fluss-cluster'}");
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.cluster(),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.CREATE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        guestAdmin.createDatabase("test-database2", DatabaseDescriptor.EMPTY, false).get();
+        assertThat(rootAdmin.databaseExists("test-database1").get()).isFalse();
+        assertThat(rootAdmin.databaseExists("test-database2").get()).isTrue();
+    }
+
+    @Test
+    void testListDatabases() throws ExecutionException, InterruptedException {
+        assertThat(guestAdmin.listDatabases().get())
+                .containsExactlyInAnyOrderElementsOf(Collections.emptyList());
+        assertThat(rootAdmin.listDatabases().get())
+                .containsExactlyInAnyOrderElementsOf(
+                        Lists.newArrayList("fluss", DATA1_TABLE_PATH_PK.getDatabaseName()));
+
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.database("fluss"),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.DESCRIBE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        assertThat(guestAdmin.listDatabases().get()).isEqualTo(Collections.singletonList("fluss"));
+
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.cluster(),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.ALL,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        assertThat(guestAdmin.listDatabases().get())
+                .containsExactlyInAnyOrderElementsOf(
+                        Lists.newArrayList("fluss", DATA1_TABLE_PATH_PK.getDatabaseName()));
+    }
+
+    @Test
+    void testAlterTable() throws Exception {
+        assertThatThrownBy(
+                        () ->
+                                guestAdmin
+                                        .createTable(
+                                                DATA1_TABLE_PATH, DATA1_TABLE_DESCRIPTOR, false)
+                                        .get())
+                .hasMessageContaining(
+                        "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate CREATE on resource Resource{type=DATABASE, name='test_db_1'}");
+        assertThat(rootAdmin.tableExists(DATA1_TABLE_PATH).get()).isFalse();
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.database(DATA1_TABLE_PATH.getDatabaseName()),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.CREATE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        guestAdmin.createTable(DATA1_TABLE_PATH, DATA1_TABLE_DESCRIPTOR, false).get();
+        assertThat(rootAdmin.tableExists(DATA1_TABLE_PATH).get()).isTrue();
+    }
+
+    @Test
+    void testListTables() throws Exception {
+        assertThat(guestAdmin.listTables(DATA1_TABLE_PATH_PK.getDatabaseName()).get())
+                .isEqualTo(Collections.emptyList());
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.database(DATA1_TABLE_PATH_PK.getDatabaseName()),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.DESCRIBE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        assertThat(guestAdmin.listTables(DATA1_TABLE_PATH_PK.getDatabaseName()).get())
+                .isEqualTo(Collections.singletonList(DATA1_TABLE_PATH_PK.getTableName()));
+    }
+
+    @Test
+    void testGetMetaInfo() throws Exception {
+        MetadataRequest metadataRequest =
+                ClientRpcMessageUtils.makeMetadataRequest(
+                        Collections.singleton(DATA1_TABLE_PATH_PK), null, null);
+
+        try (RpcClient rpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+            AdminGateway guestGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            rpcClient,
+                            AdminGateway.class);
+
+            //
+            // assertThat(guestGateway.metadata(metadataRequest).get().getTableMetadatasList())
+            //                    .isEmpty();
+
+            // if add acl to allow guest read any resource, it will allow to get metadata.
+            rootAdmin
+                    .createAcls(
+                            Collections.singletonList(
+                                    new AclBinding(
+                                            Resource.table(
+                                                    DATA1_TABLE_PATH_PK.getDatabaseName(),
+                                                    DATA1_TABLE_PATH_PK.getTableName()),
+                                            new AccessControlEntry(
+                                                    new FlussPrincipal("guest", "USER"),
+                                                    "*",
+                                                    OperationType.DESCRIBE,
+                                                    PermissionType.ALLOW))))
+                    .all()
+                    .get();
+
+            assertThat(guestGateway.metadata(metadataRequest).get().getTableMetadatasList())
+                    .hasSize(1);
+        }
+    }
+
+    @Test
+    void testProduceAndConsumer() throws Exception {
+        TableDescriptor descriptor =
+                TableDescriptor.builder().schema(DATA1_SCHEMA).distributedBy(1).build();
+        rootAdmin.createTable(DATA1_TABLE_PATH, descriptor, false).get();
+        // create acl to allow guest write.
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        Resource.table(
+                                                DATA1_TABLE_PATH.getDatabaseName(),
+                                                DATA1_TABLE_PATH.getTableName()),
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                OperationType.WRITE,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+        try (Table table = guestConn.getTable(DATA1_TABLE_PATH)) {
+            AppendWriter appendWriter = table.newAppend().createWriter();
+            appendWriter.append(row(1, "a")).get();
+
+            try (BatchScanner batchScanner =
+                    table.newScan()
+                            .limit(1)
+                            .createBatchScanner(
+                                    new TableBucket(table.getTableInfo().getTableId(), 0))) {
+                assertThatThrownBy(() -> batchScanner.pollBatch(Duration.ofMinutes(1)))
+                        .hasMessageContaining(
+                                "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate READ on resource Resource{type=TABLE, name='test_db_1.test_non_pk_table_1'}");
+            }
+            rootAdmin
+                    .createAcls(
+                            Collections.singletonList(
+                                    new AclBinding(
+                                            Resource.table(
+                                                    DATA1_TABLE_PATH.getDatabaseName(),
+                                                    DATA1_TABLE_PATH.getTableName()),
+                                            new AccessControlEntry(
+                                                    new FlussPrincipal("guest", "USER"),
+                                                    "*",
+                                                    OperationType.READ,
+                                                    PermissionType.ALLOW))))
+                    .all()
+                    .get();
+
+            // wait for acl notify to tablet server.
+            retry(
+                    Duration.ofMinutes(1),
+                    () ->
+                            assertThat(
+                                            catchThrowable(
+                                                    (() -> {
+                                                        try (BatchScanner batchScanner =
+                                                                table.newScan()
+                                                                        .limit(1)
+                                                                        .createBatchScanner(
+                                                                                new TableBucket(
+                                                                                        table.getTableInfo()
+                                                                                                .getTableId(),
+                                                                                        0))) {
+                                                            CloseableIterator<InternalRow>
+                                                                    internalRowCloseableIterator =
+                                                                            batchScanner.pollBatch(
+                                                                                    Duration
+                                                                                            .ofMinutes(
+                                                                                                    1));
+                                                            assertThat(internalRowCloseableIterator)
+                                                                    .hasNext();
+                                                            assertThat(
+                                                                            internalRowCloseableIterator
+                                                                                    .next())
+                                                                    .isEqualTo(row(1, "a"));
+                                                        }
+                                                    })))
+                                    .doesNotThrowAnyException());
+        }
+    }
+
+    @Test
+    void testInitWriter() throws Exception {
+        try (RpcClient rpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+            TabletServerGateway guestTabletServerGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getTabletServerNodes("CLIENT").get(0),
+                            rpcClient,
+                            TabletServerGateway.class);
+            assertThatThrownBy(
+                            () ->
+                                    guestTabletServerGateway
+                                            .initWriter(new InitWriterRequest())
+                                            .get())
+                    .hasMessageContaining(
+                            "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate IDEMPOTENT_WRITE on resource Resource{type=CLUSTER, name='fluss-cluster'}");
+            // if add acl to allow guest write any resource, it will allow to INIT_WRITER.
+            rootAdmin
+                    .createAcls(
+                            Collections.singletonList(
+                                    new AclBinding(
+                                            Resource.database(DATA1_TABLE_PATH.getDatabaseName()),
+                                            new AccessControlEntry(
+                                                    new FlussPrincipal("guest", "USER"),
+                                                    "*",
+                                                    OperationType.WRITE,
+                                                    PermissionType.ALLOW))))
+                    .all()
+                    .get();
+
+            // wait for acl notify to tablet server.
+            retry(
+                    Duration.ofMinutes(1),
+                    () ->
+                            assertThat(
+                                            catchThrowable(
+                                                    (() ->
+                                                            assertThat(
+                                                                            guestTabletServerGateway
+                                                                                    .initWriter(
+                                                                                            new InitWriterRequest())
+                                                                                    .get()
+                                                                                    .hasWriterId())
+                                                                    .isTrue())))
+                                    .doesNotThrowAnyException());
+        }
+    }
+
+    @Test
+    void testGetFileSystemSecurityToken() throws Exception {
+        try (RpcClient rpcClient =
+                RpcClient.create(guestConf, TestingClientMetricGroup.newInstance())) {
+            AdminGateway guestGateway =
+                    GatewayClientProxy.createGatewayProxy(
+                            () -> FLUSS_CLUSTER_EXTENSION.getCoordinatorServerNode("CLIENT"),
+                            rpcClient,
+                            AdminGateway.class);
+            assertThatThrownBy(
+                            () ->
+                                    guestGateway
+                                            .getFileSystemSecurityToken(
+                                                    new GetFileSystemSecurityTokenRequest())
+                                            .get())
+                    .hasMessageContaining(
+                            "Principal FlussPrincipal{name='guest', type='USER'} have no authorization to operate FILESYSTEM_TOKEN on resource Resource{type=CLUSTER, name='fluss-cluster'}");
+            // if add acl to allow guest read any resource, it will allow to FILESYSTEM_TOKEN.
+            rootAdmin
+                    .createAcls(
+                            Collections.singletonList(
+                                    new AclBinding(
+                                            Resource.table(
+                                                    DATA1_TABLE_PATH.getDatabaseName(),
+                                                    DATA1_TABLE_PATH.getTableName()),
+                                            new AccessControlEntry(
+                                                    new FlussPrincipal("guest", "USER"),
+                                                    "*",
+                                                    OperationType.READ,
+                                                    PermissionType.ALLOW))))
+                    .all()
+                    .get();
+            assertThat(
+                            guestGateway
+                                    .getFileSystemSecurityToken(
+                                            new GetFileSystemSecurityTokenRequest())
+                                    .get()
+                                    .getToken())
+                    .isEmpty();
+        }
+    }
+
+    private static Configuration initConfig() {
+        Configuration conf = new Configuration();
+        conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
+        // set a shorter interval for testing purpose
+        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
+        // set a shorter max lag time to make tests in FlussFailServerTableITCase faster
+        conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(10));
+        // set default datalake format for the cluster and enable datalake tables
+        conf.set(ConfigOptions.DATALAKE_FORMAT, DataLakeFormat.PAIMON);
+
+        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, MemorySize.parse("1mb"));
+        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, MemorySize.parse("1kb"));
+
+        // set security information.
+        conf.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:username_password");
+        conf.setString("security.username_password.credentials", "root:password,guest:password2");
+        conf.set(ConfigOptions.SUPER_USERS, "USER:root");
+        conf.set(ConfigOptions.AUTHORIZER_PLUGIN_TYPE, "zookeeper");
+        return conf;
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.cluster;
 
 import com.alibaba.fluss.annotation.Internal;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -62,6 +63,8 @@ public interface MetadataCache {
     Map<Integer, ServerNode> getAllAliveTabletServers(String listenerName);
 
     Set<Integer> getAliveTabletServerIds();
+
+    PhysicalTablePath getTablePath(long tableId);
 
     /** Get ids of all alive tablet server nodes. */
     default int[] getLiveServerIds() {

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
@@ -19,6 +19,8 @@ package com.alibaba.fluss.cluster;
 import com.alibaba.fluss.annotation.Internal;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 
+import javax.annotation.Nullable;
+
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Optional;
@@ -64,6 +66,7 @@ public interface MetadataCache {
 
     Set<Integer> getAliveTabletServerIds();
 
+    @Nullable
     PhysicalTablePath getTablePath(long tableId);
 
     /** Get ids of all alive tablet server nodes. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -129,6 +129,29 @@ public class ConfigOptions {
                             "Limits the maximum number of partitions that can be created for a partitioned table "
                                     + "to avoid creating too many partitions.");
 
+    public static final ConfigOption<Duration> ACL_NOTIFICATION_EXPIRATION_TIME =
+            key("acl.notification.expiration-time")
+                    .durationType()
+                    .defaultValue(Duration.ofMinutes(15))
+                    .withDescription(
+                            "The unit of auto partition check interval. "
+                                    + "The default value is 1 second.");
+
+    public static final ConfigOption<String> AUTHORIZER_PLUGIN_TYPE =
+            key("authorizer.type")
+                    .stringType()
+                    .defaultValue("zookeeper")
+                    .withDescription("The class name of the authorizer plugin. ");
+
+    public static final ConfigOption<String> SUPER_USERS =
+            key("super.users")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "A comma-separated list of superusers who have unrestricted access to all operations and resources. "
+                                    + "Each superuser should be specified in the format 'principal_type:principal_name', e.g., 'User:admin'. "
+                                    + "This configuration is critical for defining administrative privileges in the system.");
+
     // ------------------------------------------------------------------------
     //  ConfigOptions for Coordinator Server
     // ------------------------------------------------------------------------

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -134,21 +134,37 @@ public class ConfigOptions {
                     .durationType()
                     .defaultValue(Duration.ofMinutes(15))
                     .withDescription(
-                            "The unit of auto partition check interval. "
-                                    + "The default value is 1 second.");
+                            "The duration for which ACL notifications are valid before they expire. "
+                                    + "This configuration determines the time window during which an ACL notification is considered active. "
+                                    + "After this duration, the notification will no longer be valid and will be discarded. "
+                                    + "The default value is 15 minutes. "
+                                    + "This setting is important to ensure that ACL changes are propagated in a timely manner and do not remain active longer than necessary.");
 
-    public static final ConfigOption<String> AUTHORIZER_PLUGIN_TYPE =
+    public static final ConfigOption<Boolean> AUTHORIZER_ENABLED =
+            key("authorizer.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription(
+                            "Specifies whether to enable the authorization feature. "
+                                    + "If enabled, access control is enforced based on the authorization rules defined in the configuration. "
+                                    + "If disabled, all operations and resources are accessible to all users.");
+
+    public static final ConfigOption<String> AUTHORIZER_TYPE =
             key("authorizer.type")
                     .stringType()
-                    .noDefaultValue()
-                    .withDescription("The class name of the authorizer plugin. ");
+                    .defaultValue("default")
+                    .withDescription(
+                            "Specifies the type of authorizer to be used for access control. "
+                                    + "This value corresponds to the identifier of the authorization plugin. "
+                                    + "The default value is 'default', which indicates the built-in authorizer. "
+                                    + "Custom authorizers can be implemented by providing a matching plugin identifier.");
 
     public static final ConfigOption<String> SUPER_USERS =
             key("super.users")
                     .stringType()
                     .noDefaultValue()
                     .withDescription(
-                            "A comma-separated list of superusers who have unrestricted access to all operations and resources. "
+                            "A semicolon-separated list of superusers who have unrestricted access to all operations and resources. "
                                     + "Each superuser should be specified in the format 'principal_type:principal_name', e.g., 'User:admin'. "
                                     + "This configuration is critical for defining administrative privileges in the system.");
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -156,7 +156,7 @@ public class ConfigOptions {
                     .withDescription(
                             "Specifies the type of authorizer to be used for access control. "
                                     + "This value corresponds to the identifier of the authorization plugin. "
-                                    + "The default value is 'default', which indicates the built-in authorizer. "
+                                    + "The default value is 'default', which indicates the built-in authorizer implementation. "
                                     + "Custom authorizers can be implemented by providing a matching plugin identifier.");
 
     public static final ConfigOption<String> SUPER_USERS =
@@ -165,7 +165,8 @@ public class ConfigOptions {
                     .noDefaultValue()
                     .withDescription(
                             "A semicolon-separated list of superusers who have unrestricted access to all operations and resources. "
-                                    + "Each superuser should be specified in the format 'principal_type:principal_name', e.g., 'User:admin'. "
+                                    + "Note that the delimiter is semicolon since SSL user names may contain comma, "
+                                    + "and each super user should be specified in the format 'principal_type:principal_name', e.g., 'User:admin;User:bob'. "
                                     + "This configuration is critical for defining administrative privileges in the system.");
 
     // ------------------------------------------------------------------------

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -140,7 +140,7 @@ public class ConfigOptions {
     public static final ConfigOption<String> AUTHORIZER_PLUGIN_TYPE =
             key("authorizer.type")
                     .stringType()
-                    .defaultValue("zookeeper")
+                    .noDefaultValue()
                     .withDescription("The class name of the authorizer plugin. ");
 
     public static final ConfigOption<String> SUPER_USERS =

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/AuthorizationException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/AuthorizationException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/**
+ * This exception is thrown if no authorization.
+ *
+ * @since 0.7
+ */
+public class AuthorizationException extends ApiException {
+    public AuthorizationException(String message) {
+        super(message);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/SecurityDisabledException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/SecurityDisabledException.java
@@ -14,20 +14,18 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.server.authorizer;
+package com.alibaba.fluss.exception;
 
-import com.alibaba.fluss.config.Configuration;
+/**
+ * Exception for no security enabled.
+ *
+ * @since 0.7
+ */
+public class SecurityDisabledException extends ApiException {
 
-/** AuthorizerPlugin based on zookeeper. */
-public class ZooKeeperBasedAuthorizationPlugin implements AuthorizationPlugin {
+    private static final long serialVersionUID = 1L;
 
-    @Override
-    public String identifier() {
-        return "zookeeper";
-    }
-
-    @Override
-    public Authorizer createAuthorizer(Configuration configuration) {
-        return new ZooKeeperBasedAuthorizer(configuration);
+    public SecurityDisabledException(String message) {
+        super(message);
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/**
+ * Represents an Access Control List (ACL) entry defining permissions for a principal on a specific
+ * resource operation.
+ *
+ * <p>This class encapsulates the core elements of an ACL entry:
+ *
+ * <p>- Principal: User/role identifier
+ *
+ * <p>- Permission: Allow or deny access
+ *
+ * <p>- Host: Source host restriction (can be "*" for any host)
+ *
+ * <p>- Operation: Specific operation type (e.g., read/write)
+ */
+public class AccessControlEntry {
+    public static final String WILD_CARD_HOST = "*";
+
+    private final FlussPrincipal principal;
+    private final PermissionType permissionType;
+    private final String host;
+    private final OperationType operationType;
+
+    public AccessControlEntry(
+            FlussPrincipal principal,
+            String host,
+            OperationType operationType,
+            PermissionType permissionType) {
+        this.principal = principal;
+        this.permissionType = permissionType;
+        this.host = host;
+        this.operationType = operationType;
+    }
+
+    public FlussPrincipal getPrincipal() {
+        return principal;
+    }
+
+    public PermissionType getPermissionType() {
+        return permissionType;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AccessControlEntry that = (AccessControlEntry) o;
+        return Objects.equals(principal, that.principal)
+                && permissionType == that.permissionType
+                && Objects.equals(host, that.host)
+                && operationType == that.operationType;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(principal, permissionType, host, operationType);
+    }
+
+    @Override
+    public String toString() {
+        return "AccessControlEntry{"
+                + "principal="
+                + principal
+                + ", permissionType="
+                + permissionType
+                + ", host='"
+                + host
+                + '\''
+                + ", operationType="
+                + operationType
+                + '}';
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
@@ -20,6 +20,8 @@ import com.alibaba.fluss.annotation.PublicEvolving;
 
 import java.util.Objects;
 
+import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
+
 /**
  * Represents an Access Control List (ACL) entry defining permissions for a principal on a specific
  * resource operation.
@@ -50,14 +52,10 @@ public class AccessControlEntry {
             String host,
             OperationType operationType,
             PermissionType permissionType) {
-        Objects.requireNonNull(principal);
-        Objects.requireNonNull(host);
-        Objects.requireNonNull(operationType);
-        Objects.requireNonNull(permissionType);
-        this.principal = principal;
-        this.host = host;
-        this.permissionType = permissionType;
-        this.operationType = operationType;
+        this.principal = checkNotNull(principal);
+        this.host = checkNotNull(host);
+        this.permissionType = checkNotNull(permissionType);
+        this.operationType = checkNotNull(operationType);
     }
 
     public FlussPrincipal getPrincipal() {

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntry.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 import java.util.Objects;
 
 /**
@@ -31,7 +33,10 @@ import java.util.Objects;
  * <p>- Host: Source host restriction (can be "*" for any host)
  *
  * <p>- Operation: Specific operation type (e.g., read/write)
+ *
+ * @since 0.7
  */
+@PublicEvolving
 public class AccessControlEntry {
     public static final String WILD_CARD_HOST = "*";
 
@@ -45,9 +50,13 @@ public class AccessControlEntry {
             String host,
             OperationType operationType,
             PermissionType permissionType) {
+        Objects.requireNonNull(principal);
+        Objects.requireNonNull(host);
+        Objects.requireNonNull(operationType);
+        Objects.requireNonNull(permissionType);
         this.principal = principal;
-        this.permissionType = permissionType;
         this.host = host;
+        this.permissionType = permissionType;
         this.operationType = operationType;
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/**
+ * Represents a filter which matches access control entries.
+ *
+ * <p>The API for this class is still evolving and we may break compatibility in minor releases, if
+ * necessary.
+ */
+public class AccessControlEntryFilter {
+    private final AccessControlEntry data;
+
+    public static final AccessControlEntryFilter ANY =
+            new AccessControlEntryFilter(
+                    FlussPrincipal.ANY, null, OperationType.ANY, PermissionType.ANY);
+
+    public AccessControlEntryFilter(
+            FlussPrincipal principal,
+            String host,
+            OperationType operation,
+            PermissionType permissionType) {
+        Objects.requireNonNull(operation);
+        Objects.requireNonNull(permissionType);
+        this.data = new AccessControlEntry(principal, host, operation, permissionType);
+    }
+
+    /** Returns true if this filter matches the given AccessControlEntry. */
+    public boolean matches(AccessControlEntry other) {
+        if ((data.getPrincipal() != null)
+                && data.getPrincipal() != FlussPrincipal.ANY
+                && (!data.getPrincipal().equals(other.getPrincipal()))) {
+            return false;
+        }
+        if ((data.getHost() != null) && (!data.getHost().equals(other.getHost()))) {
+            return false;
+        }
+        if ((data.getOperationType() != OperationType.ANY)
+                && (!data.getOperationType().equals(other.getOperationType()))) {
+            return false;
+        }
+        if ((data.getPermissionType() != PermissionType.ANY)
+                && (!data.getPermissionType().equals(other.getPermissionType()))) {
+            return false;
+        }
+        return true;
+    }
+
+    public AccessControlEntry getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AccessControlEntryFilter)) {
+            return false;
+        }
+        AccessControlEntryFilter other = (AccessControlEntryFilter) o;
+        return data.equals(other.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return data.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "AccessControlEntryFilter{" + "data=" + data + '}';
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 
 import java.util.Objects;
 
+import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
+
 /**
  * Represents a filter which matches access control entries.
  *
@@ -48,10 +50,8 @@ public class AccessControlEntryFilter {
             PermissionType permissionType) {
         this.principal = principal;
         this.host = host;
-        Objects.requireNonNull(operation);
-        Objects.requireNonNull(permissionType);
-        this.operationType = operation;
-        this.permissionType = permissionType;
+        this.operationType = checkNotNull(operation);
+        this.permissionType = checkNotNull(permissionType);
     }
 
     /** Returns true if this filter matches the given AccessControlEntry. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AccessControlEntryFilter.java
@@ -16,6 +16,10 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
+import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -23,65 +27,99 @@ import java.util.Objects;
  *
  * <p>The API for this class is still evolving and we may break compatibility in minor releases, if
  * necessary.
+ *
+ * @since 0.7
  */
+@PublicEvolving
 public class AccessControlEntryFilter {
-    private final AccessControlEntry data;
+    @Nullable private final FlussPrincipal principal;
+    private final PermissionType permissionType;
+    @Nullable private final String host;
+    private final OperationType operationType;
 
     public static final AccessControlEntryFilter ANY =
             new AccessControlEntryFilter(
                     FlussPrincipal.ANY, null, OperationType.ANY, PermissionType.ANY);
 
     public AccessControlEntryFilter(
-            FlussPrincipal principal,
-            String host,
+            @Nullable FlussPrincipal principal,
+            @Nullable String host,
             OperationType operation,
             PermissionType permissionType) {
+        this.principal = principal;
+        this.host = host;
         Objects.requireNonNull(operation);
         Objects.requireNonNull(permissionType);
-        this.data = new AccessControlEntry(principal, host, operation, permissionType);
+        this.operationType = operation;
+        this.permissionType = permissionType;
     }
 
     /** Returns true if this filter matches the given AccessControlEntry. */
     public boolean matches(AccessControlEntry other) {
-        if ((data.getPrincipal() != null)
-                && data.getPrincipal() != FlussPrincipal.ANY
-                && (!data.getPrincipal().equals(other.getPrincipal()))) {
+        if ((principal != null)
+                && principal != FlussPrincipal.ANY
+                && (!principal.equals(other.getPrincipal()))) {
             return false;
         }
-        if ((data.getHost() != null) && (!data.getHost().equals(other.getHost()))) {
+        if ((host != null) && (!host.equals(other.getHost()))) {
             return false;
         }
-        if ((data.getOperationType() != OperationType.ANY)
-                && (!data.getOperationType().equals(other.getOperationType()))) {
+        if ((operationType != OperationType.ANY)
+                && (!operationType.equals(other.getOperationType()))) {
             return false;
         }
-        if ((data.getPermissionType() != PermissionType.ANY)
-                && (!data.getPermissionType().equals(other.getPermissionType()))) {
+        if ((permissionType != PermissionType.ANY)
+                && (!permissionType.equals(other.getPermissionType()))) {
             return false;
         }
         return true;
     }
 
-    public AccessControlEntry getData() {
-        return data;
+    public @Nullable FlussPrincipal getPrincipal() {
+        return principal;
+    }
+
+    public @Nullable String getHost() {
+        return host;
+    }
+
+    public PermissionType getPermissionType() {
+        return permissionType;
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof AccessControlEntryFilter)) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        AccessControlEntryFilter other = (AccessControlEntryFilter) o;
-        return data.equals(other.data);
+        AccessControlEntryFilter that = (AccessControlEntryFilter) o;
+        return Objects.equals(principal, that.principal)
+                && permissionType == that.permissionType
+                && Objects.equals(host, that.host)
+                && operationType == that.operationType;
     }
 
     @Override
     public int hashCode() {
-        return data.hashCode();
+        return Objects.hash(principal, permissionType, host, operationType);
     }
 
     @Override
     public String toString() {
-        return "AccessControlEntryFilter{" + "data=" + data + '}';
+        return "AccessControlEntryFilter{"
+                + "principal="
+                + principal
+                + ", permissionType="
+                + permissionType
+                + ", host='"
+                + host
+                + '\''
+                + ", operationType="
+                + operationType
+                + '}';
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBinding.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBinding.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/**
+ * Represents an Access Control List (ACL) binding that associates a resource with specific access
+ * control rules.
+ *
+ * <p>An {@code AclBinding} encapsulates the relationship between a {@link Resource} and an {@link
+ * AccessControlEntry}, defining which principal (user/role) has what permissions on the resource.
+ *
+ * @since 0.6
+ */
+public class AclBinding {
+    private final Resource resource;
+    private final AccessControlEntry accessControlEntry;
+
+    public AclBinding(Resource resource, AccessControlEntry accessControlEntry) {
+        this.resource = resource;
+        this.accessControlEntry = accessControlEntry;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public AccessControlEntry getAccessControlEntry() {
+        return accessControlEntry;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AclBinding that = (AclBinding) o;
+        return Objects.equals(resource, that.resource)
+                && Objects.equals(accessControlEntry, that.accessControlEntry);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resource, accessControlEntry);
+    }
+
+    @Override
+    public String toString() {
+        return "AclBinding{"
+                + "resource="
+                + resource
+                + ", accessControlEntry="
+                + accessControlEntry
+                + '}';
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBinding.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBinding.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 import java.util.Objects;
 
 /**
@@ -25,8 +27,9 @@ import java.util.Objects;
  * <p>An {@code AclBinding} encapsulates the relationship between a {@link Resource} and an {@link
  * AccessControlEntry}, defining which principal (user/role) has what permissions on the resource.
  *
- * @since 0.6
+ * @since 0.7
  */
+@PublicEvolving
 public class AclBinding {
     private final Resource resource;
     private final AccessControlEntry accessControlEntry;

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBindingFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBindingFilter.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/** A filter which can match AclBinding objects. */
+public class AclBindingFilter {
+    private final ResourceFilter resourceFilter;
+    private final AccessControlEntryFilter entryFilter;
+
+    /** A filter which matches any ACL binding. */
+    public static final AclBindingFilter ANY =
+            new AclBindingFilter(ResourceFilter.ANY, AccessControlEntryFilter.ANY);
+
+    public AclBindingFilter(ResourceFilter resourceFilter, AccessControlEntryFilter entryFilter) {
+        Objects.requireNonNull(resourceFilter);
+        this.resourceFilter = resourceFilter;
+        Objects.requireNonNull(entryFilter);
+        this.entryFilter = entryFilter;
+    }
+
+    public boolean matches(AclBinding binding) {
+        return resourceFilter.matches(binding.getResource())
+                && entryFilter.matches(binding.getAccessControlEntry());
+    }
+
+    public ResourceFilter getResourceFilter() {
+        return resourceFilter;
+    }
+
+    public AccessControlEntryFilter getEntryFilter() {
+        return entryFilter;
+    }
+
+    @Override
+    public String toString() {
+        return "(resourceFilter=" + resourceFilter + ", entryFilter=" + entryFilter + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof AclBindingFilter)) {
+            return false;
+        }
+        AclBindingFilter other = (AclBindingFilter) o;
+        return resourceFilter.equals(other.resourceFilter) && entryFilter.equals(other.entryFilter);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(resourceFilter, entryFilter);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBindingFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/AclBindingFilter.java
@@ -16,9 +16,16 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 import java.util.Objects;
 
-/** A filter which can match AclBinding objects. */
+/**
+ * A filter which can match AclBinding objects.
+ *
+ * @since 0.7
+ */
+@PublicEvolving
 public class AclBindingFilter {
     private final ResourceFilter resourceFilter;
     private final AccessControlEntryFilter entryFilter;

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/FlussPrincipal.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/FlussPrincipal.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.security.Principal;
+import java.util.Objects;
+
+/**
+ * Represents a security principal in Fluss, defined by a {@code name} and {@code type}.
+ *
+ * <p>The principal type indicates the category of the principal (e.g., "User", "Group", "Role"),
+ * while the name identifies the specific entity within that category. By default, the simple
+ * authorizer uses "User" as the principal type, but custom authorizers can extend this to support
+ * role-based or group-based access control lists (ACLs).
+ *
+ * <p>Example usage:
+ *
+ * <ul>
+ *   <li>{@code new FlussPrincipal("admin", "User")} – A standard user principal.
+ *   <li>{@code new FlussPrincipal("admins", "Group")} – A group-based principal for authorization.
+ * </ul>
+ *
+ * @since 0.7
+ */
+public class FlussPrincipal implements Principal {
+    public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", "User");
+    /** The wildcard principal, which represents all principals. */
+    public static final FlussPrincipal WILD_CARD_PRINCIPAL = new FlussPrincipal("*", "*");
+
+    /** The wildcard principal, which is only used in filter to matches all principals. */
+    public static final FlussPrincipal ANY = new FlussPrincipal(null, null);
+
+    private final String name;
+    private final String type;
+
+    public FlussPrincipal(String name, String type) {
+        this.name = name;
+        this.type = type;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FlussPrincipal that = (FlussPrincipal) o;
+        return Objects.equals(name, that.name) && Objects.equals(type, that.type);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, type);
+    }
+
+    @Override
+    public String toString() {
+        return "FlussPrincipal{" + "name='" + name + '\'' + ", type='" + type + '\'' + '}';
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/FlussPrincipal.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/FlussPrincipal.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 import java.security.Principal;
 import java.util.Objects;
 
@@ -36,6 +38,7 @@ import java.util.Objects;
  *
  * @since 0.7
  */
+@PublicEvolving
 public class FlussPrincipal implements Principal {
     public static final FlussPrincipal ANONYMOUS = new FlussPrincipal("ANONYMOUS", "User");
     /** The wildcard principal, which represents all principals. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/OperationType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/OperationType.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+/**
+ * Enumeration representing operation types used in ACL (Access Control List) systems.
+ *
+ * <p><b>Permission Inheritance Rules:</b>
+ *
+ * <p>1. {@link #ALL} grants permission for all operations
+ *
+ * <p>2. {@link #READ}, {@link #WRITE}, {@link #CREATE}, {@link #DROP}, and {@link #ALTER}
+ * implicitly include {@link #DESCRIBE}
+ *
+ * <p>3. When a user is granted {@link #WRITE} permission on any resource: - Automatically grants
+ * {@link #IDEMPOTENT_WRITE} permission permissions on cluster.
+ *
+ * <p>4. When a user is granted {@link #READ} permission on any resource: - Automatically grants
+ * {@link #FILESYSTEM_TOKEN} permission on cluster.
+ */
+public enum OperationType {
+    /** In a filter, matches any OperationType. */
+    ANY((byte) 1),
+    ALL((byte) 2),
+    READ((byte) 3),
+    WRITE((byte) 4),
+    CREATE((byte) 5),
+    DROP((byte) 6),
+    ALTER((byte) 7),
+    DESCRIBE((byte) 8),
+    IDEMPOTENT_WRITE((byte) 12),
+    FILESYSTEM_TOKEN((byte) 500);
+
+    private final byte code;
+
+    OperationType(byte code) {
+        this.code = code;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+
+    public static OperationType fromCode(byte code) {
+        for (OperationType operationType : OperationType.values()) {
+            if (operationType.code == code) {
+                return operationType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown operation type code: " + code);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/OperationType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/OperationType.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 /**
  * Enumeration representing operation types used in ACL (Access Control List) systems.
  *
@@ -26,12 +28,9 @@ package com.alibaba.fluss.security.acl;
  * <p>2. {@link #READ}, {@link #WRITE}, {@link #CREATE}, {@link #DROP}, and {@link #ALTER}
  * implicitly include {@link #DESCRIBE}
  *
- * <p>3. When a user is granted {@link #WRITE} permission on any resource: - Automatically grants
- * {@link #IDEMPOTENT_WRITE} permission permissions on cluster.
- *
- * <p>4. When a user is granted {@link #READ} permission on any resource: - Automatically grants
- * {@link #FILESYSTEM_TOKEN} permission on cluster.
+ * @since 0.7
  */
+@PublicEvolving
 public enum OperationType {
     /** In a filter, matches any OperationType. */
     ANY((byte) 1),
@@ -41,9 +40,7 @@ public enum OperationType {
     CREATE((byte) 5),
     DROP((byte) 6),
     ALTER((byte) 7),
-    DESCRIBE((byte) 8),
-    IDEMPOTENT_WRITE((byte) 12),
-    FILESYSTEM_TOKEN((byte) 500);
+    DESCRIBE((byte) 8);
 
     private final byte code;
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/PermissionType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/PermissionType.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+/** Enumeration representing permission types used in ACL. */
+public enum PermissionType {
+    /** In a filter, matches any PermissionType. */
+    ANY((byte) 1),
+
+    /**
+     * Permission type indicating allowed access. Grants explicit permission for specified
+     * operations on resources.
+     */
+    ALLOW((byte) 3);
+
+    private final byte code;
+
+    PermissionType(byte code) {
+        this.code = code;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+
+    public static PermissionType fromCode(byte code) {
+        for (PermissionType type : values()) {
+            if (type.code == code) {
+                return type;
+            }
+        }
+        throw new IllegalArgumentException("Unknown permission type: " + code);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/PermissionType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/PermissionType.java
@@ -16,7 +16,11 @@
 
 package com.alibaba.fluss.security.acl;
 
-/** Enumeration representing permission types used in ACL. */
+/**
+ * Enumeration representing permission types used in ACL.
+ *
+ * @since 0.7
+ */
 public enum PermissionType {
     /** In a filter, matches any PermissionType. */
     ANY((byte) 1),
@@ -25,7 +29,9 @@ public enum PermissionType {
      * Permission type indicating allowed access. Grants explicit permission for specified
      * operations on resources.
      */
-    ALLOW((byte) 3);
+    ALLOW((byte) 2);
+
+    // todo: Will introduce DENY type in the future.
 
     private final byte code;
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
@@ -1,0 +1,83 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/**
+ * Represents a resource object with type and name, used for ACL (Access Control List) management.
+ */
+public class Resource {
+    public static final String WILDCARD_RESOURCE = "*";
+    public static final String TABLE_SPLITTER = "\\.";
+
+    private static final String FLUSS_CLUSTER = "fluss-cluster";
+    private final ResourceType type;
+    private final String name;
+
+    public Resource(ResourceType type, String name) {
+        this.type = type;
+        this.name = name;
+    }
+
+    public static Resource of(String resourceType, String resourceName) {
+        return new Resource(ResourceType.fromName(resourceType), resourceName);
+    }
+
+    public ResourceType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Resource resource = (Resource) o;
+        return type == resource.type && Objects.equals(name, resource.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name);
+    }
+
+    @Override
+    public String toString() {
+        return "Resource{" + "type=" + type + ", name='" + name + '\'' + '}';
+    }
+
+    public static Resource any() {
+        return new Resource(ResourceType.ANY, "any");
+    }
+
+    public static Resource cluster() {
+        return new Resource(ResourceType.CLUSTER, FLUSS_CLUSTER);
+    }
+
+    public static Resource database(String databaseName) {
+        return new Resource(ResourceType.DATABASE, databaseName);
+    }
+
+    public static Resource table(String databaseName, String tableName) {
+        return new Resource(ResourceType.TABLE, databaseName + "." + tableName);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
@@ -16,10 +16,14 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.metadata.TablePath;
+
 import java.util.Objects;
 
 /**
  * Represents a resource object with type and name, used for ACL (Access Control List) management.
+ *
+ * @since 0.7
  */
 public class Resource {
     public static final String WILDCARD_RESOURCE = "*";
@@ -79,5 +83,10 @@ public class Resource {
 
     public static Resource table(String databaseName, String tableName) {
         return new Resource(ResourceType.TABLE, databaseName + "." + tableName);
+    }
+
+    public static Resource table(TablePath tablePath) {
+        return new Resource(
+                ResourceType.TABLE, tablePath.getDatabaseName() + "." + tablePath.getTableName());
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/Resource.java
@@ -86,7 +86,6 @@ public class Resource {
     }
 
     public static Resource table(TablePath tablePath) {
-        return new Resource(
-                ResourceType.TABLE, tablePath.getDatabaseName() + "." + tablePath.getTableName());
+        return table(tablePath.getDatabaseName(), tablePath.getTableName());
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+import java.util.Objects;
+
+/** A filter which matches Resource objects. */
+public class ResourceFilter {
+    private final ResourceType type;
+    private final String name;
+
+    public static final ResourceFilter ANY = new ResourceFilter(ResourceType.ANY, null);
+
+    public ResourceFilter(ResourceType type, String name) {
+        Objects.requireNonNull(type);
+        this.type = type;
+        this.name = name;
+    }
+
+    public ResourceType getType() {
+        return type;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return "(resourceType=" + type + ", name=" + ((name == null) ? "<any>" : name) + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ResourceFilter)) {
+            return false;
+        }
+        ResourceFilter other = (ResourceFilter) o;
+        return type.equals(other.type) && Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name);
+    }
+
+    public boolean matches(Resource other) {
+        if ((name != null) && (!name.equals(other.getName()))) {
+            return false;
+        }
+        if ((type != ResourceType.ANY) && (!type.equals(other.getType()))) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
@@ -16,16 +16,25 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
+import javax.annotation.Nullable;
+
 import java.util.Objects;
 
-/** A filter which matches Resource objects. */
+/**
+ * A filter which matches Resource objects.
+ *
+ * @since 0.7
+ */
+@PublicEvolving
 public class ResourceFilter {
     private final ResourceType type;
-    private final String name;
+    @Nullable private final String name;
 
     public static final ResourceFilter ANY = new ResourceFilter(ResourceType.ANY, null);
 
-    public ResourceFilter(ResourceType type, String name) {
+    public ResourceFilter(ResourceType type, @Nullable String name) {
         Objects.requireNonNull(type);
         this.type = type;
         this.name = name;
@@ -35,7 +44,7 @@ public class ResourceFilter {
         return type;
     }
 
-    public String getName() {
+    public @Nullable String getName() {
         return name;
     }
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
@@ -52,9 +52,25 @@ public class ResourceFilter {
         if ((name != null) && (!name.equals(other.getName()))) {
             return false;
         }
-        if ((type != ResourceType.ANY) && (!type.equals(other.getType()))) {
+        return (type == ResourceType.ANY) || (type.equals(other.getType()));
+    }
+
+    @Override
+    public String toString() {
+        return "(resourceType=" + type + ", name=" + ((name == null) ? "<any>" : name) + ")";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ResourceFilter)) {
             return false;
         }
-        return true;
+        ResourceFilter other = (ResourceFilter) o;
+        return type.equals(other.type) && Objects.equals(name, other.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(type, name);
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceFilter.java
@@ -48,25 +48,6 @@ public class ResourceFilter {
         return name;
     }
 
-    @Override
-    public String toString() {
-        return "(resourceType=" + type + ", name=" + ((name == null) ? "<any>" : name) + ")";
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (!(o instanceof ResourceFilter)) {
-            return false;
-        }
-        ResourceFilter other = (ResourceFilter) o;
-        return type.equals(other.type) && Objects.equals(name, other.name);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(type, name);
-    }
-
     public boolean matches(Resource other) {
         if ((name != null) && (!name.equals(other.getName()))) {
             return false;

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceType.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.security.acl;
+
+/**
+ * Enumeration representing resource types used in ACL management. Permission hierarchies are
+ * defined as follows:
+ *
+ * <p>1. CLUSTER permissions implicitly include all own database permissions under the same
+ * operation. 2. DATABASE permissions implicitly include all own tables permissions under the same
+ * operation 3. ANY represents global permissions covering all resource types, this only used for
+ * lookup.
+ *
+ * <p>This hierarchy ensures that higher-level permissions automatically grant access to lower-level
+ * resources within the same operation.
+ */
+public enum ResourceType {
+    /** In a filter, matches any ResourceType. */
+    ANY((byte) 1),
+    CLUSTER((byte) 2),
+    DATABASE((byte) 3),
+    TABLE((byte) 4);
+
+    private final byte code;
+
+    ResourceType(byte code) {
+        this.code = code;
+    }
+
+    public byte getCode() {
+        return code;
+    }
+
+    public static ResourceType fromCode(byte code) {
+        for (ResourceType resourceType : values()) {
+            if (resourceType.code == code) {
+                return resourceType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown resource type code " + code);
+    }
+
+    public static ResourceType fromName(String name) {
+        for (ResourceType resourceType : values()) {
+            if (resourceType.name().equalsIgnoreCase(name)) {
+                return resourceType;
+            }
+        }
+        throw new IllegalArgumentException("Unknown resource type name " + name);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceType.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/acl/ResourceType.java
@@ -32,6 +32,8 @@
 
 package com.alibaba.fluss.security.acl;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 /**
  * Enumeration representing resource types used in ACL management. Permission hierarchies are
  * defined as follows:
@@ -43,7 +45,10 @@ package com.alibaba.fluss.security.acl;
  *
  * <p>This hierarchy ensures that higher-level permissions automatically grant access to lower-level
  * resources within the same operation.
+ *
+ * @since 0.7
  */
+@PublicEvolving
 public enum ResourceType {
     /** In a filter, matches any ResourceType. */
     ANY((byte) 1),

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationFactory.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metadata.ValidationException;
@@ -53,6 +54,7 @@ import java.util.stream.Collectors;
  *
  * @since 0.7
  */
+@PublicEvolving
 public class AuthenticationFactory {
     private static final String SERVER_AUTHENTICATOR_PREFIX = "security.";
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/AuthenticationPlugin.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.plugin.Plugin;
 
 /**
@@ -26,6 +27,7 @@ import com.alibaba.fluss.plugin.Plugin;
  *
  * @since 0.7
  */
+@PublicEvolving
 public interface AuthenticationPlugin extends Plugin {
     /**
      * Returns the authentication protocol identifier for this plugin (e.g., "PLAINTEXT", "AK-SK").

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticationPlugin.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.config.Configuration;
 
 /**
@@ -26,6 +27,7 @@ import com.alibaba.fluss.config.Configuration;
  * com.alibaba.fluss.config.ConfigOptions#CLIENT_SECURITY_PROTOCOL}, and configuration parameters
  * must be prefixed with {@code client.security.${protocol}}.
  */
+@PublicEvolving
 public interface ClientAuthenticationPlugin extends AuthenticationPlugin {
     /**
      * Creates a client-side authenticator instance for this authentication protocol.

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ClientAuthenticator.java
@@ -16,11 +16,13 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.exception.AuthenticationException;
 
 import javax.annotation.Nullable;
 
 /** Authenticator for client side. */
+@PublicEvolving
 public interface ClientAuthenticator {
 
     /** The protocol name of the authenticator, which will send in the AuthenticateRequest. */

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/PlainTextAuthenticationPlugin.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.security.auth;
 
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 
 /** Authentication Plugin for PLAINTEXT which not need to do authentication. */
 public class PlainTextAuthenticationPlugin
@@ -68,6 +69,11 @@ public class PlainTextAuthenticationPlugin
         @Override
         public byte[] evaluateResponse(byte[] token) {
             return new byte[0];
+        }
+
+        @Override
+        public FlussPrincipal createPrincipal() {
+            return FlussPrincipal.ANONYMOUS;
         }
 
         @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
@@ -25,6 +25,8 @@ import com.alibaba.fluss.config.Configuration;
  * <p>The protocol type is specified via {@link
  * com.alibaba.fluss.config.ConfigOptions#SERVER_SECURITY_PROTOCOL_MAP}, and configuration
  * parameters must be prefixed with {@code security.${protocol}}.
+ *
+ * @since 0.7
  */
 public interface ServerAuthenticationPlugin extends AuthenticationPlugin {
 

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticationPlugin.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.config.Configuration;
 
 /**
@@ -28,6 +29,7 @@ import com.alibaba.fluss.config.Configuration;
  *
  * @since 0.7
  */
+@PublicEvolving
 public interface ServerAuthenticationPlugin extends AuthenticationPlugin {
 
     /**

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.security.auth;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.security.acl.FlussPrincipal;
 
@@ -24,6 +25,7 @@ import com.alibaba.fluss.security.acl.FlussPrincipal;
  *
  * @since 0.7
  */
+@PublicEvolving
 public interface ServerAuthenticator {
 
     String protocol();

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
@@ -19,7 +19,11 @@ package com.alibaba.fluss.security.auth;
 import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.security.acl.FlussPrincipal;
 
-/** Authenticator for server side. */
+/**
+ * Authenticator for server side.
+ *
+ * @since 0.7
+ */
 public interface ServerAuthenticator {
 
     String protocol();

--- a/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/security/auth/ServerAuthenticator.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.security.auth;
 
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 
 /** Authenticator for server side. */
 public interface ServerAuthenticator {
@@ -66,4 +67,10 @@ public interface ServerAuthenticator {
 
     /** Checks if the authentication from server side is completed. */
     boolean isCompleted();
+
+    /**
+     * Create principal from authenticated token for later authorization.(this can only invoke if is
+     * complete).
+     */
+    FlussPrincipal createPrincipal();
 }

--- a/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestIdentifierAuthenticationPlugin.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/security/auth/TestIdentifierAuthenticationPlugin.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.security.auth;
 
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 
 import javax.annotation.Nullable;
 
@@ -67,6 +68,11 @@ public class TestIdentifierAuthenticationPlugin
 
         @Override
         public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
+            return null;
+        }
+
+        @Override
+        public FlussPrincipal createPrincipal() {
             return null;
         }
 

--- a/fluss-flink/fluss-flink-1.18/src/test/java/com/alibaba/fluss/flink/security/acl/Flink118AuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/com/alibaba/fluss/flink/security/acl/Flink118AuthorizationITCase.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.security.acl;
+
+/** IT case for authorization in Flink 1.18. */
+public class Flink118AuthorizationITCase extends FlinkAuthorizationITCase {}

--- a/fluss-flink/fluss-flink-1.19/src/test/java/com/alibaba/fluss/flink/security/acl/Flink119AuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-1.19/src/test/java/com/alibaba/fluss/flink/security/acl/Flink119AuthorizationITCase.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.security.acl;
+
+/** IT case for authorization in Flink 1.19. */
+public class Flink119AuthorizationITCase extends FlinkAuthorizationITCase {}

--- a/fluss-flink/fluss-flink-1.20/src/test/java/com/alibaba/fluss/flink/security/acl/Flink120AuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-1.20/src/test/java/com/alibaba/fluss/flink/security/acl/Flink120AuthorizationITCase.java
@@ -1,0 +1,20 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.security.acl;
+
+/** IT case for authorization in Flink 1.20. */
+public class Flink120AuthorizationITCase extends FlinkAuthorizationITCase {}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -433,8 +433,8 @@ abstract class FlinkCatalogITCase {
         Configuration serverConfig = new Configuration();
         serverConfig.setString(
                 ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:username_password");
-        serverConfig.setString("security.username_password.username", "root");
-        serverConfig.setString("security.username_password.password", "password");
+        serverConfig.setString("security.username_password.credentials", "root:password");
+        serverConfig.setString(ConfigOptions.SUPER_USERS.key(), "USER:root");
         FlussClusterExtension flussClusterExtension =
                 FlussClusterExtension.builder()
                         .setCoordinatorServerListeners(

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
@@ -1,0 +1,473 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.security.acl;
+
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.config.MemorySize;
+import com.alibaba.fluss.exception.AuthorizationException;
+import com.alibaba.fluss.flink.catalog.FlinkCatalogOptions;
+import com.alibaba.fluss.metadata.DataLakeFormat;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.AccessControlEntryFilter;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceFilter;
+import com.alibaba.fluss.server.testutils.FlussClusterExtension;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CollectionUtil;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+
+import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.waitUntilPartitions;
+import static com.alibaba.fluss.security.acl.OperationType.CREATE;
+import static com.alibaba.fluss.security.acl.OperationType.DESCRIBE;
+import static com.alibaba.fluss.security.acl.OperationType.DROP;
+import static com.alibaba.fluss.security.acl.OperationType.READ;
+import static com.alibaba.fluss.security.acl.OperationType.WRITE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** IT case for flink authorization. */
+abstract class FlinkAuthorizationITCase {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setNumOfTabletServers(3)
+                    .setCoordinatorServerListeners("FLUSS://localhost:0, CLIENT://localhost:0")
+                    .setTabletServerListeners("FLUSS://localhost:0, CLIENT://localhost:0")
+                    .setClusterConf(initConfig())
+                    .build();
+
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
+    static TableEnvironment tEnv;
+    static TableEnvironment tBatchEnv;
+    static Admin rootAdmin;
+    static Connection rootConn;
+    static FlussPrincipal guest = new FlussPrincipal("guest", "USER");
+
+    @BeforeAll
+    static void beforeAll() {
+        Configuration conf = FLUSS_CLUSTER_EXTENSION.getClientConfig("CLIENT");
+        conf.set(ConfigOptions.CLIENT_SECURITY_PROTOCOL, "username_password");
+        Configuration rootConf = new Configuration(conf);
+        rootConf.setString("client.security.username_password.username", "root");
+        rootConf.setString("client.security.username_password.password", "password");
+        rootConn = ConnectionFactory.createConnection(rootConf);
+        rootAdmin = rootConn.getAdmin();
+
+        // open a catalog so that we can get table from the catalog
+        String bootstrapServers = String.join(",", conf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+        // create table environment
+        tEnv = TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+        tBatchEnv = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+        // crate catalog using sql
+        String createCatalogDDL =
+                String.format(
+                        "create catalog %s with ( \n"
+                                + "'type' = 'fluss', \n"
+                                + "'bootstrap.servers' = '%s', \n"
+                                + " 'client.security.protocol' = 'username_password', \n"
+                                + "'client.security.username_password.username' = 'guest', \n"
+                                + "'client.security.username_password.password' = 'password2' \n"
+                                + ")",
+                        CATALOG_NAME, bootstrapServers);
+        tEnv.executeSql(createCatalogDDL);
+        tBatchEnv.executeSql(createCatalogDDL);
+    }
+
+    @AfterAll
+    static void afterAll() throws Exception {
+        tEnv.executeSql("use catalog " + TableConfigOptions.TABLE_CATALOG_NAME.defaultValue());
+        tEnv.executeSql("DROP CATALOG IF EXISTS " + CATALOG_NAME);
+        tBatchEnv.executeSql("use catalog " + TableConfigOptions.TABLE_CATALOG_NAME.defaultValue());
+        tBatchEnv.executeSql("DROP CATALOG IF EXISTS " + CATALOG_NAME);
+
+        if (rootAdmin != null) {
+            rootAdmin.close();
+        }
+
+        if (rootConn != null) {
+            rootConn.close();
+        }
+    }
+
+    @BeforeEach
+    void before() {
+        tEnv.executeSql("use catalog " + CATALOG_NAME);
+        tBatchEnv.executeSql("use catalog " + CATALOG_NAME);
+    }
+
+    @AfterEach
+    void after() throws ExecutionException, InterruptedException {
+        rootAdmin.dropAcls(Collections.singletonList(AclBindingFilter.ANY)).all().get();
+    }
+
+    @Test
+    void testShowDatabases() throws Exception {
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
+                .isEmpty();
+        addAcl(Resource.database(DEFAULT_DB), DESCRIBE);
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
+                .containsExactly(Row.of(DEFAULT_DB));
+        dropAcl(Resource.database(DEFAULT_DB), DESCRIBE);
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
+                .isEmpty();
+    }
+
+    @Test
+    void testCreateAndDropDatabase() throws Exception {
+        String databaseName = String.format("test_show_db_%s", RandomUtils.nextInt());
+        String createDatabaseDDL = "CREATE DATABASE " + databaseName;
+        // test create database
+        assertThatThrownBy(() -> tEnv.executeSql(createDatabaseDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate CREATE on resource %s",
+                                guest, Resource.cluster()));
+        addAcl(Resource.cluster(), CREATE);
+        tEnv.executeSql(createDatabaseDDL).await();
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
+                .containsExactlyInAnyOrder(Row.of(DEFAULT_DB), Row.of(databaseName));
+
+        // test drop database
+        String dropDatabaseDDL = "drop database " + databaseName;
+        assertThatThrownBy(() -> tEnv.executeSql(dropDatabaseDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate DROP on resource %s",
+                                guest, Resource.database(databaseName)));
+        addAcl(Resource.database(databaseName), DROP);
+        tEnv.executeSql(dropDatabaseDDL).await();
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect()))
+                .containsExactlyInAnyOrder(Row.of(DEFAULT_DB));
+    }
+
+    @Test
+    void testShowTables() throws Exception {
+        TablePath testTable1 =
+                new TablePath(
+                        DEFAULT_DB, String.format("test_show_db_1_%s", RandomUtils.nextInt()));
+        TablePath testTable2 =
+                new TablePath(
+                        DEFAULT_DB, String.format("test_show_db_2_%s", RandomUtils.nextInt()));
+        String createTableDDLFormat = "CREATE TABLE %s ( a int not null primary key not enforced);";
+        addAcl(Resource.database(DEFAULT_DB), CREATE);
+        tEnv.executeSql(String.format(createTableDDLFormat, testTable1.getTableName())).await();
+        tEnv.executeSql(String.format(createTableDDLFormat, testTable2.getTableName())).await();
+        dropAcl(Resource.database(DEFAULT_DB), CREATE);
+
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show tables").collect()))
+                .isEmpty();
+        addAcl(Resource.table(testTable1), DESCRIBE);
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show tables").collect()))
+                .containsExactlyInAnyOrder(Row.of(testTable1.getTableName()));
+        addAcl(Resource.database(DEFAULT_DB), CREATE);
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show tables").collect()))
+                .containsExactlyInAnyOrder(
+                        Row.of(testTable1.getTableName()), Row.of(testTable2.getTableName()));
+    }
+
+    @Test
+    void tesCreateAndDropTable() throws Exception {
+        String tableName = String.format("test_create_db_%s", RandomUtils.nextInt());
+        TablePath testTable = new TablePath(DEFAULT_DB, tableName);
+        String createTableDDL =
+                String.format(
+                        "CREATE TABLE %s ( a int not null primary key not enforced);",
+                        testTable.getTableName());
+        // test create database
+        assertThatThrownBy(() -> tEnv.executeSql(createTableDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate CREATE on resource %s",
+                                guest, Resource.database(testTable.getDatabaseName())));
+        addAcl(Resource.database(DEFAULT_DB), CREATE);
+        tEnv.executeSql(String.format(createTableDDL)).await();
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show tables").collect()))
+                .containsExactlyInAnyOrder(Row.of(testTable.getTableName()));
+
+        // test drop database
+        String dropTableDDL = "drop table " + testTable.getTableName();
+        assertThatThrownBy(() -> tEnv.executeSql(dropTableDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate DROP on resource %s",
+                                guest, Resource.table(testTable)));
+        addAcl(Resource.table(testTable), DROP);
+        tEnv.executeSql(dropTableDDL).await();
+        assertThat(CollectionUtil.iteratorToList(tEnv.executeSql("show tables").collect()))
+                .isEmpty();
+    }
+
+    @Test
+    void testAlterPartitionTable() throws Exception {
+        addAcl(Resource.cluster(), CREATE);
+        String tableName = String.format("test_partitioned_log_table_%s", RandomUtils.nextInt());
+        TablePath testTable = new TablePath(DEFAULT_DB, tableName);
+        tEnv.executeSql(
+                        String.format(
+                                "CREATE TABLE %s (dt varchar) partitioned by (dt)  ;", tableName))
+                .await();
+        String addPartitionDDL =
+                String.format("alter table %s add partition (dt='2022-01-01');", tableName);
+
+        // test add partition
+        assertThatThrownBy(() -> tEnv.executeSql(addPartitionDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate WRITE on resource %s",
+                                guest, Resource.table(testTable)));
+        addAcl(Resource.database(DEFAULT_DB), WRITE);
+        tEnv.executeSql(String.format(addPartitionDDL)).await();
+
+        // test drop partition
+        addAcl(Resource.cluster(), DROP);
+        dropAcl(Resource.database(DEFAULT_DB), WRITE);
+        String dropPartitionDDL =
+                String.format("alter table %s drop partition (dt='2022-01-01');", tableName);
+        assertThatThrownBy(() -> tEnv.executeSql(dropPartitionDDL).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "Principal %s have no authorization to operate WRITE on resource %s",
+                                guest, Resource.table(testTable)));
+        addAcl(Resource.table(testTable), WRITE);
+        tEnv.executeSql(dropPartitionDDL).await();
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testProduceAndConsumeLogTable(boolean isPartitionTable) throws Exception {
+        addAcl(Resource.cluster(), CREATE);
+        String tableName = String.format("test_log_table_%s", RandomUtils.nextInt());
+        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+        String ddl =
+                String.format(
+                        "create table %s ("
+                                + "  id int not null,"
+                                + "  address varchar,"
+                                + "  name varchar,"
+                                + "  dt varchar)"
+                                + (isPartitionTable ? "  partitioned by (dt)" : ""),
+                        tableName);
+        tEnv.executeSql(String.format(ddl)).await();
+        if (isPartitionTable) {
+            // prepare partition in advance.
+            addAcl(Resource.database(tablePath.getDatabaseName()), WRITE);
+            tEnv.executeSql(
+                    String.format(
+                            "alter table %s add partition (dt='2022-01-01');",
+                            tablePath.getTableName()));
+            waitUntilPartitions(FLUSS_CLUSTER_EXTENSION.getZooKeeperClient(), tablePath, 1);
+            dropAcl(Resource.database(tablePath.getDatabaseName()), WRITE);
+        }
+
+        // test produce
+        String insertDML =
+                String.format(
+                        "insert into %s values (1, 'beijing', 'zhangsan', '2022-01-01');",
+                        tablePath.getTableName());
+        assertThatThrownBy(() -> tEnv.executeSql(insertDML).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "No permission to WRITE table %s in database %s",
+                                tablePath.getTableName(), tablePath.getDatabaseName()));
+        addAcl(Resource.table(tablePath), WRITE);
+        tEnv.executeSql(insertDML).await();
+
+        // test consume
+        String selectDML = String.format("select * from %s;", tablePath.getTableName());
+        assertThatThrownBy(() -> tEnv.executeSql(selectDML).await())
+                .hasRootCauseExactlyInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "No permission to READ table %s in database %s",
+                                tablePath.getTableName(), tablePath.getDatabaseName()));
+        addAcl(Resource.table(tablePath), READ);
+        assertQueryResult(
+                tEnv, selectDML, Collections.singletonList("+I[1, beijing, zhangsan, 2022-01-01]"));
+    }
+
+    @Test
+    void testPutAndLookupKvTable() throws Exception {
+        addAcl(Resource.cluster(), CREATE);
+        String tableName = String.format("test_pk_table_%s", RandomUtils.nextInt());
+        TablePath tablePath = TablePath.of(DEFAULT_DB, tableName);
+        String ddl =
+                String.format(
+                        "create table %s ("
+                                + "  id int not null,"
+                                + "  address varchar,"
+                                + "  name varchar,"
+                                + "  primary key (id) NOT ENFORCED)",
+                        tableName);
+        tBatchEnv.executeSql(String.format(ddl)).await();
+
+        // test put kv
+        String insertDML =
+                String.format(
+                        "insert into %s values (1, 'beijing', 'zhangsan'),(2, 'shanghai', 'lisi');",
+                        tablePath.getTableName());
+        assertThatThrownBy(() -> tBatchEnv.executeSql(insertDML).await())
+                .hasRootCauseInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "No permission to WRITE table %s in database %s",
+                                tablePath.getTableName(), tablePath.getDatabaseName()));
+        addAcl(Resource.table(tablePath), WRITE);
+        tBatchEnv.executeSql(insertDML).await();
+
+        // test lookup
+        String lookupSql =
+                String.format("select * from %s where id = 2;", tablePath.getTableName());
+        assertThatThrownBy(() -> tBatchEnv.executeSql(lookupSql).await())
+                .hasRootCauseExactlyInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "No permission to READ table %s in database %s",
+                                tablePath.getTableName(), tablePath.getDatabaseName()));
+        addAcl(Resource.table(tablePath), READ);
+        assertQueryResult(tBatchEnv, lookupSql, Collections.singletonList("+I[2, shanghai, lisi]"));
+
+        // test limit scan
+        dropAcl(Resource.table(tablePath), READ);
+        String limitScanSql = String.format("select * from %s limit 2;", tablePath.getTableName());
+        assertThatThrownBy(() -> tBatchEnv.executeSql(limitScanSql).await())
+                .hasRootCauseExactlyInstanceOf(AuthorizationException.class)
+                .rootCause()
+                .hasMessageContaining(
+                        String.format(
+                                "No permission to READ table %s in database %s",
+                                tablePath.getTableName(), tablePath.getDatabaseName()));
+        addAcl(Resource.database(tablePath.getDatabaseName()), READ);
+        assertQueryResult(
+                tBatchEnv,
+                limitScanSql,
+                Arrays.asList("+I[1, beijing, zhangsan]", "+I[2, shanghai, lisi]"));
+    }
+
+    void addAcl(Resource resource, OperationType operationType)
+            throws ExecutionException, InterruptedException {
+        rootAdmin
+                .createAcls(
+                        Collections.singletonList(
+                                new AclBinding(
+                                        resource,
+                                        new AccessControlEntry(
+                                                new FlussPrincipal("guest", "USER"),
+                                                "*",
+                                                operationType,
+                                                PermissionType.ALLOW))))
+                .all()
+                .get();
+    }
+
+    void dropAcl(Resource resource, OperationType operationType)
+            throws ExecutionException, InterruptedException {
+        rootAdmin
+                .dropAcls(
+                        Collections.singletonList(
+                                new AclBindingFilter(
+                                        new ResourceFilter(resource.getType(), resource.getName()),
+                                        new AccessControlEntryFilter(
+                                                guest, null, operationType, PermissionType.ALLOW))))
+                .all()
+                .get();
+    }
+
+    void assertQueryResult(TableEnvironment env, String query, List<String> expected)
+            throws Exception {
+        try (org.apache.flink.util.CloseableIterator<Row> rowIter =
+                env.executeSql(query).collect()) {
+            int expectRecords = expected.size();
+            List<String> actual = new ArrayList<>(expectRecords);
+            for (int i = 0; i < expectRecords; i++) {
+                Row r = rowIter.next();
+                String row = r.toString();
+                actual.add(row);
+            }
+            assertThat(actual).containsExactlyElementsOf(expected);
+        }
+    }
+
+    private static Configuration initConfig() {
+        Configuration conf = new Configuration();
+        conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
+        // set a shorter interval for testing purpose
+        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
+        // set a shorter max lag time to make tests in FlussFailServerTableITCase faster
+        conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(10));
+        // set default datalake format for the cluster and enable datalake tables
+        conf.set(ConfigOptions.DATALAKE_FORMAT, DataLakeFormat.PAIMON);
+
+        conf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, MemorySize.parse("1mb"));
+        conf.set(ConfigOptions.CLIENT_WRITER_BATCH_SIZE, MemorySize.parse("1kb"));
+
+        // set security information.
+        conf.setString(
+                ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(), "CLIENT:username_password");
+        conf.setString("security.username_password.credentials", "root:password,guest:password2");
+        conf.set(ConfigOptions.SUPER_USERS, "USER:root");
+        conf.set(ConfigOptions.AUTHORIZER_ENABLED, true);
+        return conf;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
@@ -109,7 +109,7 @@ abstract class FlinkAuthorizationITCase {
                         "create catalog %s with ( \n"
                                 + "'type' = 'fluss', \n"
                                 + "'bootstrap.servers' = '%s', \n"
-                                + " 'client.security.protocol' = 'username_password', \n"
+                                + "'client.security.protocol' = 'username_password', \n"
                                 + "'client.security.username_password.username' = 'guest', \n"
                                 + "'client.security.username_password.password' = 'password2' \n"
                                 + ")",
@@ -274,7 +274,6 @@ abstract class FlinkAuthorizationITCase {
         tEnv.executeSql(String.format(addPartitionDDL)).await();
 
         // test drop partition
-        addAcl(Resource.cluster(), DROP);
         dropAcl(Resource.database(DEFAULT_DB), WRITE);
         String dropPartitionDDL =
                 String.format("alter table %s drop partition (dt='2022-01-01');", tableName);
@@ -413,10 +412,7 @@ abstract class FlinkAuthorizationITCase {
                                 new AclBinding(
                                         resource,
                                         new AccessControlEntry(
-                                                new FlussPrincipal("guest", "USER"),
-                                                "*",
-                                                operationType,
-                                                PermissionType.ALLOW))))
+                                                guest, "*", operationType, PermissionType.ALLOW))))
                 .all()
                 .get();
     }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGatewayService.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/RpcGatewayService.java
@@ -36,6 +36,16 @@ public abstract class RpcGatewayService implements RpcGateway {
         currentSession.set(session);
     }
 
+    public Session currentSession() {
+        Session session = currentSession.get();
+        if (session == null) {
+            throw new IllegalStateException(
+                    "No session set. This method should only be called from within an RPC call.");
+        } else {
+            return session;
+        }
+    }
+
     /**
      * Returns the current API version of an RPC call. This method is thread-safe and can only be
      * accessed in RPC methods.

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/FetchLogResultForBucket.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/FetchLogResultForBucket.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.remote.RemoteLogFetchInfo;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.rpc.protocol.Errors;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +48,10 @@ public class FetchLogResultForBucket extends ResultForBucket {
 
     public FetchLogResultForBucket(TableBucket tableBucket, ApiError error) {
         this(tableBucket, null, null, -1L, error);
+    }
+
+    public FetchLogResultForBucket(TableBucket tableBucket, Errors error) {
+        this(tableBucket, null, null, -1L, new ApiError(error, null));
     }
 
     public FetchLogResultForBucket(

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/FetchLogResultForBucket.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/FetchLogResultForBucket.java
@@ -23,7 +23,6 @@ import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.remote.RemoteLogFetchInfo;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.protocol.ApiError;
-import com.alibaba.fluss.rpc.protocol.Errors;
 
 import javax.annotation.Nullable;
 
@@ -48,10 +47,6 @@ public class FetchLogResultForBucket extends ResultForBucket {
 
     public FetchLogResultForBucket(TableBucket tableBucket, ApiError error) {
         this(tableBucket, null, null, -1L, error);
-    }
-
-    public FetchLogResultForBucket(TableBucket tableBucket, Errors error) {
-        this(tableBucket, null, null, -1L, new ApiError(error, null));
     }
 
     public FetchLogResultForBucket(

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
@@ -16,12 +16,16 @@
 
 package com.alibaba.fluss.rpc.gateway;
 
+import com.alibaba.fluss.rpc.messages.CreateAclsRequest;
+import com.alibaba.fluss.rpc.messages.CreateAclsResponse;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.CreatePartitionRequest;
 import com.alibaba.fluss.rpc.messages.CreatePartitionResponse;
 import com.alibaba.fluss.rpc.messages.CreateTableRequest;
 import com.alibaba.fluss.rpc.messages.CreateTableResponse;
+import com.alibaba.fluss.rpc.messages.DropAclsRequest;
+import com.alibaba.fluss.rpc.messages.DropAclsResponse;
 import com.alibaba.fluss.rpc.messages.DropDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.DropDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.DropPartitionRequest;
@@ -83,5 +87,24 @@ public interface AdminGateway extends AdminReadOnlyGateway {
     @RPC(api = ApiKeys.DROP_PARTITION)
     CompletableFuture<DropPartitionResponse> dropPartition(DropPartitionRequest request);
 
+    /**
+     * create acls for a resource.
+     *
+     * @param request create acl request.
+     * @return
+     */
+    @RPC(api = ApiKeys.CREATE_ACL)
+    CompletableFuture<CreateAclsResponse> createAcls(CreateAclsRequest request);
+
+    /**
+     * Drop acls for a resource.
+     *
+     * @param request drop acl request.
+     * @return
+     */
+    @RPC(api = ApiKeys.DROP_ACL)
+    CompletableFuture<DropAclsResponse> dropAcls(DropAclsRequest request);
+
     // todo: rename table & alter table
+
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminGateway.java
@@ -91,18 +91,16 @@ public interface AdminGateway extends AdminReadOnlyGateway {
      * create acls for a resource.
      *
      * @param request create acl request.
-     * @return
      */
-    @RPC(api = ApiKeys.CREATE_ACL)
+    @RPC(api = ApiKeys.CREATE_ACLS)
     CompletableFuture<CreateAclsResponse> createAcls(CreateAclsRequest request);
 
     /**
      * Drop acls for a resource.
      *
      * @param request drop acl request.
-     * @return
      */
-    @RPC(api = ApiKeys.DROP_ACL)
+    @RPC(api = ApiKeys.DROP_ACLS)
     CompletableFuture<DropAclsResponse> dropAcls(DropAclsRequest request);
 
     // todo: rename table & alter table

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminReadOnlyGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminReadOnlyGateway.java
@@ -33,6 +33,8 @@ import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableInfoResponse;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosRequest;
@@ -186,4 +188,7 @@ public interface AdminReadOnlyGateway extends RpcGateway {
     @RPC(api = ApiKeys.GET_LATEST_LAKE_SNAPSHOT)
     CompletableFuture<GetLatestLakeSnapshotResponse> getLatestLakeSnapshot(
             GetLatestLakeSnapshotRequest request);
+
+    @RPC(api = ApiKeys.LIST_ACLS)
+    CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request);
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminReadOnlyGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/AdminReadOnlyGateway.java
@@ -189,6 +189,12 @@ public interface AdminReadOnlyGateway extends RpcGateway {
     CompletableFuture<GetLatestLakeSnapshotResponse> getLatestLakeSnapshot(
             GetLatestLakeSnapshotRequest request);
 
+    /**
+     * List acls for a table.
+     *
+     * @param request the request that specifies the table path.
+     * @return a future returns the list of acls.
+     */
     @RPC(api = ApiKeys.LIST_ACLS)
     CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request);
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussProtocolPlugin.java
@@ -41,6 +41,7 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin {
     private final long maxIdleTimeSeconds;
     private final List<String> listeners;
     private final RequestsMetrics requestsMetrics;
+    private final String internalListenerName;
 
     public FlussProtocolPlugin(
             Configuration conf,
@@ -50,6 +51,7 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin {
         this.authenticatorSuppliers = AuthenticationFactory.loadServerAuthenticatorSuppliers(conf);
         this.apiManager = new ApiManager(serverType);
         maxIdleTimeSeconds = conf.get(ConfigOptions.NETTY_CONNECTION_MAX_IDLE_TIME).getSeconds();
+        this.internalListenerName = conf.get(ConfigOptions.INTERNAL_LISTENER_NAME);
         this.listeners = listeners;
         this.requestsMetrics = requestsMetrics;
     }
@@ -71,6 +73,7 @@ public class FlussProtocolPlugin implements NetworkProtocolPlugin {
                 requestChannels,
                 apiManager,
                 listenerName,
+                listenerName.equals(internalListenerName),
                 requestsMetrics,
                 maxIdleTimeSeconds,
                 Optional.ofNullable(authenticatorSuppliers.get(listenerName))

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussRequest.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussRequest.java
@@ -19,8 +19,10 @@ package com.alibaba.fluss.rpc.netty.server;
 import com.alibaba.fluss.rpc.messages.ApiMessage;
 import com.alibaba.fluss.rpc.protocol.ApiMethod;
 import com.alibaba.fluss.rpc.protocol.RequestType;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 import com.alibaba.fluss.shaded.netty4.io.netty.buffer.ByteBuf;
 
+import java.net.InetAddress;
 import java.util.concurrent.CompletableFuture;
 
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
@@ -35,6 +37,9 @@ public final class FlussRequest implements RpcRequest {
     private final ApiMessage message;
     private final ByteBuf buffer;
     private final String listenerName;
+    private final boolean isInternal;
+    private final FlussPrincipal principal;
+    private final InetAddress address;
     private final CompletableFuture<ApiMessage> responseFuture;
 
     // the time when the request is received by server
@@ -51,6 +56,9 @@ public final class FlussRequest implements RpcRequest {
             ApiMessage message,
             ByteBuf buffer,
             String listenerName,
+            boolean isInternal,
+            FlussPrincipal principal,
+            InetAddress address,
             CompletableFuture<ApiMessage> responseFuture) {
         this.apiKey = apiKey;
         this.apiVersion = apiVersion;
@@ -58,8 +66,11 @@ public final class FlussRequest implements RpcRequest {
         this.apiMethod = apiMethod;
         this.message = message;
         this.buffer = checkNotNull(buffer);
-        this.listenerName = listenerName;
         this.responseFuture = responseFuture;
+        this.isInternal = isInternal;
+        this.principal = principal;
+        this.address = address;
+        this.listenerName = listenerName;
         this.startTimeMs = System.currentTimeMillis();
     }
 
@@ -136,6 +147,18 @@ public final class FlussRequest implements RpcRequest {
 
     public boolean cancelled() {
         return cancelled;
+    }
+
+    public InetAddress getAddress() {
+        return address;
+    }
+
+    public FlussPrincipal getPrincipal() {
+        return principal;
+    }
+
+    public boolean isInternal() {
+        return isInternal;
     }
 
     @Override

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussRequestHandler.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/FlussRequestHandler.java
@@ -51,7 +51,12 @@ public class FlussRequestHandler implements RequestHandler<FlussRequest> {
         ApiMessage message = request.getMessage();
         try {
             service.setCurrentSession(
-                    new Session(request.getApiVersion(), request.getListenerName()));
+                    new Session(
+                            request.getApiVersion(),
+                            request.getListenerName(),
+                            request.isInternal(),
+                            request.getAddress(),
+                            request.getPrincipal()));
             // invoke the corresponding method on RpcGateway instance.
             CompletableFuture<?> responseFuture =
                     (CompletableFuture<?>) api.getMethod().invoke(service, message);

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandler.java
@@ -42,6 +42,7 @@ import com.alibaba.fluss.utils.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.ArrayDeque;
 import java.util.Deque;
@@ -67,6 +68,7 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
 
     private final RequestChannel requestChannel;
     private final ApiManager apiManager;
+    private final boolean isInternal;
     private final String listenerName;
     private final RequestsMetrics requestsMetrics;
     private volatile ChannelHandlerContext ctx;
@@ -80,11 +82,13 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
             RequestChannel requestChannel,
             ApiManager apiManager,
             String listenerName,
+            boolean isInternal,
             RequestsMetrics requestsMetrics,
             ServerAuthenticator authenticator) {
         this.requestChannel = requestChannel;
         this.apiManager = apiManager;
         this.listenerName = listenerName;
+        this.isInternal = isInternal;
         this.requestsMetrics = requestsMetrics;
         this.authenticator = authenticator;
         this.state = ConnectionState.START;
@@ -128,6 +132,9 @@ public final class NettyServerHandler extends ChannelInboundHandlerAdapter {
                             requestMessage,
                             buffer,
                             listenerName,
+                            isInternal,
+                            authenticator.isCompleted() ? authenticator.createPrincipal() : null,
+                            ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress(),
                             future);
 
             Deque<FlussRequest> inflightResponses =

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -43,6 +43,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
     private final RequestChannel[] requestChannels;
     private final ApiManager apiManager;
     private final String endpointListenerName;
+    private final boolean isInternal;
     private final RequestsMetrics requestsMetrics;
     private final Supplier<ServerAuthenticator> authenticatorSupplier;
 
@@ -52,6 +53,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
             RequestChannel[] requestChannels,
             ApiManager apiManager,
             String endpointListenerName,
+            boolean isInternal,
             RequestsMetrics requestsMetrics,
             long maxIdleTimeSeconds,
             Supplier<ServerAuthenticator> authenticatorSupplier) {
@@ -59,6 +61,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
         this.requestChannels = requestChannels;
         this.apiManager = apiManager;
         this.endpointListenerName = endpointListenerName;
+        this.isInternal = isInternal;
         this.requestsMetrics = requestsMetrics;
         this.maxIdleTimeSeconds = (int) maxIdleTimeSeconds;
         this.authenticatorSupplier = authenticatorSupplier;
@@ -93,6 +96,7 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
                                 requestChannels[channelIndex],
                                 apiManager,
                                 endpointListenerName,
+                                isInternal,
                                 requestsMetrics,
                                 serverAuthenticator));
     }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/Session.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/Session.java
@@ -16,16 +16,30 @@
 
 package com.alibaba.fluss.rpc.netty.server;
 
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+
 import java.io.Serializable;
+import java.net.InetAddress;
 
 /** The connection session of a request. */
 public class Session implements Serializable {
     private final short apiVersion;
     private final String listenerName;
+    private final boolean isInternal;
+    private InetAddress inetAddress;
+    private FlussPrincipal principal;
 
-    public Session(short apiVersion, String listenerName) {
+    public Session(
+            short apiVersion,
+            String listenerName,
+            boolean isInternal,
+            InetAddress inetAddress,
+            FlussPrincipal principal) {
         this.apiVersion = apiVersion;
         this.listenerName = listenerName;
+        this.isInternal = isInternal;
+        this.inetAddress = inetAddress;
+        this.principal = principal;
     }
 
     public short getApiVersion() {
@@ -34,5 +48,17 @@ public class Session implements Serializable {
 
     public String getListenerName() {
         return listenerName;
+    }
+
+    public InetAddress getInetAddress() {
+        return inetAddress;
+    }
+
+    public FlussPrincipal getPrincipal() {
+        return principal;
+    }
+
+    public boolean isInternal() {
+        return isInternal;
     }
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/Session.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/Session.java
@@ -26,8 +26,8 @@ public class Session implements Serializable {
     private final short apiVersion;
     private final String listenerName;
     private final boolean isInternal;
-    private InetAddress inetAddress;
-    private FlussPrincipal principal;
+    private final InetAddress inetAddress;
+    private final FlussPrincipal principal;
 
     public Session(
             short apiVersion,

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -65,7 +65,10 @@ public enum ApiKeys {
     GET_DATABASE_INFO(1035, 0, 0, PUBLIC),
     CREATE_PARTITION(1036, 0, 0, PUBLIC),
     DROP_PARTITION(1037, 0, 0, PUBLIC),
-    AUTHENTICATE(1038, 0, 0, PUBLIC);
+    AUTHENTICATE(1038, 0, 0, PUBLIC),
+    CREATE_ACL(1039, 0, 0, PUBLIC),
+    LIST_ACLS(1040, 0, 0, PUBLIC),
+    DROP_ACL(1041, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -66,9 +66,9 @@ public enum ApiKeys {
     CREATE_PARTITION(1036, 0, 0, PUBLIC),
     DROP_PARTITION(1037, 0, 0, PUBLIC),
     AUTHENTICATE(1038, 0, 0, PUBLIC),
-    CREATE_ACL(1039, 0, 0, PUBLIC),
+    CREATE_ACLS(1039, 0, 0, PUBLIC),
     LIST_ACLS(1040, 0, 0, PUBLIC),
-    DROP_ACL(1041, 0, 0, PUBLIC);
+    DROP_ACLS(1041, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.rpc.protocol;
 
 import com.alibaba.fluss.exception.ApiException;
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.exception.AuthorizationException;
 import com.alibaba.fluss.exception.CorruptMessageException;
 import com.alibaba.fluss.exception.CorruptRecordException;
 import com.alibaba.fluss.exception.DatabaseAlreadyExistException;
@@ -193,8 +194,9 @@ public enum Errors {
             LeaderNotAvailableException::new),
     PARTITION_MAX_NUM_EXCEPTION(
             45, "Exceed the maximum number of partitions.", TooManyPartitionsException::new),
-    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new),
-    SECURITY_DISABLED_EXCEPTION(47, "Security is disabled.", SecurityDisabledException::new);
+    AUTHENTICATE_EXCEPTION(46, "Authentication failed.", AuthenticationException::new),
+    SECURITY_DISABLED_EXCEPTION(47, "Security is disabled.", SecurityDisabledException::new),
+    AUTHORIZATION_EXCEPTION(48, "Authorization failed", AuthorizationException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -53,6 +53,7 @@ import com.alibaba.fluss.exception.PartitionAlreadyExistsException;
 import com.alibaba.fluss.exception.PartitionNotExistException;
 import com.alibaba.fluss.exception.RecordTooLargeException;
 import com.alibaba.fluss.exception.SchemaNotExistException;
+import com.alibaba.fluss.exception.SecurityDisabledException;
 import com.alibaba.fluss.exception.SecurityTokenException;
 import com.alibaba.fluss.exception.StorageException;
 import com.alibaba.fluss.exception.TableAlreadyExistException;
@@ -192,7 +193,8 @@ public enum Errors {
             LeaderNotAvailableException::new),
     PARTITION_MAX_NUM_EXCEPTION(
             45, "Exceed the maximum number of partitions.", TooManyPartitionsException::new),
-    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new);
+    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new),
+    SECURITY_DISABLED_EXCEPTION(47, "Security is disabled.", SecurityDisabledException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -1,0 +1,134 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.util;
+
+import com.alibaba.fluss.rpc.messages.PbAclFilter;
+import com.alibaba.fluss.rpc.messages.PbAclInfo;
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.AccessControlEntryFilter;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceFilter;
+import com.alibaba.fluss.security.acl.ResourceType;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Utils for making rpc request/response from inner object or convert inner class to rpc
+ * request/response for client and server.
+ */
+public class CommonRpcMessageUtils {
+
+    public static List<PbAclInfo> toPbAclInfos(Collection<AclBinding> aclBindings) {
+        return aclBindings.stream()
+                .map(CommonRpcMessageUtils::toPbAclInfo)
+                .collect(Collectors.toList());
+    }
+
+    public static List<AclBinding> toAclBindings(Collection<PbAclInfo> pbAclInfos) {
+        return pbAclInfos.stream()
+                .map(CommonRpcMessageUtils::toAclBinding)
+                .collect(Collectors.toList());
+    }
+
+    public static List<PbAclFilter> toPbAclBindingFilters(
+            Collection<AclBindingFilter> aclBindingFilters) {
+        return aclBindingFilters.stream()
+                .map(CommonRpcMessageUtils::toPbAclFilter)
+                .collect(Collectors.toList());
+    }
+
+    public static List<AclBindingFilter> toAclBindingFilters(Collection<PbAclFilter> pbAclFilters) {
+        return pbAclFilters.stream()
+                .map(CommonRpcMessageUtils::toAclFilter)
+                .collect(Collectors.toList());
+    }
+
+    public static AclBinding toAclBinding(PbAclInfo pbAclInfo) {
+        return new AclBinding(
+                new Resource(
+                        ResourceType.fromCode((byte) pbAclInfo.getResourceType()),
+                        pbAclInfo.getResourceName()),
+                new AccessControlEntry(
+                        new FlussPrincipal(
+                                pbAclInfo.getPrincipalName(), pbAclInfo.getPrincipalType()),
+                        pbAclInfo.getHost(),
+                        OperationType.fromCode((byte) pbAclInfo.getOperationType()),
+                        PermissionType.fromCode((byte) pbAclInfo.getPermissionType())));
+    }
+
+    public static PbAclInfo toPbAclInfo(AclBinding aclBinding) {
+        return new PbAclInfo()
+                .setResourceType(aclBinding.getResource().getType().getCode())
+                .setResourceName(aclBinding.getResource().getName())
+                .setPrincipalName(aclBinding.getAccessControlEntry().getPrincipal().getName())
+                .setPrincipalType(aclBinding.getAccessControlEntry().getPrincipal().getType())
+                .setHost(aclBinding.getAccessControlEntry().getHost())
+                .setOperationType(aclBinding.getAccessControlEntry().getOperationType().getCode())
+                .setPermissionType(
+                        aclBinding.getAccessControlEntry().getPermissionType().getCode());
+    }
+
+    public static PbAclFilter toPbAclFilter(AclBindingFilter aclBindingFilter) {
+        AccessControlEntry accessControlEntry = aclBindingFilter.getEntryFilter().getData();
+        ResourceFilter resourceFilter = aclBindingFilter.getResourceFilter();
+
+        PbAclFilter pbAclFilter = new PbAclFilter();
+        pbAclFilter
+                .setResourceType(resourceFilter.getType().getCode())
+                .setOperationType(accessControlEntry.getOperationType().getCode())
+                .setPermissionType(accessControlEntry.getPermissionType().getCode());
+        if (resourceFilter.getName() != null) {
+            pbAclFilter.setResourceName(resourceFilter.getName());
+        }
+
+        if (accessControlEntry.getPrincipal() != null) {
+            pbAclFilter.setPrincipalName(accessControlEntry.getPrincipal().getName());
+        }
+
+        if (accessControlEntry.getPrincipal() != null) {
+            pbAclFilter.setPrincipalType(accessControlEntry.getPrincipal().getType());
+        }
+
+        if (accessControlEntry.getHost() != null) {
+            pbAclFilter.setHost(accessControlEntry.getHost());
+        }
+        return pbAclFilter;
+    }
+
+    public static AclBindingFilter toAclFilter(PbAclFilter pbAclFilter) {
+        return new AclBindingFilter(
+                new ResourceFilter(
+                        ResourceType.fromCode((byte) pbAclFilter.getResourceType()),
+                        pbAclFilter.hasResourceName() ? pbAclFilter.getResourceName() : null),
+                new AccessControlEntryFilter(
+                        pbAclFilter.hasPrincipalName() && pbAclFilter.hasPrincipalType()
+                                ? new FlussPrincipal(
+                                        pbAclFilter.getPrincipalName(),
+                                        pbAclFilter.getPrincipalType())
+                                : null,
+                        pbAclFilter.hasHost() ? pbAclFilter.getHost() : null,
+                        OperationType.fromCode((byte) pbAclFilter.getOperationType()),
+                        PermissionType.fromCode((byte) pbAclFilter.getPermissionType())));
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -102,11 +102,13 @@ public class CommonRpcMessageUtils {
             pbAclFilter.setResourceName(resourceFilter.getName());
         }
 
-        if (accessControlEntry.getPrincipal() != null) {
+        if (accessControlEntry.getPrincipal() != null
+                && accessControlEntry.getPrincipal().getName() != null) {
             pbAclFilter.setPrincipalName(accessControlEntry.getPrincipal().getName());
         }
 
-        if (accessControlEntry.getPrincipal() != null) {
+        if (accessControlEntry.getPrincipal() != null
+                && accessControlEntry.getPrincipal().getType() != null) {
             pbAclFilter.setPrincipalType(accessControlEntry.getPrincipal().getType());
         }
 

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/util/CommonRpcMessageUtils.java
@@ -90,30 +90,30 @@ public class CommonRpcMessageUtils {
     }
 
     public static PbAclFilter toPbAclFilter(AclBindingFilter aclBindingFilter) {
-        AccessControlEntry accessControlEntry = aclBindingFilter.getEntryFilter().getData();
+        AccessControlEntryFilter accessControlEntryFilter = aclBindingFilter.getEntryFilter();
         ResourceFilter resourceFilter = aclBindingFilter.getResourceFilter();
 
         PbAclFilter pbAclFilter = new PbAclFilter();
         pbAclFilter
                 .setResourceType(resourceFilter.getType().getCode())
-                .setOperationType(accessControlEntry.getOperationType().getCode())
-                .setPermissionType(accessControlEntry.getPermissionType().getCode());
+                .setOperationType(accessControlEntryFilter.getOperationType().getCode())
+                .setPermissionType(accessControlEntryFilter.getPermissionType().getCode());
         if (resourceFilter.getName() != null) {
             pbAclFilter.setResourceName(resourceFilter.getName());
         }
 
-        if (accessControlEntry.getPrincipal() != null
-                && accessControlEntry.getPrincipal().getName() != null) {
-            pbAclFilter.setPrincipalName(accessControlEntry.getPrincipal().getName());
+        if (accessControlEntryFilter.getPrincipal() != null
+                && accessControlEntryFilter.getPrincipal().getName() != null) {
+            pbAclFilter.setPrincipalName(accessControlEntryFilter.getPrincipal().getName());
         }
 
-        if (accessControlEntry.getPrincipal() != null
-                && accessControlEntry.getPrincipal().getType() != null) {
-            pbAclFilter.setPrincipalType(accessControlEntry.getPrincipal().getType());
+        if (accessControlEntryFilter.getPrincipal() != null
+                && accessControlEntryFilter.getPrincipal().getType() != null) {
+            pbAclFilter.setPrincipalType(accessControlEntryFilter.getPrincipal().getType());
         }
 
-        if (accessControlEntry.getHost() != null) {
-            pbAclFilter.setHost(accessControlEntry.getHost());
+        if (accessControlEntryFilter.getHost() != null) {
+            pbAclFilter.setHost(accessControlEntryFilter.getHost());
         }
         return pbAclFilter;
     }

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -755,3 +755,70 @@ message PbPartitionSpec {
 
 
 
+//  acl
+message PbAclInfo{
+  required string resource_name = 1;
+  required int32 resource_type = 2;
+  required string principal_name = 3;
+  required string principal_type = 4;
+  required string host = 5;
+  required int32 operation_type = 6;
+  required int32 permission_type = 7;
+}
+
+message PbAclFilter{
+  optional string resource_name = 1;
+  required int32 resource_type = 2;
+  optional string principal_name = 3;
+  optional string principal_type = 4;
+  optional string host = 5;
+  required int32 operation_type = 6;
+  required int32 permission_type = 7;
+}
+
+
+
+
+message ListAclsRequest{
+  required PbAclFilter acl_filter = 1;
+}
+
+
+message ListAclsResponse{
+  repeated PbAclInfo acl = 1;
+}
+
+message CreateAclsRequest{
+  repeated PbAclInfo acl = 1;
+}
+
+message CreateAclsResponse{
+  repeated PbCreateAclRespInfo aclRes = 1;
+}
+message PbCreateAclRespInfo {
+  required PbAclInfo acl = 1;
+  optional int32 error_code = 2;
+  optional string error_message = 3;
+}
+
+
+message DropAclsRequest{
+  repeated PbAclFilter acl_filter = 1;
+}
+
+message DropAclsResponse{
+  repeated DropAclsFilterResult filter_results = 1;
+}
+
+message DropAclsFilterResult {
+  repeated DeleteAclsMatchingAcl matching_acls = 1;
+  optional int32 error_code = 2;
+  optional string error_message = 3;
+
+}
+
+message DeleteAclsMatchingAcl{
+  required PbAclInfo acl = 1;
+  optional int32 error_code = 2;
+  optional string error_message = 3;
+}

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -481,6 +481,37 @@ message AuthenticateResponse {
   optional bytes challenge = 1;
 }
 
+// acl related requests and responses
+message ListAclsRequest{
+  required PbAclFilter acl_filter = 1;
+}
+
+
+message ListAclsResponse{
+  repeated PbAclInfo acl = 1;
+}
+
+message CreateAclsRequest{
+  repeated PbAclInfo acl = 1;
+}
+
+message CreateAclsResponse{
+  repeated PbCreateAclRespInfo aclRes = 1;
+}
+message PbCreateAclRespInfo {
+  required PbAclInfo acl = 1;
+  optional int32 error_code = 2;
+  optional string error_message = 3;
+}
+
+message DropAclsRequest{
+  repeated PbAclFilter acl_filter = 1;
+}
+
+message DropAclsResponse{
+  repeated PbDropAclsFilterResult filter_results = 1;
+}
+
 // --------------- Inner classes ----------------
 message PbApiVersion {
   required int32 api_key = 1;
@@ -753,10 +784,8 @@ message PbPartitionSpec {
   repeated PbKeyValue partition_key_values = 1;
 }
 
-
-
-//  acl
-message PbAclInfo{
+message PbAclInfo
+{
   required string resource_name = 1;
   required int32 resource_type = 2;
   required string principal_name = 3;
@@ -776,48 +805,14 @@ message PbAclFilter{
   required int32 permission_type = 7;
 }
 
-
-
-
-message ListAclsRequest{
-  required PbAclFilter acl_filter = 1;
-}
-
-
-message ListAclsResponse{
-  repeated PbAclInfo acl = 1;
-}
-
-message CreateAclsRequest{
-  repeated PbAclInfo acl = 1;
-}
-
-message CreateAclsResponse{
-  repeated PbCreateAclRespInfo aclRes = 1;
-}
-message PbCreateAclRespInfo {
-  required PbAclInfo acl = 1;
-  optional int32 error_code = 2;
-  optional string error_message = 3;
-}
-
-
-message DropAclsRequest{
-  repeated PbAclFilter acl_filter = 1;
-}
-
-message DropAclsResponse{
-  repeated DropAclsFilterResult filter_results = 1;
-}
-
-message DropAclsFilterResult {
-  repeated DeleteAclsMatchingAcl matching_acls = 1;
+message PbDropAclsFilterResult {
+  repeated PbDropAclsMatchingAcl matching_acls = 1;
   optional int32 error_code = 2;
   optional string error_message = 3;
 
 }
 
-message DeleteAclsMatchingAcl{
+message PbDropAclsMatchingAcl{
   required PbAclInfo acl = 1;
   optional int32 error_code = 2;
   optional string error_message = 3;

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -486,7 +486,6 @@ message ListAclsRequest{
   required PbAclFilter acl_filter = 1;
 }
 
-
 message ListAclsResponse{
   repeated PbAclInfo acl = 1;
 }
@@ -497,11 +496,6 @@ message CreateAclsRequest{
 
 message CreateAclsResponse{
   repeated PbCreateAclRespInfo aclRes = 1;
-}
-message PbCreateAclRespInfo {
-  required PbAclInfo acl = 1;
-  optional int32 error_code = 2;
-  optional string error_message = 3;
 }
 
 message DropAclsRequest{
@@ -784,8 +778,13 @@ message PbPartitionSpec {
   repeated PbKeyValue partition_key_values = 1;
 }
 
-message PbAclInfo
-{
+message PbCreateAclRespInfo {
+  required PbAclInfo acl = 1;
+  optional int32 error_code = 2;
+  optional string error_message = 3;
+}
+
+message PbAclInfo {
   required string resource_name = 1;
   required int32 resource_type = 2;
   required string principal_name = 3;
@@ -795,7 +794,7 @@ message PbAclInfo
   required int32 permission_type = 7;
 }
 
-message PbAclFilter{
+message PbAclFilter {
   optional string resource_name = 1;
   required int32 resource_type = 2;
   optional string principal_name = 3;
@@ -812,7 +811,7 @@ message PbDropAclsFilterResult {
 
 }
 
-message PbDropAclsMatchingAcl{
+message PbDropAclsMatchingAcl {
   required PbAclInfo acl = 1;
   optional int32 error_code = 2;
   optional string error_message = 3;

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
@@ -40,6 +40,8 @@ import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanRequest;
 import com.alibaba.fluss.rpc.messages.LimitScanResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
@@ -231,6 +233,11 @@ public class TestingTabletGatewayService extends TestingGatewayService
     @Override
     public CompletableFuture<GetLatestLakeSnapshotResponse> getLatestLakeSnapshot(
             GetLatestLakeSnapshotRequest request) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request) {
         return null;
     }
 }

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/AuthenticationTest.java
@@ -208,8 +208,7 @@ public class AuthenticationTest {
         configuration.setString(
                 ConfigOptions.SERVER_SECURITY_PROTOCOL_MAP.key(),
                 "CLIENT1:mutual,CLIENT2:username_password");
-        configuration.setString("security.username_password.username", "root");
-        configuration.setString("security.username_password.password", "password");
+        configuration.setString("security.username_password.credentials", "root:password");
         // 3 worker threads is enough for this test
         configuration.setString(ConfigOptions.NETTY_SERVER_NUM_WORKER_THREADS.key(), "3");
         MetricGroup metricGroup = NOPMetricsGroup.newInstance();

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/MutualAuthenticationPlugin.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.rpc.netty.authenticate;
 import com.alibaba.fluss.config.ConfigOption;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 import com.alibaba.fluss.security.auth.ClientAuthenticationPlugin;
 import com.alibaba.fluss.security.auth.ClientAuthenticator;
 import com.alibaba.fluss.security.auth.ServerAuthenticationPlugin;
@@ -149,6 +150,11 @@ public class MutualAuthenticationPlugin
                             + (initialSalt + 1)
                             + ", but got "
                             + tokenValue);
+        }
+
+        @Override
+        public FlussPrincipal createPrincipal() {
+            return FlussPrincipal.ANONYMOUS;
         }
 
         @Override

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
@@ -42,7 +42,9 @@ public class UsernamePasswordAuthenticationPlugin
             key("client.security.username_password.password").stringType().noDefaultValue();
 
     private static final ConfigOption<Map<String, String>> CREDENTIALS =
-            key("security.credentials").mapType().defaultValue(Collections.emptyMap());
+            key("security.username_password.credentials")
+                    .mapType()
+                    .defaultValue(Collections.emptyMap());
 
     private static final String AUTH_PROTOCOL = "username_password";
 

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/authenticate/UsernamePasswordAuthenticationPlugin.java
@@ -19,13 +19,15 @@ package com.alibaba.fluss.rpc.netty.authenticate;
 import com.alibaba.fluss.config.ConfigOption;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
 import com.alibaba.fluss.security.auth.ClientAuthenticationPlugin;
 import com.alibaba.fluss.security.auth.ClientAuthenticator;
 import com.alibaba.fluss.security.auth.ServerAuthenticationPlugin;
 import com.alibaba.fluss.security.auth.ServerAuthenticator;
 
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 import static com.alibaba.fluss.config.ConfigBuilder.key;
 
@@ -39,11 +41,8 @@ public class UsernamePasswordAuthenticationPlugin
     private static final ConfigOption<String> CLIENT_PASSWORD =
             key("client.security.username_password.password").stringType().noDefaultValue();
 
-    private static final ConfigOption<String> SERVER_USERNAME =
-            key("security.username_password.username").stringType().noDefaultValue();
-
-    private static final ConfigOption<String> SERVER_PASSWORD =
-            key("security.username_password.password").stringType().noDefaultValue();
+    private static final ConfigOption<Map<String, String>> CREDENTIALS =
+            key("security.credentials").mapType().defaultValue(Collections.emptyMap());
 
     private static final String AUTH_PROTOCOL = "username_password";
 
@@ -82,13 +81,10 @@ public class UsernamePasswordAuthenticationPlugin
 
     @Override
     public ServerAuthenticator createServerAuthenticator(Configuration configuration) {
-        String expectedUsername = configuration.getString(SERVER_USERNAME);
-        String expectedPassword = configuration.getString(SERVER_PASSWORD);
-        if (expectedPassword == null || expectedUsername == null) {
-            throw new AuthenticationException("username and password shouldn't be null.");
-        }
+        Map<String, String> credentials = configuration.getMap(CREDENTIALS);
         return new ServerAuthenticator() {
             volatile boolean isComplete = false;
+            volatile FlussPrincipal flussPrincipal;
 
             @Override
             public String protocol() {
@@ -97,14 +93,21 @@ public class UsernamePasswordAuthenticationPlugin
 
             @Override
             public byte[] evaluateResponse(byte[] token) throws AuthenticationException {
-                byte[] expectedToken = serializeToken(expectedUsername, expectedPassword);
-                if (!Arrays.equals(token, expectedToken)) {
+                String[] credential = deserializeToken(token);
+                if (!credentials.containsKey(credential[0])
+                        || !credentials.get(credential[0]).equals(credential[1])) {
                     throw new AuthenticationException("username or password is incorrect.");
                 }
 
                 isComplete = true;
+                flussPrincipal = new FlussPrincipal(credential[0], "USER");
 
                 return new byte[0];
+            }
+
+            @Override
+            public FlussPrincipal createPrincipal() {
+                return flussPrincipal;
             }
 
             @Override
@@ -116,5 +119,13 @@ public class UsernamePasswordAuthenticationPlugin
 
     private byte[] serializeToken(String username, String password) {
         return (username + "," + password).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private String[] deserializeToken(byte[] token) {
+        String[] parts = new String(token, StandardCharsets.UTF_8).split(",");
+        if (parts.length != 2) {
+            throw new AuthenticationException("Invalid token format.");
+        }
+        return parts;
     }
 }

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandlerTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/netty/server/NettyServerHandlerTest.java
@@ -67,7 +67,8 @@ final class NettyServerHandlerTest {
                 new NettyServerHandler(
                         requestChannel,
                         new ApiManager(ServerType.TABLET_SERVER),
-                        "CLIENT",
+                        "FLUSS",
+                        true,
                         RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup),
                         new PlainTextAuthenticationPlugin.PlainTextServerAuthenticator());
         this.ctx = mockChannelHandlerContext();

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
@@ -67,7 +67,8 @@ class MessageCodecTest {
                 new NettyServerHandler(
                         requestChannel,
                         new ApiManager(ServerType.TABLET_SERVER),
-                        "CLIENT",
+                        "FLUSS",
+                        true,
                         RequestsMetrics.createCoordinatorServerRequestMetrics(metricGroup),
                         new PlainTextAuthenticationPlugin.PlainTextServerAuthenticator());
         this.ctx = mockChannelHandlerContext();

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/MessageCodecTest.java
@@ -41,6 +41,7 @@ import com.alibaba.fluss.shaded.netty4.io.netty.util.concurrent.EventExecutor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.InetSocketAddress;
 import java.util.Collections;
 
 import static com.alibaba.fluss.testutils.ByteBufChannel.toByteBuf;
@@ -195,6 +196,7 @@ class MessageCodecTest {
         when(channelId.asLongText()).thenReturn("long_text");
         Channel channel = mock(Channel.class);
         when(channel.id()).thenReturn(channelId);
+        when(channel.remoteAddress()).thenReturn(new InetSocketAddress("localhost", 8080));
         ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
         when(ctx.channel()).thenReturn(channel);
         EventExecutor eventExecutor = mock(EventExecutor.class);

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/RequestChannelTest.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/protocol/RequestChannelTest.java
@@ -51,7 +51,10 @@ public class RequestChannelTest {
                             null,
                             new GetTableInfoRequest(),
                             new EmptyByteBuf(new UnpooledByteBufAllocator(true, true)),
-                            "CLIENT",
+                            "FLUSS",
+                            true,
+                            null,
+                            null,
                             new CompletableFuture<>());
             channel.putRequest(rpcRequest);
             rpcRequests.add(rpcRequest);
@@ -71,7 +74,10 @@ public class RequestChannelTest {
                         null,
                         new GetTableInfoRequest(),
                         new EmptyByteBuf(new UnpooledByteBufAllocator(true, true)),
-                        "CLIENT",
+                        "FLUSS",
+                        true,
+                        null,
+                        null,
                         new CompletableFuture<>());
         RpcRequest rpcRequest2 =
                 new FlussRequest(
@@ -81,7 +87,10 @@ public class RequestChannelTest {
                         null,
                         new FetchLogRequest().setMaxBytes(100).setFollowerServerId(2),
                         new EmptyByteBuf(new UnpooledByteBufAllocator(true, true)),
-                        "CLIENT",
+                        "FLUSS",
+                        true,
+                        null,
+                        null,
                         new CompletableFuture<>());
         channel.putRequest(rpcRequest1);
         channel.putRequest(rpcRequest2);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.server;
 import com.alibaba.fluss.cluster.BucketLocation;
 import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.cluster.ServerType;
+import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.exception.FlussRuntimeException;
 import com.alibaba.fluss.exception.KvSnapshotNotExistException;
 import com.alibaba.fluss.exception.LakeTableSnapshotNotExistException;
@@ -55,6 +56,8 @@ import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableInfoResponse;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosRequest;
@@ -70,8 +73,17 @@ import com.alibaba.fluss.rpc.messages.TableExistsRequest;
 import com.alibaba.fluss.rpc.messages.TableExistsResponse;
 import com.alibaba.fluss.rpc.messages.UpdateMetadataRequest;
 import com.alibaba.fluss.rpc.messages.UpdateMetadataResponse;
+import com.alibaba.fluss.rpc.netty.server.Session;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
+import com.alibaba.fluss.rpc.util.CommonRpcMessageUtils;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceType;
+import com.alibaba.fluss.server.authorizer.Action;
+import com.alibaba.fluss.server.authorizer.Authorizer;
 import com.alibaba.fluss.server.coordinator.CoordinatorService;
 import com.alibaba.fluss.server.coordinator.MetadataManager;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshot;
@@ -96,15 +108,18 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeGetLatestKvSnapshotsResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeGetLatestLakeSnapshotResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeKvSnapshotMetadataResponse;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeListAclsResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.toGetFileSystemSecurityTokenResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.toListPartitionInfosResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.toPhysicalTablePath;
@@ -127,6 +142,7 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     protected final ZooKeeperClient zkClient;
     protected final ServerMetadataCache metadataCache;
     protected final MetadataManager metadataManager;
+    protected final Authorizer authorizer;
 
     private long tokenLastUpdateTimeMs = 0;
     private ObtainedSecurityToken securityToken = null;
@@ -136,13 +152,15 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
             ServerType provider,
             ZooKeeperClient zkClient,
             ServerMetadataCache metadataCache,
-            MetadataManager metadataManager) {
+            MetadataManager metadataManager,
+            @Nullable Authorizer authorizer) {
         this.remoteFileSystem = remoteFileSystem;
         this.provider = provider;
         this.apiManager = new ApiManager(provider);
         this.zkClient = zkClient;
         this.metadataCache = metadataCache;
         this.metadataManager = metadataManager;
+        this.authorizer = authorizer;
     }
 
     @Override
@@ -170,13 +188,19 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     public CompletableFuture<ListDatabasesResponse> listDatabases(ListDatabasesRequest request) {
         ListDatabasesResponse response = new ListDatabasesResponse();
         List<String> databaseNames = metadataManager.listDatabases();
-        response.addAllDatabaseNames(databaseNames);
+
+        Set<String> authorizedDatabaseNames =
+                filterByAuthorized(OperationType.DESCRIBE, ResourceType.DATABASE, databaseNames);
+
+        response.addAllDatabaseNames(authorizedDatabaseNames);
         return CompletableFuture.completedFuture(response);
     }
 
     @Override
     public CompletableFuture<GetDatabaseInfoResponse> getDatabaseInfo(
             GetDatabaseInfoRequest request) {
+        doAuthorize(OperationType.DESCRIBE, Resource.database(request.getDatabaseName()));
+
         GetDatabaseInfoResponse response = new GetDatabaseInfoResponse();
         DatabaseInfo databaseInfo = metadataManager.getDatabase(request.getDatabaseName());
         response.setDatabaseJson(databaseInfo.getDatabaseDescriptor().toJsonBytes())
@@ -197,14 +221,29 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     public CompletableFuture<ListTablesResponse> listTables(ListTablesRequest request) {
         ListTablesResponse response = new ListTablesResponse();
         List<String> tableNames = metadataManager.listTables(request.getDatabaseName());
-        response.addAllTableNames(tableNames);
+
+        Set<String> authorizedTableNames =
+                filterByAuthorized(
+                        OperationType.DESCRIBE,
+                        ResourceType.TABLE,
+                        tableNames.stream()
+                                .map(t -> request.getDatabaseName() + "." + t)
+                                .collect(Collectors.toSet()));
+        response.addAllTableNames(
+                authorizedTableNames.stream()
+                        .map(t -> t.substring(t.indexOf(".") + 1))
+                        .collect(Collectors.toList()));
         return CompletableFuture.completedFuture(response);
     }
 
     @Override
     public CompletableFuture<GetTableInfoResponse> getTableInfo(GetTableInfoRequest request) {
-        GetTableInfoResponse response = new GetTableInfoResponse();
         TablePath tablePath = toTablePath(request.getTablePath());
+        doAuthorize(
+                OperationType.DESCRIBE,
+                Resource.table(tablePath.getDatabaseName(), tablePath.getTableName()));
+
+        GetTableInfoResponse response = new GetTableInfoResponse();
         TableInfo tableInfo = metadataManager.getTable(tablePath);
         response.setTableJson(tableInfo.toTableDescriptor().toJsonBytes())
                 .setSchemaId(tableInfo.getSchemaId())
@@ -252,14 +291,23 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
         List<PartitionMetadataInfo> partitionMetadataInfos = new ArrayList<>();
 
         for (PbTablePath pbTablePath : pbTablePaths) {
-            TablePath tablePath = toTablePath(pbTablePath);
-            tablePaths.add(tablePath);
-            tableMetadataInfos.add(getTableMetadata(tablePath, listenerName));
+            if (isAuthorized(
+                    OperationType.DESCRIBE,
+                    Resource.table(pbTablePath.getDatabaseName(), pbTablePath.getTableName()))) {
+                TablePath tablePath = toTablePath(pbTablePath);
+                tablePaths.add(tablePath);
+                tableMetadataInfos.add(getTableMetadata(tablePath, listenerName));
+            }
         }
 
         for (PbPhysicalTablePath partitionPath : partitions) {
-            partitionMetadataInfos.add(
-                    getPartitionMetadata(toPhysicalTablePath(partitionPath), listenerName));
+            if (isAuthorized(
+                    OperationType.DESCRIBE,
+                    Resource.table(
+                            partitionPath.getDatabaseName(), partitionPath.getTableName()))) {
+                partitionMetadataInfos.add(
+                        getPartitionMetadata(toPhysicalTablePath(partitionPath), listenerName));
+            }
         }
 
         // get partition info from partition ids
@@ -276,7 +324,7 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     @Override
     public CompletableFuture<UpdateMetadataResponse> updateMetadata(UpdateMetadataRequest request) {
         UpdateMetadataResponse updateMetadataResponse = new UpdateMetadataResponse();
-        metadataCache.updateMetadata(ClusterMetadataInfo.fromUpdateMetadataRequest(request));
+        metadataCache.updateClusterMetadata(ClusterMetadataInfo.fromUpdateMetadataRequest(request));
         return CompletableFuture.completedFuture(updateMetadataResponse);
     }
 
@@ -371,6 +419,8 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     @Override
     public CompletableFuture<GetFileSystemSecurityTokenResponse> getFileSystemSecurityToken(
             GetFileSystemSecurityTokenRequest request) {
+        doAuthorize(OperationType.FILESYSTEM_TOKEN, Resource.cluster());
+
         try {
             // In order to avoid repeatedly obtaining security token, cache it for a while.
             long currentTimeMs = System.currentTimeMillis();
@@ -430,6 +480,21 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
         LakeTableSnapshot lakeTableSnapshot = optLakeTableSnapshot.get();
         return CompletableFuture.completedFuture(
                 makeGetLatestLakeSnapshotResponse(tableId, lakeTableSnapshot));
+    }
+
+    @Override
+    public CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request) {
+        doAuthorize(OperationType.DESCRIBE, Resource.cluster());
+
+        AclBindingFilter aclBindingFilter =
+                CommonRpcMessageUtils.toAclFilter(request.getAclFilter());
+        try {
+            Collection<AclBinding> acls = authorizer.listAcls(aclBindingFilter);
+            return CompletableFuture.completedFuture(makeListAclsResponse(acls));
+        } catch (Exception e) {
+            throw new FlussRuntimeException(
+                    String.format("Failed to list acls for resource: ", aclBindingFilter), e);
+        }
     }
 
     private Set<ServerNode> getAllTabletServerNodes(String listenerName) {
@@ -617,6 +682,59 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
             return new AssignmentInfo(
                     tableId, zkClient.getTableAssignment(tableId).orElse(null), null);
         }
+    }
+
+    protected void doAuthorize(OperationType operationType, Resource resource) {
+        Session session = currentSession();
+        // internal request will not be authorized
+        if (!isAuthorized(operationType, resource)) {
+            LOG.warn(
+                    "Principal {} have no authorization to operate {} on resource {}",
+                    session.getPrincipal(),
+                    operationType,
+                    resource);
+            throw new AuthenticationException(
+                    String.format(
+                            "Principal %s have no authorization to operate %s on resource %s ",
+                            session.getPrincipal(), operationType, resource));
+        }
+    }
+
+    protected boolean isAuthorized(OperationType operationType, Resource resource) {
+        Session session = currentSession();
+        // internal request will not be authorized
+        return authorizer == null
+                || session.isInternal()
+                || authorizer.authorize(session, operationType, resource);
+    }
+
+    protected Set<String> filterByAuthorized(
+            OperationType operation, ResourceType resourceType, Collection<String> resourceNames) {
+
+        Set<String> resourceNameSet = new HashSet<>(resourceNames);
+
+        if (authorizer == null) {
+            return new HashSet<>(resourceNameSet);
+        }
+
+        List<Action> actions = new ArrayList<>();
+        for (String resourceName : resourceNameSet) {
+            actions.add(new Action(new Resource(resourceType, resourceName), operation));
+        }
+
+        List<Boolean> results = authorizer.authorize(currentSession(), actions);
+
+        Set<String> authorizedResource = new HashSet<>();
+        Iterator<String> resourceIterator = resourceNameSet.iterator();
+        for (Boolean result : results) {
+            if (result && resourceIterator.hasNext()) {
+                authorizedResource.add(resourceIterator.next());
+            } else if (resourceIterator.hasNext()) {
+                resourceIterator.next(); // Skip denied resources
+            }
+        }
+
+        return authorizedResource;
     }
 
     private static class AssignmentInfo {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
@@ -442,6 +442,7 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     @Override
     public CompletableFuture<GetFileSystemSecurityTokenResponse> getFileSystemSecurityToken(
             GetFileSystemSecurityTokenRequest request) {
+        // TODO: add ACL for per-table in https://github.com/alibaba/fluss/issues/752
         try {
             // In order to avoid repeatedly obtaining security token, cache it for a while.
             long currentTimeMs = System.currentTimeMillis();

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AbstractAuthorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AbstractAuthorizer.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.rpc.netty.server.Session;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.Resource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Abstract Authorizer class provides common functionality for authorizing operations on resources.
+ */
+public abstract class AbstractAuthorizer implements Authorizer {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractAuthorizer.class);
+
+    @Override
+    public boolean isAuthorized(Session session, OperationType operationType, Resource resource) {
+        return session.isInternal()
+                || authorizeAction(session, new Action(resource, operationType));
+    }
+
+    @Override
+    public void authorize(Session session, OperationType operationType, Resource resource)
+            throws AuthenticationException {
+        // internal request will not be authorized
+        if (!isAuthorized(session, operationType, resource)) {
+            LOG.warn(
+                    "Principal {} have no authorization to operate {} on resource {}",
+                    session.getPrincipal(),
+                    operationType,
+                    resource);
+            throw new AuthenticationException(
+                    String.format(
+                            "Principal %s have no authorization to operate %s on resource %s ",
+                            session.getPrincipal(), operationType, resource));
+        }
+    }
+
+    @Override
+    public Collection<Resource> filterByAuthorized(
+            Session session, OperationType operation, List<Resource> resources) {
+
+        List<Action> actions =
+                resources.stream()
+                        .map(resource -> new Action(resource, operation))
+                        .collect(Collectors.toList());
+
+        List<Boolean> results = authorizeActions(session, actions);
+
+        return IntStream.range(0, results.size())
+                .filter(results::get)
+                .mapToObj(actions::get)
+                .map(Action::getResource)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * Authorizes multiple actions for a given session.
+     *
+     * @param session the session associated with the request
+     * @param action a action to be authorized
+     * @return a list of boolean results indicating whether each action is authorized
+     */
+    abstract boolean authorizeAction(Session session, Action action);
+
+    public List<Boolean> authorizeActions(Session session, List<Action> actions) {
+        return actions.stream()
+                .map(action -> authorizeAction(session, action))
+                .collect(Collectors.toList());
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AbstractAuthorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AbstractAuthorizer.java
@@ -16,7 +16,7 @@
 
 package com.alibaba.fluss.server.authorizer;
 
-import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.exception.AuthorizationException;
 import com.alibaba.fluss.rpc.netty.server.Session;
 import com.alibaba.fluss.security.acl.OperationType;
 import com.alibaba.fluss.security.acl.Resource;
@@ -43,7 +43,7 @@ public abstract class AbstractAuthorizer implements Authorizer {
 
     @Override
     public void authorize(Session session, OperationType operationType, Resource resource)
-            throws AuthenticationException {
+            throws AuthorizationException {
         // internal request will not be authorized
         if (!isAuthorized(session, operationType, resource)) {
             LOG.warn(
@@ -51,7 +51,7 @@ public abstract class AbstractAuthorizer implements Authorizer {
                     session.getPrincipal(),
                     operationType,
                     resource);
-            throw new AuthenticationException(
+            throw new AuthorizationException(
                     String.format(
                             "Principal %s have no authorization to operate %s on resource %s ",
                             session.getPrincipal(), operationType, resource));
@@ -81,7 +81,7 @@ public abstract class AbstractAuthorizer implements Authorizer {
      *
      * @param session the session associated with the request
      * @param action a action to be authorized
-     * @return a list of boolean results indicating whether each action is authorized
+     * @return boolean results a boolean indicating whether the action is authorized
      */
     abstract boolean authorizeAction(Session session, Action action);
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclCreateResult.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclCreateResult.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.security.acl.AclBinding;
+
+import java.util.Optional;
+
+/**
+ * AclCreateResult represents the result of an ACL (Access Control List) creation operation. It
+ * encapsulates either a successful creation result containing the {@link AclBinding} or an
+ * exception indicating a failure during the operation.
+ */
+public class AclCreateResult {
+
+    /** The ACL binding created as part of the operation, if successful. */
+    private final AclBinding aclBinding;
+
+    /** The exception encountered during the ACL creation operation, if any. */
+    private final ApiException exception;
+
+    public AclCreateResult(AclBinding aclBinding, ApiException exception) {
+        this.aclBinding = aclBinding;
+        this.exception = exception;
+    }
+
+    public static AclCreateResult success(AclBinding aclBinding) {
+        return new AclCreateResult(aclBinding, null);
+    }
+
+    public Optional<ApiException> exception() {
+        return exception == null ? Optional.empty() : Optional.of(exception);
+    }
+
+    public AclBinding getAclBinding() {
+        return aclBinding;
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.security.acl.AclBinding;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * AclDeleteResult represents the result of an ACL (Access Control List) deletion operation. It
+ * encapsulates the results of matching ACL filters and any exceptions encountered during the
+ * process.
+ */
+public class AclDeleteResult {
+
+    /** The exception encountered while attempting to match ACL filters for deletion, if any. */
+    private final ApiException exception;
+
+    /** The collection of delete results for each matching ACL binding. */
+    private final Collection<AclBindingDeleteResult> aclBindingDeleteResults;
+
+    public AclDeleteResult(Collection<AclBindingDeleteResult> deleteResults) {
+        this(deleteResults, null);
+    }
+
+    public AclDeleteResult(
+            Collection<AclBindingDeleteResult> deleteResults, ApiException exception) {
+        this.aclBindingDeleteResults = deleteResults;
+        this.exception = exception;
+    }
+
+    public Optional<ApiException> exception() {
+        return exception == null ? Optional.empty() : Optional.of(exception);
+    }
+
+    public Collection<AclBindingDeleteResult> aclBindingDeleteResults() {
+        return aclBindingDeleteResults;
+    }
+
+    /**
+     * AclBindingDeleteResult represents the result of deleting a specific ACL binding that matched
+     * a delete filter.
+     */
+    public static class AclBindingDeleteResult {
+
+        /** The ACL binding that matched the delete filter. */
+        private final AclBinding aclBinding;
+
+        /** The exception encountered while attempting to delete the ACL binding, if any. */
+        private final ApiException exception;
+
+        public AclBindingDeleteResult(AclBinding aclBinding, ApiException exception) {
+            this.aclBinding = aclBinding;
+            this.exception = exception;
+        }
+
+        public AclBinding aclBinding() {
+            return aclBinding;
+        }
+
+        public Optional<ApiException> exception() {
+            return exception == null ? Optional.empty() : Optional.of(exception);
+        }
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
@@ -16,8 +16,10 @@
 
 package com.alibaba.fluss.server.authorizer;
 
-import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.rpc.protocol.ApiError;
 import com.alibaba.fluss.security.acl.AclBinding;
+
+import javax.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -29,8 +31,8 @@ import java.util.Optional;
  */
 public class AclDeleteResult {
 
-    /** The exception encountered while attempting to match ACL filters for deletion, if any. */
-    private final ApiException exception;
+    /** The error encountered while attempting to match ACL filters for deletion, if any. */
+    @Nullable private final ApiError error;
 
     /** The collection of delete results for each matching ACL binding. */
     private final Collection<AclBindingDeleteResult> aclBindingDeleteResults;
@@ -40,13 +42,13 @@ public class AclDeleteResult {
     }
 
     public AclDeleteResult(
-            Collection<AclBindingDeleteResult> deleteResults, ApiException exception) {
+            Collection<AclBindingDeleteResult> deleteResults, @Nullable ApiError error) {
         this.aclBindingDeleteResults = deleteResults;
-        this.exception = exception;
+        this.error = error;
     }
 
-    public Optional<ApiException> exception() {
-        return exception == null ? Optional.empty() : Optional.of(exception);
+    public Optional<ApiError> error() {
+        return error == null ? Optional.empty() : Optional.of(error);
     }
 
     public Collection<AclBindingDeleteResult> aclBindingDeleteResults() {
@@ -63,19 +65,19 @@ public class AclDeleteResult {
         private final AclBinding aclBinding;
 
         /** The exception encountered while attempting to delete the ACL binding, if any. */
-        private final ApiException exception;
+        @Nullable private final ApiError error;
 
-        public AclBindingDeleteResult(AclBinding aclBinding, ApiException exception) {
+        public AclBindingDeleteResult(AclBinding aclBinding, ApiError apiError) {
             this.aclBinding = aclBinding;
-            this.exception = exception;
+            this.error = apiError;
         }
 
         public AclBinding aclBinding() {
             return aclBinding;
         }
 
-        public Optional<ApiException> exception() {
-            return exception == null ? Optional.empty() : Optional.of(exception);
+        public Optional<ApiError> error() {
+            return error == null ? Optional.empty() : Optional.of(error);
         }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AclDeleteResult.java
@@ -48,7 +48,7 @@ public class AclDeleteResult {
     }
 
     public Optional<ApiError> error() {
-        return error == null ? Optional.empty() : Optional.of(error);
+        return Optional.ofNullable(error);
     }
 
     public Collection<AclBindingDeleteResult> aclBindingDeleteResults() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Action.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Action.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.Resource;
+
+/** The action to operator. */
+public class Action {
+    private final Resource resource;
+    private final OperationType operation;
+
+    public Action(Resource resource, OperationType operation) {
+        this.resource = resource;
+        this.operation = operation;
+    }
+
+    public Resource getResource() {
+        return resource;
+    }
+
+    public OperationType getOperation() {
+        return operation;
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.plugin.Plugin;
+
+/** AuthorizePlugin. */
+public interface AuthorizationPlugin extends Plugin {
+
+    String identifier();
+
+    Authorizer createAuthorizer(Configuration configuration);
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
@@ -16,13 +16,32 @@
 
 package com.alibaba.fluss.server.authorizer;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.plugin.Plugin;
+import com.alibaba.fluss.server.zk.ZooKeeperClient;
+
+import java.util.Optional;
 
 /** AuthorizePlugin. */
 public interface AuthorizationPlugin extends Plugin {
 
     String identifier();
 
-    Authorizer createAuthorizer(Configuration configuration);
+    Authorizer createAuthorizer(Context context);
+
+    /** Provides session information describing the authorizer to be accessed. */
+    @PublicEvolving
+    interface Context{
+
+        /**
+         * Get configuration of fluss server to authorize.
+         */
+        Configuration getConfiguration();
+
+        /**
+         * Get zookeeper client to store authorization information.
+         */
+        Optional<ZooKeeperClient> getZooKeeperClient();
+    }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizationPlugin.java
@@ -32,16 +32,12 @@ public interface AuthorizationPlugin extends Plugin {
 
     /** Provides session information describing the authorizer to be accessed. */
     @PublicEvolving
-    interface Context{
+    interface Context {
 
-        /**
-         * Get configuration of fluss server to authorize.
-         */
+        /** Get configuration of fluss server to authorize. */
         Configuration getConfiguration();
 
-        /**
-         * Get zookeeper client to store authorization information.
-         */
+        /** Get zookeeper client to store authorization information. */
         Optional<ZooKeeperClient> getZooKeeperClient();
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Authorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Authorizer.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.rpc.netty.server.Session;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.Resource;
+
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/** authorizer. */
+public interface Authorizer extends Closeable {
+
+    void startup() throws Exception;
+
+    void close();
+
+    default Boolean authorize(Session session, OperationType operationType, Resource resource) {
+        return authorize(session, Collections.singletonList(new Action(resource, operationType)))
+                .get(0);
+    }
+
+    List<Boolean> authorize(Session session, List<Action> actions);
+
+    List<AclCreateResult> addAcls(List<AclBinding> aclBindings);
+
+    List<AclDeleteResult> dropAcls(List<AclBindingFilter> filters);
+
+    Collection<AclBinding> listAcls(AclBindingFilter filter);
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Authorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/Authorizer.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.authorizer;
 
 import com.alibaba.fluss.exception.AuthenticationException;
+import com.alibaba.fluss.exception.AuthorizationException;
 import com.alibaba.fluss.rpc.netty.server.Session;
 import com.alibaba.fluss.security.acl.AclBinding;
 import com.alibaba.fluss.security.acl.AclBindingFilter;
@@ -45,27 +46,34 @@ public interface Authorizer extends Closeable {
     void close();
 
     /**
-     * Checks if a given session is authorized to perform a specific operation on a resource.
+     * Checks if a given session is authorized to perform a specific operation on a resource. This
+     * method is used for authorization checks and returns a boolean result indicating whether the
+     * session has the required permissions. It does not throw an exception if the session is
+     * unauthorized.
      *
-     * @param session
-     * @param operationType
-     * @param resource
-     * @return
+     * @param session the session associated with the request
+     * @param operationType the type of operation being checked
+     * @param resource the resource on which the operation is being performed
+     * @return true if the session is authorized, false otherwise
      */
     boolean isAuthorized(Session session, OperationType operationType, Resource resource);
 
     /**
-     * Checks if a given session is authorized to perform a specific operation on a resource.
+     * Checks if a given session is authorized to perform a specific operation on a resource. Unlike
+     * {@link #isAuthorized(Session, OperationType, Resource)}, this method enforces authorization
+     * by throwing an {@link AuthenticationException} if the session is not authorized to perform
+     * the operation. It is intended for scenarios where access control must be strictly enforced.
      *
-     * @throws AuthenticationException if the session is not authorized to perform the operation
+     * @param session the session associated with the request
+     * @param operationType the type of operation being checked
+     * @param resource the resource on which the operation is being performed
+     * @throws AuthorizationException if the session is not authorized to perform the operation
      */
     void authorize(Session session, OperationType operationType, Resource resource)
-            throws AuthenticationException;
+            throws AuthorizationException;
 
     /**
      * Filters a collection of resource names based on the provided session, operation, resources.
-     *
-     * @return
      */
     Collection<Resource> filterByAuthorized(
             Session session, OperationType operation, List<Resource> resources);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizerLoader.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizerLoader.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.ValidationException;
+import com.alibaba.fluss.plugin.PluginManager;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+/** authorizer loader. */
+public class AuthorizerLoader {
+
+    /** Load authorizer. */
+    public static @Nullable Authorizer createAuthorizer(
+            Configuration configuration, @Nullable PluginManager pluginManager) {
+        String authorizerType = configuration.get(ConfigOptions.AUTHORIZER_PLUGIN_TYPE);
+        if (authorizerType == null) {
+            return null;
+        }
+
+        Collection<Supplier<Iterator<AuthorizationPlugin>>> pluginSuppliers = new ArrayList<>(2);
+        pluginSuppliers.add(() -> ServiceLoader.load(AuthorizationPlugin.class).iterator());
+
+        if (pluginManager != null) {
+            pluginSuppliers.add(() -> pluginManager.load(AuthorizationPlugin.class));
+        }
+
+        List<AuthorizationPlugin> matchingPlugins = new ArrayList<>();
+        for (Supplier<Iterator<AuthorizationPlugin>> pluginSupplier : pluginSuppliers) {
+            Iterator<AuthorizationPlugin> plugins = pluginSupplier.get();
+            while (plugins.hasNext()) {
+                AuthorizationPlugin plugin = plugins.next();
+                if (plugin.identifier().equals(authorizerType)) {
+                    matchingPlugins.add(plugin);
+                }
+            }
+        }
+
+        if (matchingPlugins.size() != 1) {
+            throw new ValidationException(
+                    String.format(
+                            "Could not find same authorizer plugin for protocol '%s' in the classpath.\n\n"
+                                    + "Available factory protocols are:\n\n"
+                                    + "%s",
+                            authorizerType,
+                            matchingPlugins.stream()
+                                    .map(f -> f.getClass().getName())
+                                    .distinct()
+                                    .sorted()
+                                    .collect(Collectors.joining("\n"))));
+        }
+
+        return matchingPlugins.get(0).createAuthorizer(configuration);
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizerLoader.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/AuthorizerLoader.java
@@ -40,7 +40,9 @@ public class AuthorizerLoader {
 
     /** Load authorizer. */
     public static @Nullable Authorizer createAuthorizer(
-            Configuration configuration, ZooKeeperClient zooKeeperClient, @Nullable PluginManager pluginManager) {
+            Configuration configuration,
+            ZooKeeperClient zooKeeperClient,
+            @Nullable PluginManager pluginManager) {
         if (!configuration.get(AUTHORIZER_ENABLED)) {
             return null;
         }
@@ -77,7 +79,9 @@ public class AuthorizerLoader {
                                     .collect(Collectors.joining("\n"))));
         }
 
-        return matchingPlugins.get(0).createAuthorizer(new DefaultContext(configuration, zooKeeperClient));
+        return matchingPlugins
+                .get(0)
+                .createAuthorizer(new DefaultContext(configuration, zooKeeperClient));
     }
 
     /** Default implementation of {@link AuthorizationPlugin.Context}. */
@@ -85,7 +89,8 @@ public class AuthorizerLoader {
         private final Configuration configuration;
         private final ZooKeeperClient zooKeeperClient;
 
-        public DefaultContext(Configuration configuration, @Nullable ZooKeeperClient zooKeeperClient) {
+        public DefaultContext(
+                Configuration configuration, @Nullable ZooKeeperClient zooKeeperClient) {
             this.configuration = configuration;
             this.zooKeeperClient = zooKeeperClient;
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizationPlugin.java
@@ -14,17 +14,20 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.exception;
+package com.alibaba.fluss.server.authorizer;
 
-/**
- * This exception is thrown if no authorization.
- *
- * @since 0.7
- */
-public class AuthorizationException extends ApiException {
-    private static final long serialVersionUID = 1L;
+import com.alibaba.fluss.config.Configuration;
 
-    public AuthorizationException(String message) {
-        super(message);
+/** Default {@link AuthorizationPlugin} based on zookeeper. */
+public class DefaultAuthorizationPlugin implements AuthorizationPlugin {
+
+    @Override
+    public String identifier() {
+        return "default";
+    }
+
+    @Override
+    public Authorizer createAuthorizer(Context context) {
+        return new DefaultAuthorizer(context);
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizationPlugin.java
@@ -16,8 +16,6 @@
 
 package com.alibaba.fluss.server.authorizer;
 
-import com.alibaba.fluss.config.Configuration;
-
 /** Default {@link AuthorizationPlugin} based on zookeeper. */
 public class DefaultAuthorizationPlugin implements AuthorizationPlugin {
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizer.java
@@ -133,7 +133,7 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
     public DefaultAuthorizer(AuthorizationPlugin.Context context) {
         this.configuration = context.getConfiguration();
         this.superUsers = parseSuperUsers(configuration);
-        if(context.getZooKeeperClient().isPresent()){
+        if (context.getZooKeeperClient().isPresent()) {
             this.zooKeeperClient = context.getZooKeeperClient().get();
         } else {
             this.zooKeeperClient = ZooKeeperUtils.startZookeeperClient(configuration, this);
@@ -148,8 +148,6 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
                                 .toMillis(),
                         new ZkNotificationHandler(),
                         SystemClock.getInstance());
-
-
     }
 
     @Override
@@ -160,7 +158,7 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
 
     @Override
     public void close() {
-        if(zooKeeperClient != null){
+        if (zooKeeperClient != null) {
             zooKeeperClient.close();
         }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizer.java
@@ -218,30 +218,8 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
                                                         new AclCreateResult(
                                                                 aclBindings.get(idx), exception);
                                             });
-                            entries.values()
-                                    .forEach(
-                                            idx ->
-                                                    results[idx] =
-                                                            new AclCreateResult(
-                                                                    aclBindings.get(idx),
-                                                                    exception));
                         }
                     });
-
-            Map<FlussPrincipal, Integer> readIndices = new HashMap<>();
-            Map<FlussPrincipal, Integer> writeIndices = new HashMap<>();
-            for (int i = 0; i < aclBindings.size(); i++) {
-                if (results[i].exception().isPresent()) {
-                    continue;
-                }
-                if (aclBindings.get(i).getAccessControlEntry().getOperationType()
-                        == OperationType.READ) {
-                    readIndices.put(aclBindings.get(i).getAccessControlEntry().getPrincipal(), i);
-                } else if (aclBindings.get(i).getAccessControlEntry().getOperationType()
-                        == OperationType.WRITE) {
-                    writeIndices.put(aclBindings.get(i).getAccessControlEntry().getPrincipal(), i);
-                }
-            }
         }
         return Arrays.asList(results);
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.server.coordinator.event.watcher.TabletServerChangeWatcher;
+import com.alibaba.fluss.server.zk.ZooKeeperClient;
+import com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.recipes.cache.CuratorCache;
+import com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.recipes.cache.CuratorCacheListener;
+import com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent;
+import com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
+import com.alibaba.fluss.shaded.zookeeper3.org.apache.zookeeper.data.Stat;
+import com.alibaba.fluss.utils.clock.Clock;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.recipes.cache.PathChildrenCacheEvent.Type.CHILD_ADDED;
+
+/** A watcher to watch the change notification (create/delete/alter) in zookeeper. */
+public class ZkNodeChangeNotificationWatcher {
+
+    private static final Logger LOG = LoggerFactory.getLogger(TabletServerChangeWatcher.class);
+    private final CuratorCache curatorCache;
+    private final NotificationHandler notificationHandler;
+    private volatile boolean running;
+    private volatile long lastExecutedChange = -1L;
+    private final ZooKeeperClient zooKeeperClient;
+    private final String seqNodeRoot;
+    private final String seqNodePrefix;
+    private final long changeExpirationMs;
+    private final Clock clock;
+    private final Object lock = new Object();
+
+    public ZkNodeChangeNotificationWatcher(
+            ZooKeeperClient zooKeeperClient,
+            String seqNodeRoot,
+            String seqNodePrefix,
+            long changeExpirationMs,
+            NotificationHandler notificationHandler,
+            Clock clock) {
+
+        this.curatorCache = CuratorCache.build(zooKeeperClient.getCuratorClient(), seqNodeRoot);
+        this.notificationHandler = notificationHandler;
+        this.zooKeeperClient = zooKeeperClient;
+        this.seqNodeRoot = seqNodeRoot;
+        this.seqNodePrefix = seqNodePrefix;
+        this.changeExpirationMs = changeExpirationMs;
+        this.clock = clock;
+        this.curatorCache
+                .listenable()
+                .addListener(
+                        CuratorCacheListener.builder()
+                                .forPathChildrenCache(
+                                        seqNodeRoot,
+                                        zooKeeperClient.getCuratorClient(),
+                                        new ZkNodeChangeNotifactionListener())
+                                .build());
+    }
+
+    public void start() {
+        running = true;
+        // Initialize notifications by reading existing notification entries from ZooKeeper.
+        // This ensures that any pending notifications are processed when the watcher starts
+        processNotifications();
+
+        curatorCache.start();
+    }
+
+    public void stop() {
+        if (!running) {
+            return;
+        }
+        running = false;
+        LOG.info("Stopping TableChangeWatcher");
+        curatorCache.close();
+    }
+
+    private void processNotifications() {
+        synchronized (lock) {
+            try {
+                List<String> notifications = zooKeeperClient.getChildren(seqNodeRoot);
+                Collections.sort(notifications);
+                if (!notifications.isEmpty()) {
+                    LOG.info("Processing notifications for path = {}", seqNodeRoot);
+                    long now = clock.milliseconds();
+                    for (String notification : notifications) {
+                        long changeId = changeNumber(notification);
+                        if (changeId > lastExecutedChange) {
+                            processNotifications(notification);
+                            lastExecutedChange = changeId;
+                        }
+                    }
+                    purgeObsoleteNotifications(now, notifications);
+                }
+
+            } catch (Exception e) {
+                LOG.error(
+                        "Error while processing notification change for path = {}", seqNodeRoot, e);
+            }
+        }
+    }
+
+    private void processNotifications(String notification) {
+        String notificationNode = seqNodeRoot + "/" + notification;
+        try {
+            Optional<byte[]> data = zooKeeperClient.getOrEmpty(notificationNode);
+            if (data.isPresent()) {
+                notificationHandler.processNotification(data.get());
+            }
+        } catch (Exception e) {
+            LOG.error(
+                    "Error while processing notification change for path = {}",
+                    notificationNode,
+                    e);
+        }
+    }
+
+    /** Purges expired notifications. */
+    private void purgeObsoleteNotifications(long now, List<String> sortedNotifications) {
+        for (String notification : sortedNotifications) {
+            String notificationNode = seqNodeRoot + "/" + notification;
+            try {
+                Optional<Stat> state = zooKeeperClient.getState(notificationNode);
+                if (state.isPresent() && now - state.get().getCtime() >= changeExpirationMs) {
+                    LOG.debug("Purging change notification {}", notificationNode);
+                    zooKeeperClient.deletePath(notificationNode);
+                }
+            } catch (Exception e) {
+                LOG.error(
+                        "Error while purging obsolete notification change for path = {}",
+                        notificationNode,
+                        e);
+            }
+        }
+    }
+
+    private long changeNumber(String name) {
+        return Long.parseLong(name.substring(seqNodePrefix.length()));
+    }
+
+    private final class ZkNodeChangeNotifactionListener implements PathChildrenCacheListener {
+
+        @Override
+        public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) {
+            if (CHILD_ADDED.equals(event.getType())) {
+                processNotifications();
+            }
+        }
+    }
+
+    /**
+     * NotificationHandler defines the contract for processing notifications received from
+     * ZooKeeper.
+     *
+     * <p>This interface is implemented by classes that handle specific notification events, such as
+     * ACL changes or other state updates in ZooKeeper.
+     */
+    public interface NotificationHandler {
+        void processNotification(byte[] notification) throws Exception;
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
@@ -36,9 +36,9 @@ import static com.alibaba.fluss.shaded.curator5.org.apache.curator.framework.rec
 
 /** A watcher to watch the change notification (create/delete/alter) in zookeeper. */
 public class ZkNodeChangeNotificationWatcher {
-
     private static final Logger LOG =
             LoggerFactory.getLogger(ZkNodeChangeNotificationWatcher.class);
+
     private final CuratorCache curatorCache;
     private final NotificationHandler notificationHandler;
     private volatile boolean running;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizationPlugin.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizationPlugin.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.config.Configuration;
+
+/** AuthorizerPlugin based on zookeeper. */
+public class ZooKeeperBasedAuthorizationPlugin implements AuthorizationPlugin {
+
+    @Override
+    public String identifier() {
+        return "zookeeper";
+    }
+
+    @Override
+    public Authorizer createAuthorizer(Configuration configuration) {
+        return new ZooKeeperBasedAuthorizer(configuration);
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizer.java
@@ -1,0 +1,688 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.ApiException;
+import com.alibaba.fluss.rpc.netty.server.Session;
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceType;
+import com.alibaba.fluss.server.utils.FatalErrorHandler;
+import com.alibaba.fluss.server.zk.ZooKeeperClient;
+import com.alibaba.fluss.server.zk.ZooKeeperUtils;
+import com.alibaba.fluss.server.zk.data.ResourceAcl;
+import com.alibaba.fluss.server.zk.data.ZkData.AclChangeNotificationNode;
+import com.alibaba.fluss.server.zk.data.ZkData.AclChangesNode;
+import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Maps;
+import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Sets;
+import com.alibaba.fluss.utils.clock.SystemClock;
+import com.alibaba.fluss.utils.types.Tuple2;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+import static com.alibaba.fluss.security.acl.Resource.TABLE_SPLITTER;
+import static java.util.Collections.emptySet;
+
+/** An authorization manager that leverages ZooKeeper to store access control lists (ACLs). */
+public class ZooKeeperBasedAuthorizer implements Authorizer, FatalErrorHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperBasedAuthorizer.class);
+
+    /** Static mapping of ResourceType to allowed resources. */
+    private static final Map<ResourceType, Function<Resource, Set<Resource>>> RESOURCE_MAPPING;
+
+    static {
+        Map<ResourceType, Function<Resource, Set<Resource>>> mapping =
+                new EnumMap<>(ResourceType.class);
+        mapping.put(
+                ResourceType.TABLE,
+                res -> {
+                    String[] split = res.getName().split(TABLE_SPLITTER);
+                    return Sets.newHashSet(res, Resource.database(split[0]), Resource.cluster());
+                });
+        mapping.put(ResourceType.DATABASE, res -> Sets.newHashSet(res, Resource.cluster()));
+        mapping.put(ResourceType.CLUSTER, Sets::newHashSet);
+        RESOURCE_MAPPING = Collections.unmodifiableMap(mapping);
+    }
+
+    private final Configuration configuration;
+    private final Set<FlussPrincipal> superUsers;
+    private final boolean shouldAllowEveryoneIfNoAclIsFound = false;
+
+    private ZooKeeperClient zooKeeperClient;
+    private ZkNodeChangeNotificationWatcher aclChangeNotificationWatcher;
+    private final Object lock = new Object();
+    // The maximum number of times we should try to update the resource acls in zookeeper before
+    // failing;
+    // This should never occur, but is a safeguard just in case.
+    protected int maxUpdateRetries = 10;
+
+    // Main cache: Stores the mapping between resources and access control entries, sorted by
+    // resource.
+    private final TreeMap<Resource, Set<AccessControlEntry>> aclCache =
+            new TreeMap<>(new ResourceOrdering());
+
+    // Reverse index cache: Maps access control entry types to resources for quick lookups.
+    private final HashMap<ResourceTypeKey, Set<String>> resourceCache = new HashMap<>();
+
+    public ZooKeeperBasedAuthorizer(Configuration configuration) {
+        this.configuration = configuration;
+        this.superUsers = parseSuperUsers(configuration);
+    }
+
+    @Override
+    public void startup() throws Exception {
+        zooKeeperClient = ZooKeeperUtils.startZookeeperClient(configuration, this);
+        aclChangeNotificationWatcher =
+                new ZkNodeChangeNotificationWatcher(
+                        zooKeeperClient,
+                        AclChangesNode.path(),
+                        AclChangeNotificationNode.prefix(),
+                        configuration
+                                .get(ConfigOptions.ACL_NOTIFICATION_EXPIRATION_TIME)
+                                .toMillis(),
+                        new ZkNotificationHandler(),
+                        SystemClock.getInstance());
+
+        aclChangeNotificationWatcher.start();
+        loadCache();
+    }
+
+    @Override
+    public void close() {
+        if (zooKeeperClient != null) {
+            zooKeeperClient.close();
+        }
+
+        if (aclChangeNotificationWatcher != null) {
+            aclChangeNotificationWatcher.stop();
+        }
+    }
+
+    @Override
+    public List<Boolean> authorize(Session session, List<Action> actions) {
+        return actions.stream()
+                .map(action -> authorizeAction(session, action))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<AclCreateResult> addAcls(List<AclBinding> aclBindings) {
+        if (aclBindings.isEmpty()) {
+            return Collections.emptyList();
+        }
+        AclCreateResult[] results = new AclCreateResult[aclBindings.size()];
+        // key is resource, while is the index of acl binding in aclBindings.
+        Map<Resource, Map<AccessControlEntry, Integer>> aclsToCreate =
+                groupAclsByResource(aclBindings);
+        synchronized (lock) {
+            aclsToCreate.forEach(
+                    (resource, entries) -> {
+                        try {
+                            updateResourceAcl(
+                                    resource,
+                                    (currentAcls) -> {
+                                        Set<AccessControlEntry> newAcls =
+                                                new HashSet<>(currentAcls);
+                                        newAcls.addAll(entries.keySet());
+                                        return newAcls;
+                                    });
+                            entries.values()
+                                    .forEach(
+                                            idx -> {
+                                                results[idx] =
+                                                        AclCreateResult.success(
+                                                                aclBindings.get(idx));
+                                            });
+
+                        } catch (Throwable e) {
+                            entries.values()
+                                    .forEach(
+                                            idx -> {
+                                                results[idx] =
+                                                        new AclCreateResult(
+                                                                aclBindings.get(idx),
+                                                                new ApiException(e));
+                                            });
+                        }
+                    });
+
+            Map<FlussPrincipal, Integer> readIndices = new HashMap<>();
+            Map<FlussPrincipal, Integer> writeIndices = new HashMap<>();
+            for (int i = 0; i < aclBindings.size(); i++) {
+                if (results[i].exception().isPresent()) {
+                    continue;
+                }
+                if (aclBindings.get(i).getAccessControlEntry().getOperationType()
+                        == OperationType.READ) {
+                    readIndices.put(aclBindings.get(i).getAccessControlEntry().getPrincipal(), i);
+                } else if (aclBindings.get(i).getAccessControlEntry().getOperationType()
+                        == OperationType.WRITE) {
+                    writeIndices.put(aclBindings.get(i).getAccessControlEntry().getPrincipal(), i);
+                }
+            }
+
+            if (!readIndices.isEmpty() || !writeIndices.isEmpty()) {
+                try {
+                    updateResourceAcl(
+                            Resource.cluster(),
+                            (currentAcls) -> {
+                                Set<AccessControlEntry> newAcls = new HashSet<>(currentAcls);
+                                newAcls.addAll(
+                                        readIndices.keySet().stream()
+                                                .map(
+                                                        principal ->
+                                                                new AccessControlEntry(
+                                                                        principal,
+                                                                        AccessControlEntry
+                                                                                .WILD_CARD_HOST,
+                                                                        OperationType
+                                                                                .FILESYSTEM_TOKEN,
+                                                                        PermissionType.ALLOW))
+                                                .collect(Collectors.toSet()));
+                                newAcls.addAll(
+                                        writeIndices.keySet().stream()
+                                                .map(
+                                                        principal ->
+                                                                new AccessControlEntry(
+                                                                        principal,
+                                                                        AccessControlEntry
+                                                                                .WILD_CARD_HOST,
+                                                                        OperationType
+                                                                                .IDEMPOTENT_WRITE,
+                                                                        PermissionType.ALLOW))
+                                                .collect(Collectors.toSet()));
+                                return newAcls;
+                            });
+                } catch (Exception e) {
+                    Map<FlussPrincipal, Integer> allIndices = new HashMap<>(readIndices);
+                    allIndices.putAll(writeIndices);
+                    allIndices.forEach(
+                            (p, idx) ->
+                                    results[idx] =
+                                            new AclCreateResult(
+                                                    aclBindings.get(idx), new ApiException(e)));
+                }
+            }
+        }
+        return Arrays.asList(results);
+    }
+
+    @Override
+    public List<AclDeleteResult> dropAcls(List<AclBindingFilter> aclBindingFilters) {
+        Map<AclBinding, Integer> deletedBindings = new HashMap<>();
+        Map<AclBinding, ApiException> deleteExceptions = new HashMap<>();
+        List<Tuple2<AclBindingFilter, Integer>> filters =
+                IntStream.range(0, aclBindingFilters.size())
+                        .mapToObj(i -> Tuple2.of(aclBindingFilters.get(i), i))
+                        .collect(Collectors.toList());
+
+        synchronized (lock) {
+            Set<Resource> resources = new HashSet<>(aclCache.keySet());
+            Map<Resource, List<Tuple2<AclBindingFilter, Integer>>> resourcesToUpdate =
+                    new HashMap<>();
+            for (Resource resource : resources) {
+                List<Tuple2<AclBindingFilter, Integer>> matchingFilters = new ArrayList<>();
+                for (Tuple2<AclBindingFilter, Integer> filter : filters) {
+                    if (filter.f0.getResourceFilter().matches(resource)) {
+                        matchingFilters.add(filter);
+                    }
+                }
+                if (!matchingFilters.isEmpty()) {
+                    resourcesToUpdate.put(resource, matchingFilters);
+                }
+            }
+
+            for (Map.Entry<Resource, List<Tuple2<AclBindingFilter, Integer>>> entry :
+                    resourcesToUpdate.entrySet()) {
+                Resource resource = entry.getKey();
+                List<Tuple2<AclBindingFilter, Integer>> matchingFilters = entry.getValue();
+                Map<AclBinding, Integer> resourceBindingsBeingDeleted = new HashMap<>();
+
+                try {
+                    updateResourceAcl(
+                            resource,
+                            currentAcls -> {
+                                Set<AccessControlEntry> aclsToRemove = new HashSet<>();
+                                for (AccessControlEntry acl : currentAcls) {
+                                    for (Tuple2<AclBindingFilter, Integer> filter :
+                                            matchingFilters) {
+                                        if (filter.f0.getEntryFilter().matches(acl)) {
+                                            AclBinding binding = new AclBinding(resource, acl);
+                                            deletedBindings.putIfAbsent(binding, filter.f1);
+                                            resourceBindingsBeingDeleted.putIfAbsent(
+                                                    binding, filter.f1);
+                                            aclsToRemove.add(acl);
+                                        }
+                                    }
+                                }
+                                return Sets.difference(currentAcls, aclsToRemove);
+                            });
+                } catch (Exception e) {
+                    for (AclBinding binding : resourceBindingsBeingDeleted.keySet()) {
+                        deleteExceptions.putIfAbsent(binding, new ApiException(e));
+                    }
+                }
+            }
+        }
+
+        Map<Integer, Set<AclDeleteResult.AclBindingDeleteResult>> deletedResult = new HashMap<>();
+        for (Map.Entry<AclBinding, Integer> entry : deletedBindings.entrySet()) {
+            deletedResult
+                    .computeIfAbsent(entry.getValue(), k -> new HashSet<>())
+                    .add(
+                            new AclDeleteResult.AclBindingDeleteResult(
+                                    entry.getKey(),
+                                    deleteExceptions.getOrDefault(entry.getKey(), null)));
+        }
+
+        List<AclDeleteResult> results = new ArrayList<>();
+        for (int i = 0; i < aclBindingFilters.size(); i++) {
+            Set<AclDeleteResult.AclBindingDeleteResult> bindings =
+                    deletedResult.getOrDefault(i, Collections.emptySet());
+            results.add(new AclDeleteResult(bindings));
+        }
+
+        return results;
+    }
+
+    @Override
+    public Collection<AclBinding> listAcls(AclBindingFilter aclBindingFilter) {
+        Set<AclBinding> aclBindings = new HashSet<>();
+
+        aclCache.forEach(
+                (resource, aclSet) -> {
+                    aclSet.forEach(
+                            acl -> {
+                                AclBinding aclBinding = new AclBinding(resource, acl);
+                                if (aclBindingFilter.matches(aclBinding)) {
+                                    aclBindings.add(aclBinding);
+                                }
+                            });
+                });
+
+        return aclBindings;
+    }
+
+    private void loadCache() throws Exception {
+        synchronized (lock) {
+            ResourceType[] resourceTypes = ResourceType.values();
+            for (ResourceType resourceType : resourceTypes) {
+                List<String> resourceNames = zooKeeperClient.listResourcesByType(resourceType);
+                for (String resourceName : resourceNames) {
+                    Resource resource = new Resource(resourceType, resourceName);
+                    Optional<ResourceAcl> resourceAcl = null;
+                    try {
+                        resourceAcl = zooKeeperClient.getResourceAcl(resource);
+                    } catch (Exception e) {
+                        LOG.error("load cache error", e);
+                    }
+                    resourceAcl.ifPresent(acl -> updateCache(resource, acl.getEntries()));
+                }
+            }
+        }
+    }
+
+    private Map<Resource, Map<AccessControlEntry, Integer>> groupAclsByResource(
+            List<AclBinding> aclBindings) {
+        List<Map.Entry<AclBinding, Integer>> aclBindingsWithIndex = new ArrayList<>();
+        for (int i = 0; i < aclBindings.size(); i++) {
+            aclBindingsWithIndex.add(Maps.immutableEntry(aclBindings.get(i), i));
+        }
+
+        return aclBindingsWithIndex.stream()
+                .collect(
+                        Collectors.groupingBy(
+                                entry -> entry.getKey().getResource(),
+                                Collectors.toMap(
+                                        aclBindingIntegerEntry ->
+                                                aclBindingIntegerEntry
+                                                        .getKey()
+                                                        .getAccessControlEntry(),
+                                        Map.Entry::getValue)));
+    }
+
+    private void updateResourceAcl(
+            Resource resource,
+            Function<Set<AccessControlEntry>, Set<AccessControlEntry>> newAclSupplier) {
+        boolean writeComplete = false;
+        int retries = 0;
+        Throwable lastException = null;
+
+        Set<AccessControlEntry> newAces = null;
+        Set<AccessControlEntry> currentAcls = null;
+        while (!writeComplete && retries <= maxUpdateRetries) {
+            try {
+                currentAcls =
+                        aclCache.containsKey(resource)
+                                ? getAclsFromCache(resource)
+                                : getAclsFromZk(resource);
+                newAces = newAclSupplier.apply(currentAcls);
+                if (!newAces.isEmpty()) {
+                    zooKeeperClient.upsertResourceAcl(resource, new ResourceAcl(newAces));
+                } else {
+                    LOG.trace("Deleting path for {} because it had no ACLs remaining", resource);
+                    zooKeeperClient.deleteResourceAcl(resource);
+                }
+                writeComplete = true;
+            } catch (Throwable e) {
+                LOG.error(
+                        "Failed to update ACLs for {} after trying a of {} times. Retry again.",
+                        resource,
+                        retries,
+                        e);
+                retries++;
+                lastException = e;
+            }
+        }
+
+        if (!writeComplete) {
+            throw new IllegalArgumentException(
+                    String.format(
+                            "Failed to update ACLs for %s after trying a maximum of %s times, last exception is ",
+                            resource, maxUpdateRetries),
+                    lastException);
+        }
+
+        if (!newAces.equals(currentAcls)) {
+            updateCache(resource, newAces);
+            updateAclChangedFlag(resource);
+        }
+    }
+
+    private void updateCache(Resource resource, Set<AccessControlEntry> newAces) {
+        Set<AccessControlEntry> currentAces = aclCache.getOrDefault(resource, emptySet());
+        Set<AccessControlEntry> acesToAdd = new HashSet<>(newAces);
+        acesToAdd.removeAll(currentAces);
+        Set<AccessControlEntry> acesToRemove = new HashSet<>(currentAces);
+        acesToRemove.removeAll(newAces);
+
+        acesToAdd.forEach(
+                ace -> {
+                    ResourceTypeKey resourceTypeKey = new ResourceTypeKey(ace, resource.getType());
+                    if (!resourceCache.containsKey(resourceTypeKey)) {
+                        resourceCache.put(resourceTypeKey, new HashSet<>());
+                    }
+                    resourceCache.get(resourceTypeKey).add(resource.getName());
+                });
+
+        acesToRemove.forEach(
+                ace -> {
+                    ResourceTypeKey resourceTypeKey = new ResourceTypeKey(ace, resource.getType());
+                    if (resourceCache.containsKey(resourceTypeKey)) {
+                        Set<String> newResource = resourceCache.get(resourceTypeKey);
+                        newResource.remove(resource.getName());
+                        if (newResource.isEmpty()) {
+                            resourceCache.remove(resourceTypeKey);
+                        }
+                    }
+                });
+
+        if (newAces.isEmpty()) {
+            aclCache.remove(resource);
+        } else {
+            aclCache.put(resource, newAces);
+        }
+    }
+
+    private void updateAclChangedFlag(Resource resource) {
+        try {
+            zooKeeperClient.insertAclChangeNotification(resource);
+        } catch (Exception e) {
+            LOG.error("Failed to update acl change flag for {}", resource, e);
+            throw new IllegalStateException(
+                    String.format("Failed to update acl change flag for %s", resource), e);
+        }
+    }
+
+    private boolean authorizeAction(Session session, Action action) {
+        FlussPrincipal principal = session.getPrincipal();
+        return superUsers.contains(principal)
+                || aclsAllowAccess(
+                        action.getResource(),
+                        principal,
+                        action.getOperation(),
+                        session.getInetAddress().getHostAddress());
+    }
+
+    boolean aclsAllowAccess(
+            Resource resource, FlussPrincipal principal, OperationType operation, String host) {
+        Set<AccessControlEntry> accessControlEntries = matchingAcls(resource);
+        return isEmptyAclAndAuthorized(resource, accessControlEntries)
+                || allowAclExists(resource, principal, operation, host, accessControlEntries);
+    }
+
+    private boolean isEmptyAclAndAuthorized(Resource resource, Collection acls) {
+        if (acls.isEmpty()) {
+            LOG.debug(
+                    "No acl found for resource {}, authorized = {}",
+                    resource,
+                    shouldAllowEveryoneIfNoAclIsFound);
+            return shouldAllowEveryoneIfNoAclIsFound;
+        }
+        return false;
+    }
+
+    private boolean allowAclExists(
+            Resource resource,
+            FlussPrincipal principal,
+            OperationType operation,
+            String host,
+            Set<AccessControlEntry> acls) {
+        // Check if there are any Allow ACLs which would allow this operation.
+        // Allowing read, write, delete, or alter implies allowing describe.
+        // See #{org.apache.kafka.common.acl.AclOperation} for more details about ACL inheritance.
+        Set<OperationType> allowOps = new HashSet<>();
+        if (operation == OperationType.DESCRIBE) {
+            allowOps.add(OperationType.DESCRIBE);
+            allowOps.add(OperationType.READ);
+            allowOps.add(OperationType.WRITE);
+            allowOps.add(OperationType.CREATE);
+            allowOps.add(OperationType.DROP);
+            allowOps.add(OperationType.ALTER);
+        } else {
+            allowOps.add(operation);
+        }
+
+        for (OperationType allowOp : allowOps) {
+            if (matchingAclExists(allowOp, resource, principal, host, PermissionType.ALLOW, acls)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private boolean matchingAclExists(
+            OperationType operation,
+            Resource resource,
+            FlussPrincipal principal,
+            String host,
+            PermissionType permissionType,
+            Set<AccessControlEntry> acls) {
+        return acls.stream()
+                .filter(
+                        acl ->
+                                acl.getPermissionType() == permissionType
+                                        && (acl.getPrincipal().equals(principal)
+                                                || acl.getPrincipal()
+                                                        .equals(FlussPrincipal.WILD_CARD_PRINCIPAL))
+                                        && (operation == acl.getOperationType()
+                                                || acl.getOperationType() == OperationType.ALL)
+                                        && (acl.getHost().equals(host)
+                                                || acl.getHost()
+                                                        .equals(AccessControlEntry.WILD_CARD_HOST)))
+                .findFirst()
+                .map(
+                        acl -> {
+                            LOG.debug(
+                                    "operation = {} on resource = {} from host = {} is {} based on acl = {}",
+                                    operation,
+                                    resource,
+                                    host,
+                                    permissionType,
+                                    acl);
+                            return true;
+                        })
+                .orElse(false);
+    }
+
+    private Set<AccessControlEntry> matchingAcls(Resource resource) {
+        TreeMap<Resource, Set<AccessControlEntry>> aclCacheSnapshot = aclCache;
+        Set<AccessControlEntry> wildcard =
+                aclCacheSnapshot.get(new Resource(resource.getType(), Resource.WILDCARD_RESOURCE));
+
+        Set<Resource> allowResources =
+                RESOURCE_MAPPING
+                        .getOrDefault(resource.getType(), r -> Collections.emptySet())
+                        .apply(resource);
+
+        Set<AccessControlEntry> literal = new HashSet<>();
+        for (Resource allowResource : allowResources) {
+            Set<AccessControlEntry> allowAcls = aclCacheSnapshot.get(allowResource);
+            if (allowAcls != null) {
+                literal.addAll(allowAcls);
+            }
+        }
+        return Stream.of(wildcard, literal)
+                .filter(Objects::nonNull)
+                .flatMap(Set::stream)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public void onFatalError(Throwable exception) {}
+
+    private Set<AccessControlEntry> getAclsFromCache(Resource resource) throws Exception {
+        return zooKeeperClient
+                .getResourceAcl(resource)
+                .map(ResourceAcl::getEntries)
+                .orElse(emptySet());
+    }
+
+    private Set<AccessControlEntry> getAclsFromZk(Resource resource) throws Exception {
+        return zooKeeperClient
+                .getResourceAcl(resource)
+                .map(ResourceAcl::getEntries)
+                .orElse(emptySet());
+    }
+
+    private static Set<FlussPrincipal> parseSuperUsers(Configuration configuration) {
+        return configuration
+                .getOptional(ConfigOptions.SUPER_USERS)
+                .map(
+                        config ->
+                                Arrays.stream(config.split(","))
+                                        .map(String::trim)
+                                        .map(
+                                                user -> {
+                                                    String[] userInfo = user.split(":");
+                                                    return new FlussPrincipal(
+                                                            userInfo[1], userInfo[0]);
+                                                })
+                                        .collect(Collectors.toSet()))
+                .orElse(Collections.emptySet());
+    }
+
+    /**
+     * ZkNotificationHandler is responsible for processing ACL change notifications received from
+     * ZooKeeper. It updates the internal cache based on the changes in ACLs for a specific
+     * resource.
+     */
+    public class ZkNotificationHandler
+            implements ZkNodeChangeNotificationWatcher.NotificationHandler {
+        @Override
+        public void processNotification(byte[] notification) throws Exception {
+            synchronized (lock) {
+                Resource resource = AclChangeNotificationNode.decode(notification);
+                Set<AccessControlEntry> acls = getAclsFromZk(resource);
+                LOG.info("Processing Acl change notification for {}, acls : {}", resource, acls);
+                updateCache(resource, acls);
+            }
+        }
+    }
+
+    // Orders by resource type, then resource pattern type and finally reverse ordering by name.
+    private static class ResourceOrdering implements Comparator<Resource> {
+        @Override
+        public int compare(Resource a, Resource b) {
+            int rt = a.getType().compareTo(b.getType());
+            return rt != 0 ? rt : a.getName().compareTo(b.getName());
+        }
+    }
+
+    private static class ResourceTypeKey {
+        private final AccessControlEntry accessControlEntry;
+        private final ResourceType resourceType;
+
+        public ResourceTypeKey(AccessControlEntry accessControlEntry, ResourceType resourceType) {
+            this.accessControlEntry = accessControlEntry;
+            this.resourceType = resourceType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            ResourceTypeKey that = (ResourceTypeKey) o;
+            return Objects.equals(accessControlEntry, that.accessControlEntry)
+                    && resourceType == that.resourceType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(accessControlEntry, resourceType);
+        }
+
+        @Override
+        public String toString() {
+            return "ResourceTypeKey{"
+                    + "accessControlEntry="
+                    + accessControlEntry
+                    + ", resourceType="
+                    + resourceType
+                    + '}';
+        }
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -1049,7 +1049,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
     private void updateServerMetadataCache(
             Optional<ServerInfo> coordinatorServer, Set<ServerInfo> aliveTabletServers) {
         // 1. update local metadata cache.
-        serverMetadataCache.updateMetadata(
+        serverMetadataCache.updateClusterMetadata(
                 new ClusterMetadataInfo(coordinatorServer, aliveTabletServers));
 
         // 2. send update metadata request to all alive tablet servers

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -47,6 +47,7 @@ import com.alibaba.fluss.utils.concurrent.FutureUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 import java.util.ArrayList;
@@ -122,6 +123,7 @@ public class CoordinatorServer extends ServerBase {
     private ExecutorService ioExecutor;
 
     @GuardedBy("lock")
+    @Nullable
     private Authorizer authorizer;
 
     public CoordinatorServer(Configuration conf) {
@@ -157,7 +159,7 @@ public class CoordinatorServer extends ServerBase {
 
             this.metadataCache = new ServerMetadataCacheImpl();
 
-            this.authorizer = AuthorizerLoader.createAuthorizer(conf, pluginManager);
+            this.authorizer = AuthorizerLoader.createAuthorizer(conf, zkClient, pluginManager);
             if (authorizer != null) {
                 authorizer.startup();
             }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -29,6 +29,8 @@ import com.alibaba.fluss.rpc.RpcServer;
 import com.alibaba.fluss.rpc.metrics.ClientMetricGroup;
 import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
 import com.alibaba.fluss.server.ServerBase;
+import com.alibaba.fluss.server.authorizer.Authorizer;
+import com.alibaba.fluss.server.authorizer.AuthorizerLoader;
 import com.alibaba.fluss.server.coordinator.event.CoordinatorEventManager;
 import com.alibaba.fluss.server.metadata.ServerMetadataCache;
 import com.alibaba.fluss.server.metadata.ServerMetadataCacheImpl;
@@ -119,6 +121,9 @@ public class CoordinatorServer extends ServerBase {
     @GuardedBy("lock")
     private ExecutorService ioExecutor;
 
+    @GuardedBy("lock")
+    private Authorizer authorizer;
+
     public CoordinatorServer(Configuration conf) {
         super(conf);
         validateConfigs(conf);
@@ -152,6 +157,11 @@ public class CoordinatorServer extends ServerBase {
 
             this.metadataCache = new ServerMetadataCacheImpl();
 
+            this.authorizer = AuthorizerLoader.createAuthorizer(conf, pluginManager);
+            if (authorizer != null) {
+                authorizer.startup();
+            }
+
             MetadataManager metadataManager = new MetadataManager(zkClient, conf);
             this.coordinatorService =
                     new CoordinatorService(
@@ -160,7 +170,8 @@ public class CoordinatorServer extends ServerBase {
                             zkClient,
                             this::getCoordinatorEventManager,
                             metadataCache,
-                            metadataManager);
+                            metadataManager,
+                            authorizer);
 
             this.rpcServer =
                     RpcServer.create(
@@ -333,6 +344,14 @@ public class CoordinatorServer extends ServerBase {
             try {
                 if (zkClient != null) {
                     zkClient.close();
+                }
+            } catch (Throwable t) {
+                exception = ExceptionUtils.firstOrSuppressed(t, exception);
+            }
+
+            try {
+                if (authorizer != null) {
+                    authorizer.close();
                 }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.server.coordinator;
 import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.AuthenticationException;
 import com.alibaba.fluss.exception.InvalidDatabaseException;
 import com.alibaba.fluss.exception.InvalidTableException;
 import com.alibaba.fluss.exception.TableNotPartitionedException;
@@ -39,19 +40,36 @@ import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestRequest;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestResponse;
+import com.alibaba.fluss.rpc.messages.CreateAclsRequest;
+import com.alibaba.fluss.rpc.messages.CreateAclsResponse;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.CreatePartitionRequest;
 import com.alibaba.fluss.rpc.messages.CreatePartitionResponse;
 import com.alibaba.fluss.rpc.messages.CreateTableRequest;
 import com.alibaba.fluss.rpc.messages.CreateTableResponse;
+import com.alibaba.fluss.rpc.messages.DeleteAclsMatchingAcl;
+import com.alibaba.fluss.rpc.messages.DropAclsFilterResult;
+import com.alibaba.fluss.rpc.messages.DropAclsRequest;
+import com.alibaba.fluss.rpc.messages.DropAclsResponse;
 import com.alibaba.fluss.rpc.messages.DropDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.DropDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.DropPartitionRequest;
 import com.alibaba.fluss.rpc.messages.DropPartitionResponse;
 import com.alibaba.fluss.rpc.messages.DropTableRequest;
 import com.alibaba.fluss.rpc.messages.DropTableResponse;
+import com.alibaba.fluss.rpc.messages.PbCreateAclRespInfo;
+import com.alibaba.fluss.rpc.netty.server.Session;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.rpc.protocol.Errors;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.Resource;
 import com.alibaba.fluss.server.RpcServiceBase;
+import com.alibaba.fluss.server.authorizer.AclCreateResult;
+import com.alibaba.fluss.server.authorizer.AclDeleteResult;
+import com.alibaba.fluss.server.authorizer.Authorizer;
 import com.alibaba.fluss.server.coordinator.event.AdjustIsrReceivedEvent;
 import com.alibaba.fluss.server.coordinator.event.CommitKvSnapshotEvent;
 import com.alibaba.fluss.server.coordinator.event.CommitLakeTableSnapshotEvent;
@@ -71,10 +89,16 @@ import com.alibaba.fluss.utils.concurrent.FutureUtils;
 import javax.annotation.Nullable;
 
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
+import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toPbAclInfo;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getAdjustIsrData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getCommitLakeTableSnapshotData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getCommitRemoteLogManifestData;
@@ -98,8 +122,15 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
             ZooKeeperClient zkClient,
             Supplier<EventManager> eventManagerSupplier,
             ServerMetadataCache metadataCache,
-            MetadataManager metadataManager) {
-        super(remoteFileSystem, ServerType.COORDINATOR, zkClient, metadataCache, metadataManager);
+            MetadataManager metadataManager,
+            @Nullable Authorizer authorizer) {
+        super(
+                remoteFileSystem,
+                ServerType.COORDINATOR,
+                zkClient,
+                metadataCache,
+                metadataManager,
+                authorizer);
         this.defaultBucketNumber = conf.getInt(ConfigOptions.DEFAULT_BUCKET_NUMBER);
         this.defaultReplicationFactor = conf.getInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR);
         this.eventManagerSupplier = eventManagerSupplier;
@@ -118,6 +149,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<CreateDatabaseResponse> createDatabase(CreateDatabaseRequest request) {
+        doAuthorize(OperationType.CREATE, Resource.cluster());
+
         CreateDatabaseResponse response = new CreateDatabaseResponse();
         try {
             TablePath.validateDatabaseName(request.getDatabaseName());
@@ -138,6 +171,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<DropDatabaseResponse> dropDatabase(DropDatabaseRequest request) {
+        doAuthorize(OperationType.DROP, Resource.database(request.getDatabaseName()));
+
         DropDatabaseResponse response = new DropDatabaseResponse();
         metadataManager.dropDatabase(
                 request.getDatabaseName(), request.isIgnoreIfNotExists(), request.isCascade());
@@ -146,8 +181,10 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<CreateTableResponse> createTable(CreateTableRequest request) {
+
         TablePath tablePath = toTablePath(request.getTablePath());
         tablePath.validate();
+        doAuthorize(OperationType.CREATE, Resource.database(tablePath.getDatabaseName()));
 
         TableDescriptor tableDescriptor;
         try {
@@ -224,21 +261,41 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<DropTableResponse> dropTable(DropTableRequest request) {
+        TablePath tablePath = toTablePath(request.getTablePath());
+        doAuthorize(
+                OperationType.DROP,
+                Resource.table(tablePath.getDatabaseName(), tablePath.getTableName()));
+
         DropTableResponse response = new DropTableResponse();
-        metadataManager.dropTable(
-                toTablePath(request.getTablePath()), request.isIgnoreIfNotExists());
+        metadataManager.dropTable(tablePath, request.isIgnoreIfNotExists());
         return CompletableFuture.completedFuture(response);
     }
 
     @Override
     public CompletableFuture<CreatePartitionResponse> createPartition(
             CreatePartitionRequest request) {
-        CreatePartitionResponse response = new CreatePartitionResponse();
         TablePath tablePath = toTablePath(request.getTablePath());
+        doAuthorize(
+                OperationType.CREATE,
+                Resource.table(tablePath.getDatabaseName(), tablePath.getTableName()));
+
+        CreatePartitionResponse response = new CreatePartitionResponse();
         TableInfo tableInfo = metadataManager.getTable(tablePath);
         if (!tableInfo.isPartitioned()) {
             throw new TableNotPartitionedException(
                     "Only partitioned table support create partition.");
+        }
+
+        Session session = currentSession();
+        if (!authorizer.authorize(
+                session,
+                OperationType.CREATE,
+                Resource.table(tablePath.getDatabaseName(), tablePath.getTableName()))) {
+            // todo: 统一一下
+            throw new AuthenticationException(
+                    String.format(
+                            "Principal %s have no authorization to operate %s on resource %s ",
+                            session.getPrincipal(), OperationType.CREATE, Resource.cluster()));
         }
 
         // first, validate the partition spec, and get resolved partition spec.
@@ -269,8 +326,12 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<DropPartitionResponse> dropPartition(DropPartitionRequest request) {
-        DropPartitionResponse response = new DropPartitionResponse();
         TablePath tablePath = toTablePath(request.getTablePath());
+        doAuthorize(
+                OperationType.CREATE,
+                Resource.table(tablePath.getDatabaseName(), tablePath.getTableName()));
+
+        DropPartitionResponse response = new DropPartitionResponse();
         TableInfo tableInfo = metadataManager.getTable(tablePath);
         if (!tableInfo.isPartitioned()) {
             throw new TableNotPartitionedException(
@@ -323,6 +384,75 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
                         new CommitRemoteLogManifestEvent(
                                 getCommitRemoteLogManifestData(request), response));
         return response;
+    }
+
+    @Override
+    public CompletableFuture<CreateAclsResponse> createAcls(CreateAclsRequest request) {
+        doAuthorize(OperationType.ALTER, Resource.cluster());
+
+        List<AclBinding> aclBindings = toAclBindings(request.getAclsList());
+        List<AclCreateResult> aclCreateResults = authorizer.addAcls(aclBindings);
+        List<PbCreateAclRespInfo> pbAclRespInfos = new ArrayList<>();
+
+        for (AclCreateResult result : aclCreateResults) {
+            PbCreateAclRespInfo pbAclRespInfo = new PbCreateAclRespInfo();
+            pbAclRespInfo.setAcl(toPbAclInfo(result.getAclBinding()));
+            if (result.exception().isPresent()) {
+                ApiError apiError = ApiError.fromThrowable(result.exception().get());
+                pbAclRespInfos.add(
+                        pbAclRespInfo
+                                .setErrorCode(apiError.error().code())
+                                .setErrorMessage(apiError.message()));
+            } else {
+                pbAclRespInfos.add(pbAclRespInfo.setErrorCode(Errors.NONE.code()));
+            }
+        }
+        return CompletableFuture.completedFuture(
+                new CreateAclsResponse().addAllAclRes(pbAclRespInfos));
+    }
+
+    @Override
+    public CompletableFuture<DropAclsResponse> dropAcls(DropAclsRequest request) {
+        doAuthorize(OperationType.ALTER, Resource.cluster());
+
+        List<AclBindingFilter> filters = toAclBindingFilters(request.getAclFiltersList());
+        List<AclDeleteResult> aclDeleteResults = authorizer.dropAcls(filters);
+        List<DropAclsFilterResult> dropAclsFilterResults = new ArrayList<>();
+
+        for (AclDeleteResult result : aclDeleteResults) {
+            if (result.exception().isPresent()) {
+                dropAclsFilterResults.add(
+                        new DropAclsFilterResult()
+                                .setErrorCode(
+                                        ApiError.fromThrowable(result.exception().get())
+                                                .error()
+                                                .code())
+                                .setErrorMessage(
+                                        ApiError.fromThrowable(result.exception().get())
+                                                .error()
+                                                .message()));
+                continue;
+            }
+
+            Collection<AclDeleteResult.AclBindingDeleteResult> aclBindingDeleteResults =
+                    result.aclBindingDeleteResults();
+            List<DeleteAclsMatchingAcl> deleteAclsMatchingAcls = new ArrayList<>();
+            for (AclDeleteResult.AclBindingDeleteResult aclBindingDeleteResult :
+                    aclBindingDeleteResults) {
+                DeleteAclsMatchingAcl deleteAclsMatchingAcl = new DeleteAclsMatchingAcl();
+                deleteAclsMatchingAcl.setAcl(toPbAclInfo(aclBindingDeleteResult.aclBinding()));
+                if (result.exception().isPresent()) {
+                    ApiError apiError = ApiError.fromThrowable(result.exception().get());
+                    deleteAclsMatchingAcl.setErrorCode(apiError.error().code());
+                    deleteAclsMatchingAcl.setErrorMessage(apiError.error().message());
+                }
+                deleteAclsMatchingAcls.add(deleteAclsMatchingAcl);
+            }
+            dropAclsFilterResults.add(
+                    new DropAclsFilterResult().addAllMatchingAcls(deleteAclsMatchingAcls));
+        }
+        return CompletableFuture.completedFuture(
+                new DropAclsResponse().addAllFilterResults(dropAclsFilterResults));
     }
 
     @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/AbstractServerMetadataCache.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/AbstractServerMetadataCache.java
@@ -17,9 +17,11 @@
 package com.alibaba.fluss.server.metadata;
 
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.server.coordinator.CoordinatorServer;
 import com.alibaba.fluss.server.tablet.TabletServer;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -41,9 +43,12 @@ public abstract class AbstractServerMetadataCache implements ServerMetadataCache
      */
     protected volatile ServerCluster clusterMetadata;
 
+    protected volatile Map<Long, PhysicalTablePath> tableBucketMetadata;
+
     public AbstractServerMetadataCache() {
         // no coordinator server address while creating.
         this.clusterMetadata = ServerCluster.empty();
+        this.tableBucketMetadata = new HashMap<>();
     }
 
     @Override
@@ -70,5 +75,10 @@ public abstract class AbstractServerMetadataCache implements ServerMetadataCache
     @Override
     public Set<Integer> getAliveTabletServerIds() {
         return clusterMetadata.getAliveTabletServerIds();
+    }
+
+    @Override
+    public PhysicalTablePath getTablePath(long tableId) {
+        return tableBucketMetadata.get(tableId);
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerMetadataCache.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerMetadataCache.java
@@ -17,14 +17,22 @@
 package com.alibaba.fluss.server.metadata;
 
 import com.alibaba.fluss.cluster.MetadataCache;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
 
 /** Metadata cache for server. it only caches the cluster metadata. */
 public interface ServerMetadataCache extends MetadataCache {
 
     /**
-     * Update the metadata by the remote update metadata request.
+     * Update the cluster metadata by the remote update metadata request.
      *
      * @param clusterMetadataInfo the metadata info.
      */
-    void updateMetadata(ClusterMetadataInfo clusterMetadataInfo);
+    void updateClusterMetadata(ClusterMetadataInfo clusterMetadataInfo);
+
+    /**
+     * Update the table and database metadata by the remote update table leader and isr request.
+     * only leader server cache the table which it stored data. This metedata will used to get the
+     * table name and database name when consumer and produce.
+     */
+    void upsertTableBucketMetadata(Long tableId, PhysicalTablePath physicalTablePath);
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImpl.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImpl.java
@@ -16,6 +16,8 @@
 
 package com.alibaba.fluss.server.metadata;
 
+import com.alibaba.fluss.metadata.PhysicalTablePath;
+
 import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.locks.Lock;
@@ -32,7 +34,7 @@ public class ServerMetadataCacheImpl extends AbstractServerMetadataCache {
     }
 
     @Override
-    public void updateMetadata(ClusterMetadataInfo clusterMetadataInfo) {
+    public void updateClusterMetadata(ClusterMetadataInfo clusterMetadataInfo) {
         inLock(
                 bucketMetadataLock,
                 () -> {
@@ -50,6 +52,15 @@ public class ServerMetadataCacheImpl extends AbstractServerMetadataCache {
                     }
 
                     clusterMetadata = new ServerCluster(coordinatorServer, newAliveTableServers);
+                });
+    }
+
+    @Override
+    public void upsertTableBucketMetadata(Long tableId, PhysicalTablePath physicalTablePath) {
+        inLock(
+                bucketMetadataLock,
+                () -> {
+                    tableBucketMetadata.put(tableId, physicalTablePath);
                 });
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -117,6 +117,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -327,7 +328,8 @@ public class ReplicaManager {
     public void becomeLeaderOrFollower(
             int requestCoordinatorEpoch,
             List<NotifyLeaderAndIsrData> notifyLeaderAndIsrDataList,
-            Consumer<List<NotifyLeaderAndIsrResultForBucket>> responseCallback) {
+            Consumer<List<NotifyLeaderAndIsrResultForBucket>> responseCallback,
+            BiConsumer<Long, PhysicalTablePath> leaderBucketCallback) {
         Map<TableBucket, NotifyLeaderAndIsrResultForBucket> result = new HashMap<>();
         inLock(
                 replicaStateChangeLock,
@@ -343,6 +345,8 @@ public class ReplicaManager {
                             boolean becomeLeader = validateAndGetIsBecomeLeader(data);
                             if (becomeLeader) {
                                 replicasToBeLeader.add(data);
+                                leaderBucketCallback.accept(
+                                        tb.getTableId(), data.getPhysicalTablePath());
                             } else {
                                 replicasToBeFollower.add(data);
                             }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
@@ -130,6 +130,7 @@ public class TabletServer extends ServerBase {
     private ZooKeeperClient zkClient;
 
     @GuardedBy("lock")
+    @Nullable
     private Authorizer authorizer;
 
     public TabletServer(Configuration conf) {
@@ -176,7 +177,7 @@ public class TabletServer extends ServerBase {
             this.kvManager = KvManager.create(conf, zkClient, logManager);
             kvManager.startup();
 
-            this.authorizer = AuthorizerLoader.createAuthorizer(conf, pluginManager);
+            this.authorizer = AuthorizerLoader.createAuthorizer(conf, zkClient, pluginManager);
             if (authorizer != null) {
                 authorizer.startup();
             }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
@@ -17,12 +17,19 @@
 package com.alibaba.fluss.server.tablet;
 
 import com.alibaba.fluss.cluster.ServerType;
+import com.alibaba.fluss.exception.AuthorizationException;
 import com.alibaba.fluss.exception.UnknownTableOrBucketException;
 import com.alibaba.fluss.fs.FileSystem;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.record.KvRecordBatch;
 import com.alibaba.fluss.record.MemoryLogRecords;
+import com.alibaba.fluss.rpc.entity.FetchLogResultForBucket;
+import com.alibaba.fluss.rpc.entity.LookupResultForBucket;
+import com.alibaba.fluss.rpc.entity.PrefixLookupResultForBucket;
+import com.alibaba.fluss.rpc.entity.ProduceLogResultForBucket;
+import com.alibaba.fluss.rpc.entity.PutKvResultForBucket;
+import com.alibaba.fluss.rpc.entity.ResultForBucket;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
 import com.alibaba.fluss.rpc.messages.FetchLogRequest;
 import com.alibaba.fluss.rpc.messages.FetchLogResponse;
@@ -50,6 +57,8 @@ import com.alibaba.fluss.rpc.messages.PutKvRequest;
 import com.alibaba.fluss.rpc.messages.PutKvResponse;
 import com.alibaba.fluss.rpc.messages.StopReplicaRequest;
 import com.alibaba.fluss.rpc.messages.StopReplicaResponse;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.rpc.protocol.Errors;
 import com.alibaba.fluss.security.acl.OperationType;
 import com.alibaba.fluss.security.acl.Resource;
 import com.alibaba.fluss.server.RpcServiceBase;
@@ -65,13 +74,18 @@ import com.alibaba.fluss.server.zk.ZooKeeperClient;
 
 import javax.annotation.Nullable;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
+import static com.alibaba.fluss.security.acl.OperationType.READ;
+import static com.alibaba.fluss.security.acl.OperationType.WRITE;
 import static com.alibaba.fluss.server.log.FetchParams.DEFAULT_MAX_WAIT_MS_WHEN_MIN_BYTES_ENABLE;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getFetchLogData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getListOffsetsData;
@@ -131,23 +145,50 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
 
     @Override
     public CompletableFuture<ProduceLogResponse> produceLog(ProduceLogRequest request) {
-        doAuthorizeTable(request.getTableId(), OperationType.WRITE);
-        CompletableFuture<ProduceLogResponse> response = new CompletableFuture<>();
         Map<TableBucket, MemoryLogRecords> produceLogData = getProduceLogData(request);
+        Map<TableBucket, ProduceLogResultForBucket> errorResponseMap = new HashMap<>();
+        Map<TableBucket, MemoryLogRecords> interesting =
+                authorizer != null
+                        ? processBucketAuthorization(
+                                OperationType.WRITE,
+                                produceLogData,
+                                errorResponseMap,
+                                ProduceLogResultForBucket::new)
+                        : produceLogData;
+        if (interesting.isEmpty()) {
+            return CompletableFuture.completedFuture(
+                    makeProduceLogResponse(errorResponseMap.values()));
+        }
+
+        CompletableFuture<ProduceLogResponse> response = new CompletableFuture<>();
         replicaManager.appendRecordsToLog(
                 request.getTimeoutMs(),
                 request.getAcks(),
                 produceLogData,
-                bucketResponseMap -> response.complete(makeProduceLogResponse(bucketResponseMap)));
+                bucketResponseMap -> {
+                    if (!errorResponseMap.isEmpty()) {
+                        bucketResponseMap = new ArrayList<>(bucketResponseMap);
+                        bucketResponseMap.addAll(errorResponseMap.values());
+                    }
+                    response.complete(makeProduceLogResponse(bucketResponseMap));
+                });
         return response;
     }
 
     @Override
     public CompletableFuture<FetchLogResponse> fetchLog(FetchLogRequest request) {
-        CompletableFuture<FetchLogResponse> response = new CompletableFuture<>();
         Map<TableBucket, FetchData> fetchLogData = getFetchLogData(request);
-        doAuthorizeTable(fetchLogData.keySet(), OperationType.READ);
+        Map<TableBucket, FetchLogResultForBucket> errorResponseMap = new HashMap<>();
+        Map<TableBucket, FetchData> interesting =
+                authorizer != null && request.getFollowerServerId() < 0
+                        ? processBucketAuthorization(
+                                READ, fetchLogData, errorResponseMap, FetchLogResultForBucket::new)
+                        : fetchLogData;
+        if (interesting.isEmpty()) {
+            return CompletableFuture.completedFuture(makeFetchLogResponse(errorResponseMap));
+        }
 
+        CompletableFuture<FetchLogResponse> response = new CompletableFuture<>();
         FetchParams fetchParams;
         if (request.hasMinBytes()) {
             fetchParams =
@@ -163,49 +204,121 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         }
         replicaManager.fetchLogRecords(
                 fetchParams,
-                fetchLogData,
-                fetchResponseMap -> response.complete(makeFetchLogResponse(fetchResponseMap)));
+                interesting,
+                fetchResponseMap -> {
+                    if (!errorResponseMap.isEmpty()) {
+                        fetchResponseMap = new HashMap<>(fetchResponseMap);
+                        fetchResponseMap.putAll(errorResponseMap);
+                    }
+                    response.complete(makeFetchLogResponse(fetchResponseMap));
+                });
+
         return response;
     }
 
     @Override
     public CompletableFuture<PutKvResponse> putKv(PutKvRequest request) {
-        CompletableFuture<PutKvResponse> response = new CompletableFuture<>();
         Map<TableBucket, KvRecordBatch> putKvData = getPutKvData(request);
-        doAuthorizeTable(putKvData.keySet(), OperationType.WRITE);
+        Map<TableBucket, PutKvResultForBucket> errorResponseMap = new HashMap<>();
+        Map<TableBucket, KvRecordBatch> interesting =
+                authorizer != null
+                        ? processBucketAuthorization(
+                                WRITE, putKvData, errorResponseMap, PutKvResultForBucket::new)
+                        : putKvData;
+        if (interesting.isEmpty()) {
+            return CompletableFuture.completedFuture(makePutKvResponse(errorResponseMap.values()));
+        }
+
+        CompletableFuture<PutKvResponse> response = new CompletableFuture<>();
         replicaManager.putRecordsToKv(
                 request.getTimeoutMs(),
                 request.getAcks(),
                 putKvData,
                 getTargetColumns(request),
-                bucketResponseMap -> response.complete(makePutKvResponse(bucketResponseMap)));
+                bucketResponseMap -> {
+                    if (!errorResponseMap.isEmpty()) {
+                        bucketResponseMap = new ArrayList<>(bucketResponseMap);
+                        bucketResponseMap.addAll(errorResponseMap.values());
+                    }
+                    response.complete(makePutKvResponse(bucketResponseMap));
+                });
         return response;
     }
 
     @Override
     public CompletableFuture<LookupResponse> lookup(LookupRequest request) {
-        CompletableFuture<LookupResponse> response = new CompletableFuture<>();
         Map<TableBucket, List<byte[]>> lookupData = toLookupData(request);
-        doAuthorizeTable(lookupData.keySet(), OperationType.READ);
-        replicaManager.lookups(lookupData, value -> response.complete(makeLookupResponse(value)));
+        Map<TableBucket, LookupResultForBucket> errorResponseMap = new HashMap<>();
+        Map<TableBucket, List<byte[]>> interesting =
+                authorizer != null
+                        ? processBucketAuthorization(
+                                READ, lookupData, errorResponseMap, LookupResultForBucket::new)
+                        : lookupData;
+        if (interesting.isEmpty()) {
+            return CompletableFuture.completedFuture(makeLookupResponse(errorResponseMap));
+        }
+
+        CompletableFuture<LookupResponse> response = new CompletableFuture<>();
+        replicaManager.lookups(
+                lookupData,
+                value -> {
+                    if (!errorResponseMap.isEmpty()) {
+                        value = new HashMap<>(value);
+                        value.putAll(errorResponseMap);
+                    }
+                    response.complete(makeLookupResponse(value));
+                });
         return response;
     }
 
     @Override
     public CompletableFuture<PrefixLookupResponse> prefixLookup(PrefixLookupRequest request) {
         Map<TableBucket, List<byte[]>> prefixLookupData = toPrefixLookupData(request);
-        doAuthorizeTable(prefixLookupData.keySet(), OperationType.READ);
+        Map<TableBucket, PrefixLookupResultForBucket> errorResponseMap = new HashMap<>();
+        Map<TableBucket, List<byte[]>> interesting =
+                authorizer != null
+                        ? processBucketAuthorization(
+                                READ,
+                                prefixLookupData,
+                                errorResponseMap,
+                                PrefixLookupResultForBucket::new)
+                        : prefixLookupData;
+        if (interesting.isEmpty()) {
+            return CompletableFuture.completedFuture(makePrefixLookupResponse(errorResponseMap));
+        }
 
         CompletableFuture<PrefixLookupResponse> response = new CompletableFuture<>();
         replicaManager.prefixLookups(
-                prefixLookupData, value -> response.complete(makePrefixLookupResponse(value)));
+                prefixLookupData,
+                value -> {
+                    if (!errorResponseMap.isEmpty()) {
+                        value = new HashMap<>(value);
+                        value.putAll(errorResponseMap);
+                    }
+                    response.complete(makePrefixLookupResponse(value));
+                });
         return response;
     }
 
     @Override
     public CompletableFuture<LimitScanResponse> limitScan(LimitScanRequest request) {
+        long tableId = request.getTableId();
+        PhysicalTablePath path = metadataCache.getTablePath(tableId);
+        if (path == null) {
+            throw new UnknownTableOrBucketException(
+                    String.format("Leader bucket of %s is not ready.", tableId));
+        }
+
+        if (authorizer != null
+                && !authorizer.isAuthorized(
+                        currentSession(), READ, Resource.table(path.getTablePath()))) {
+            throw new AuthorizationException(
+                    String.format(
+                            "No permission to %s table %s in database %s",
+                            READ, path.getTableName(), path.getDatabaseName()));
+        }
+
         CompletableFuture<LimitScanResponse> response = new CompletableFuture<>();
-        doAuthorizeTable(request.getTableId(), OperationType.READ);
         replicaManager.limitScan(
                 new TableBucket(
                         request.getTableId(),
@@ -289,27 +402,62 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
         return response;
     }
 
-    private void doAuthorizeTable(
-            Collection<TableBucket> tableBuckets, OperationType operationType) {
-        Set<Long> tableIds =
-                tableBuckets.stream().map(TableBucket::getTableId).collect(Collectors.toSet());
-        for (Long tableId : tableIds) {
-            doAuthorizeTable(tableId, operationType);
-        }
+    private <T, K extends ResultForBucket> Map<TableBucket, T> processBucketAuthorization(
+            OperationType operationType,
+            Map<TableBucket, T> bucketDataMap,
+            Map<TableBucket, K> errorResponseMap,
+            BiFunction<TableBucket, ApiError, K> resultForBucketSupplier) {
+        Map<TableBucket, T> interesting = new HashMap<>();
+        Set<Long> filteredTableIds = filterAuthorizedTables(bucketDataMap.keySet(), operationType);
+        bucketDataMap.forEach(
+                (tableBucket, bucketData) -> {
+                    long tableId = tableBucket.getTableId();
+                    PhysicalTablePath tablePath = metadataCache.getTablePath(tableId);
+                    if (tablePath == null) {
+                        errorResponseMap.put(
+                                tableBucket,
+                                resultForBucketSupplier.apply(
+                                        tableBucket,
+                                        new ApiError(
+                                                Errors.UNKNOWN_TABLE_OR_BUCKET_EXCEPTION,
+                                                String.format(
+                                                        "Leader bucket of %s is not ready.",
+                                                        tableId))));
+                    } else if (!filteredTableIds.contains(tableId)) {
+                        errorResponseMap.put(
+                                tableBucket,
+                                resultForBucketSupplier.apply(
+                                        tableBucket,
+                                        new ApiError(
+                                                Errors.AUTHORIZATION_EXCEPTION,
+                                                String.format(
+                                                        "No permission to %s table %s in database %s",
+                                                        operationType,
+                                                        tablePath.getTableName(),
+                                                        tablePath.getDatabaseName()))));
+                    } else {
+                        interesting.put(tableBucket, bucketData);
+                    }
+                });
+        return interesting;
     }
 
-    private void doAuthorizeTable(long tableId, OperationType operationType) {
-        PhysicalTablePath path = metadataCache.getTablePath(tableId);
-        if (path == null) {
-            throw new UnknownTableOrBucketException(
-                    String.format("Leader bucket of %s is not ready.", tableId));
-        }
-
-        if (authorizer != null) {
-            authorizer.authorize(
-                    currentSession(),
-                    operationType,
-                    Resource.table(path.getDatabaseName(), path.getTableName()));
-        }
+    private Set<Long> filterAuthorizedTables(
+            Collection<TableBucket> tableBuckets, OperationType operationType) {
+        return tableBuckets.stream()
+                .map(TableBucket::getTableId)
+                .filter(
+                        tableId -> {
+                            PhysicalTablePath tablePath = metadataCache.getTablePath(tableId);
+                            return tablePath != null
+                                    && authorizer != null
+                                    && authorizer.isAuthorized(
+                                            currentSession(),
+                                            operationType,
+                                            Resource.table(
+                                                    tablePath.getDatabaseName(),
+                                                    tablePath.getTableName()));
+                        })
+                .collect(Collectors.toSet());
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
@@ -264,7 +264,10 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
 
     @Override
     public CompletableFuture<InitWriterResponse> initWriter(InitWriterRequest request) {
-        doAuthorize(OperationType.IDEMPOTENT_WRITE, Resource.cluster());
+        if (authorizer != null) {
+            authorizer.authorize(
+                    currentSession(), OperationType.IDEMPOTENT_WRITE, Resource.cluster());
+        }
         CompletableFuture<InitWriterResponse> response = new CompletableFuture<>();
         response.complete(makeInitWriterResponse(metadataManager.initWriterId()));
         return response;
@@ -302,6 +305,12 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
             throw new NotLeaderOrFollowerException(
                     String.format("Leader bucket of %s is not ready.", tableId));
         }
-        doAuthorize(operationType, Resource.table(path.getDatabaseName(), path.getTableName()));
+
+        if (authorizer != null) {
+            authorizer.authorize(
+                    currentSession(),
+                    operationType,
+                    Resource.table(path.getDatabaseName(), path.getTableName()));
+        }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -56,6 +56,7 @@ import com.alibaba.fluss.rpc.messages.GetLatestKvSnapshotsResponse;
 import com.alibaba.fluss.rpc.messages.GetLatestLakeSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.ListOffsetsResponse;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosResponse;
@@ -66,6 +67,7 @@ import com.alibaba.fluss.rpc.messages.NotifyLakeTableOffsetRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
+import com.alibaba.fluss.rpc.messages.PbAclInfo;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrReqForTable;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrRespForBucket;
@@ -112,6 +114,7 @@ import com.alibaba.fluss.rpc.messages.StopReplicaRequest;
 import com.alibaba.fluss.rpc.messages.StopReplicaResponse;
 import com.alibaba.fluss.rpc.messages.UpdateMetadataRequest;
 import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.security.acl.AclBinding;
 import com.alibaba.fluss.server.entity.AdjustIsrResultForBucket;
 import com.alibaba.fluss.server.entity.CommitLakeTableSnapshotData;
 import com.alibaba.fluss.server.entity.CommitRemoteLogManifestData;
@@ -1263,5 +1266,22 @@ public class ServerRpcMessageUtils {
             partitionKeyAndValues.put(pbKeyValue.getKey(), pbKeyValue.getValue());
         }
         return new PartitionSpec(partitionKeyAndValues);
+    }
+
+    public static ListAclsResponse makeListAclsResponse(Collection<AclBinding> aclBindings) {
+        ListAclsResponse listAclsResponse = new ListAclsResponse();
+        for (AclBinding aclBinding : aclBindings) {
+            PbAclInfo aclInfo = listAclsResponse.addAcl();
+            aclInfo.setResourceName(aclBinding.getResource().getName())
+                    .setResourceType(aclBinding.getResource().getType().getCode())
+                    .setPrincipalName(aclBinding.getAccessControlEntry().getPrincipal().getName())
+                    .setPrincipalType(aclBinding.getAccessControlEntry().getPrincipal().getType())
+                    .setHost(aclBinding.getAccessControlEntry().getHost())
+                    .setOperationType(
+                            aclBinding.getAccessControlEntry().getOperationType().getCode())
+                    .setPermissionType(
+                            aclBinding.getAccessControlEntry().getPermissionType().getCode());
+        }
+        return listAclsResponse;
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -417,7 +417,7 @@ public class ServerRpcMessageUtils {
     }
 
     public static ProduceLogResponse makeProduceLogResponse(
-            List<ProduceLogResultForBucket> appendLogResultForBucketList) {
+            Collection<ProduceLogResultForBucket> appendLogResultForBucketList) {
         ProduceLogResponse produceResponse = new ProduceLogResponse();
         List<PbProduceLogRespForBucket> produceLogRespForBucketList = new ArrayList<>();
         for (ProduceLogResultForBucket bucketResult : appendLogResultForBucketList) {
@@ -633,7 +633,7 @@ public class ServerRpcMessageUtils {
         return targetColumns.length == 0 ? null : targetColumns;
     }
 
-    public static PutKvResponse makePutKvResponse(List<PutKvResultForBucket> kvPutResult) {
+    public static PutKvResponse makePutKvResponse(Collection<PutKvResultForBucket> kvPutResult) {
         PutKvResponse putKvResponse = new PutKvResponse();
         List<PbPutKvRespForBucket> putKvRespForBucketList = new ArrayList<>();
         for (PutKvResultForBucket bucketResult : kvPutResult) {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
@@ -25,7 +25,7 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.security.acl.AccessControlEntry;
 import com.alibaba.fluss.security.acl.Resource;
 import com.alibaba.fluss.security.acl.ResourceType;
-import com.alibaba.fluss.server.authorizer.ZooKeeperBasedAuthorizer.VersionedAcls;
+import com.alibaba.fluss.server.authorizer.DefaultAuthorizer.VersionedAcls;
 import com.alibaba.fluss.server.zk.data.BucketSnapshot;
 import com.alibaba.fluss.server.zk.data.CoordinatorAddress;
 import com.alibaba.fluss.server.zk.data.DatabaseRegistration;
@@ -38,7 +38,6 @@ import com.alibaba.fluss.server.zk.data.TableAssignment;
 import com.alibaba.fluss.server.zk.data.TableRegistration;
 import com.alibaba.fluss.server.zk.data.TabletServerRegistration;
 import com.alibaba.fluss.server.zk.data.ZkData.AclChangeNotificationNode;
-import com.alibaba.fluss.server.zk.data.ZkData.AclChangesNode;
 import com.alibaba.fluss.server.zk.data.ZkData.BucketIdsZNode;
 import com.alibaba.fluss.server.zk.data.ZkData.BucketRemoteLogsZNode;
 import com.alibaba.fluss.server.zk.data.ZkData.BucketSnapshotIdZNode;
@@ -762,13 +761,6 @@ public class ZooKeeperClient implements AutoCloseable {
         LOG.info("add acl change notification for resource {}  ", resource);
     }
 
-    public void deleteAclChangeNotifications() throws Exception {
-        List<String> children = getChildren(AclChangesNode.path());
-        for (String child : children) {
-            zkClient.delete().forPath(AclChangesNode.path() + "/" + child);
-        }
-    }
-
     // --------------------------------------------------------------------------------------------
     // Utils
     // --------------------------------------------------------------------------------------------
@@ -788,7 +780,7 @@ public class ZooKeeperClient implements AutoCloseable {
     }
 
     /** Gets the data and stat of a given zk node path. */
-    public Optional<Stat> getState(String path) throws Exception {
+    public Optional<Stat> getStat(String path) throws Exception {
         try {
             Stat stat = zkClient.checkExists().forPath(path);
             LOG.info("stat of path {} is {}", path, stat);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAcl.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAcl.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.server.zk.data;
+
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * The registration information of acl in {@link ZkData.ResourceAclNode}. It is used to store the
+ * acl information in zookeeper.
+ *
+ * @see ResourceAclJsonSerde for json serialization and deserialization.
+ */
+public class ResourceAcl {
+    private final Set<AccessControlEntry> entries;
+
+    public ResourceAcl(Set<AccessControlEntry> entries) {
+        this.entries = entries;
+    }
+
+    public Set<AccessControlEntry> getEntries() {
+        return entries;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        ResourceAcl that = (ResourceAcl) o;
+        return Objects.equals(entries, that.entries);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(entries);
+    }
+
+    @Override
+    public String toString() {
+        return "AclRegistration{" + "entries=" + entries + '}';
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerde.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerde.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.server.zk.data;
+
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
+import com.alibaba.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import com.alibaba.fluss.utils.json.JsonDeserializer;
+import com.alibaba.fluss.utils.json.JsonSerializer;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/** Json serializer and deserializer for {@link ResourceAcl}. */
+public class ResourceAclJsonSerde
+        implements JsonSerializer<ResourceAcl>, JsonDeserializer<ResourceAcl> {
+    public static final ResourceAclJsonSerde INSTANCE = new ResourceAclJsonSerde();
+
+    private static final String VERSION_KEY = "version";
+    private static final String ACLS = "acls";
+    private static final String PRINCIPAL_TYPE = "principal_type";
+    private static final String PRINCIPAL_NAME = "principal_name";
+    private static final String PERMISSION_TYPE = "permission_type";
+    private static final String HOST = "host";
+    private static final String OPERATION_TYPE = "operation";
+    private static final int VERSION = 1;
+
+    @Override
+    public void serialize(ResourceAcl resourceAcl, JsonGenerator generator) throws IOException {
+        generator.writeStartObject();
+        generator.writeNumberField(VERSION_KEY, VERSION);
+        serializeAccessControlEntries(generator, resourceAcl.getEntries());
+
+        generator.writeEndObject();
+    }
+
+    @Override
+    public ResourceAcl deserialize(JsonNode node) {
+        Set<AccessControlEntry> entries = deserializeAccessControlEntries(node.get(ACLS));
+        return new ResourceAcl(entries);
+    }
+
+    private static void serializeAccessControlEntries(
+            JsonGenerator generator, Collection<AccessControlEntry> accessControlEntries)
+            throws IOException {
+        generator.writeArrayFieldStart(ACLS);
+        for (AccessControlEntry entry : accessControlEntries) {
+            generator.writeStartObject();
+            generator.writeStringField(PRINCIPAL_TYPE, entry.getPrincipal().getType());
+            generator.writeStringField(PRINCIPAL_NAME, entry.getPrincipal().getName());
+            generator.writeStringField(PERMISSION_TYPE, entry.getPermissionType().name());
+            generator.writeStringField(HOST, entry.getHost());
+            generator.writeStringField(HOST, entry.getHost());
+            generator.writeStringField(OPERATION_TYPE, entry.getOperationType().name());
+            generator.writeEndObject();
+        }
+        generator.writeEndArray();
+    }
+
+    private static Set<AccessControlEntry> deserializeAccessControlEntries(JsonNode node) {
+        Iterator<JsonNode> elements = node.elements();
+        Set<AccessControlEntry> entries = new HashSet<>();
+        while (elements.hasNext()) {
+            JsonNode aclNode = elements.next();
+            AccessControlEntry entry =
+                    new AccessControlEntry(
+                            new FlussPrincipal(
+                                    aclNode.get(PRINCIPAL_NAME).asText(),
+                                    aclNode.get(PRINCIPAL_TYPE).asText()),
+                            aclNode.get(HOST).asText(),
+                            OperationType.valueOf(aclNode.get(OPERATION_TYPE).asText()),
+                            PermissionType.valueOf(aclNode.get(PERMISSION_TYPE).asText()));
+            entries.add(entry);
+        }
+        return entries;
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerde.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerde.java
@@ -70,7 +70,6 @@ public class ResourceAclJsonSerde
             generator.writeStringField(PRINCIPAL_NAME, entry.getPrincipal().getName());
             generator.writeStringField(PERMISSION_TYPE, entry.getPermissionType().name());
             generator.writeStringField(HOST, entry.getHost());
-            generator.writeStringField(HOST, entry.getHost());
             generator.writeStringField(OPERATION_TYPE, entry.getOperationType().name());
             generator.writeEndObject();
         }

--- a/fluss-server/src/main/resources/META-INF/services/com.alibaba.fluss.server.authorizer.AuthorizationPlugin
+++ b/fluss-server/src/main/resources/META-INF/services/com.alibaba.fluss.server.authorizer.AuthorizationPlugin
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+com.alibaba.fluss.server.authorizer.ZooKeeperBasedAuthorizationPlugin

--- a/fluss-server/src/main/resources/META-INF/services/com.alibaba.fluss.server.authorizer.AuthorizationPlugin
+++ b/fluss-server/src/main/resources/META-INF/services/com.alibaba.fluss.server.authorizer.AuthorizationPlugin
@@ -14,4 +14,4 @@
 # limitations under the License.
 #
 
-com.alibaba.fluss.server.authorizer.ZooKeeperBasedAuthorizationPlugin
+com.alibaba.fluss.server.authorizer.DefaultAuthorizationPlugin

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/DefaultAuthorizerTest.java
@@ -18,7 +18,6 @@ package com.alibaba.fluss.server.authorizer;
 
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
-import com.alibaba.fluss.plugin.PluginUtils;
 import com.alibaba.fluss.rpc.netty.server.Session;
 import com.alibaba.fluss.security.acl.AccessControlEntry;
 import com.alibaba.fluss.security.acl.AccessControlEntryFilter;
@@ -91,16 +90,9 @@ public class DefaultAuthorizerTest {
         zooKeeperClient = ZooKeeperUtils.startZookeeperClient(configuration, new NOPErrorHandler());
         authorizer =
                 (DefaultAuthorizer)
-                        AuthorizerLoader.createAuthorizer(
-                                configuration,
-                                zooKeeperClient,
-                                PluginUtils.createPluginManagerFromRootFolder(configuration));
+                        AuthorizerLoader.createAuthorizer(configuration, zooKeeperClient, null);
         authorizer2 =
-                (DefaultAuthorizer)
-                        AuthorizerLoader.createAuthorizer(
-                                configuration,
-                                null,
-                                PluginUtils.createPluginManagerFromRootFolder(configuration));
+                (DefaultAuthorizer) AuthorizerLoader.createAuthorizer(configuration, null, null);
         authorizer.startup();
         authorizer2.startup();
     }
@@ -211,13 +203,7 @@ public class DefaultAuthorizerTest {
     void testAuthorizerNoZkConfig() {
         Configuration configuration =
                 new Configuration().set(ConfigOptions.AUTHORIZER_ENABLED, true);
-        assertThatThrownBy(
-                        () ->
-                                AuthorizerLoader.createAuthorizer(
-                                        configuration,
-                                        null,
-                                        PluginUtils.createPluginManagerFromRootFolder(
-                                                configuration)))
+        assertThatThrownBy(() -> AuthorizerLoader.createAuthorizer(configuration, null, null))
                 .hasMessageContaining(
                         "No valid ZooKeeper quorum has been specified. You can specify the quorum via the configuration key 'zookeeper.address");
     }
@@ -422,10 +408,7 @@ public class DefaultAuthorizerTest {
         deleteAclChangeNotifications();
 
         try (Authorizer newAuthorizer =
-                AuthorizerLoader.createAuthorizer(
-                        configuration,
-                        null,
-                        PluginUtils.createPluginManagerFromRootFolder(configuration))) {
+                AuthorizerLoader.createAuthorizer(configuration, null, null)) {
             newAuthorizer.startup();
             assertThat(listAcls(newAuthorizer, resource1)).isEqualTo(acls1);
             assertThat(listAcls(newAuthorizer, resource2)).isEqualTo(acls2);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.server.zk.NOPErrorHandler;
+import com.alibaba.fluss.server.zk.ZooKeeperClient;
+import com.alibaba.fluss.server.zk.ZooKeeperExtension;
+import com.alibaba.fluss.server.zk.data.ZkData;
+import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
+import com.alibaba.fluss.utils.clock.ManualClock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link ZkNodeChangeNotificationWatcher }. */
+public class ZkNodeChangeNotificationWatcherTest {
+
+    @RegisterExtension
+    public static final AllCallbackWrapper<ZooKeeperExtension> ZOO_KEEPER_EXTENSION_WRAPPER =
+            new AllCallbackWrapper<>(new ZooKeeperExtension());
+
+    @Test
+    void testZkNodeChangeNotifications() throws Exception {
+        String seqNodeRoot = ZkData.AclChangesNode.path();
+        String seqNodePrefix = ZkData.AclChangeNotificationNode.prefix();
+        ZooKeeperClient zookeeperClient =
+                ZOO_KEEPER_EXTENSION_WRAPPER
+                        .getCustomExtension()
+                        .getZooKeeperClient(NOPErrorHandler.INSTANCE);
+        TestingNotificationHandler handler = new TestingNotificationHandler();
+
+        long startTime = System.currentTimeMillis();
+        ManualClock clock = new ManualClock(startTime);
+        // Step 1: Insert initial notifications before starting the watcher
+        ArrayList<Resource> expectedRegistrations =
+                new ArrayList<>(
+                        Arrays.asList(
+                                Resource.cluster(),
+                                Resource.database("test_database1"),
+                                Resource.table("test_database2", "test_table")));
+        for (Resource resource : expectedRegistrations) {
+            zookeeperClient.insertAclChangeNotification(resource);
+        }
+
+        ZkNodeChangeNotificationWatcher aclChangeWatcher =
+                new ZkNodeChangeNotificationWatcher(
+                        zookeeperClient,
+                        seqNodeRoot,
+                        seqNodePrefix,
+                        Duration.ofMinutes(5).toMillis(),
+                        handler,
+                        clock);
+        aclChangeWatcher.start();
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(handler.resourceNotifications)
+                                .containsExactlyInAnyOrderElementsOf(expectedRegistrations));
+        // Verify that all initial notifications are processed
+        List<String> nodesBeforeStart = zookeeperClient.getChildren(seqNodeRoot);
+        assertThat(nodesBeforeStart).hasSize(3);
+
+        // Step 2: Insert a new notification after the watcher has started
+        Resource newNoticedResource = Resource.table("test_database3", "test_table");
+        zookeeperClient.insertAclChangeNotification(newNoticedResource);
+        expectedRegistrations.add(newNoticedResource);
+        retry(
+                Duration.ofMinutes(1),
+                () ->
+                        assertThat(handler.resourceNotifications)
+                                .containsExactlyInAnyOrderElementsOf(expectedRegistrations));
+        // Verify that the new notification is processed
+        List<String> nodesAfterStart = zookeeperClient.getChildren(ZkData.AclChangesNode.path());
+        assertThat(nodesAfterStart).hasSize(4);
+
+        // Step 3: Test purging of obsolete notifications
+        long maxCtimeBeforeStart = 0;
+        for (String node : nodesBeforeStart) {
+            maxCtimeBeforeStart =
+                    Math.max(
+                            zookeeperClient.getState(seqNodeRoot + "/" + node).get().getCtime(),
+                            maxCtimeBeforeStart);
+        }
+        // Advance the clock to make the initial notifications obsolete
+        clock.advanceTime(
+                maxCtimeBeforeStart - startTime + Duration.ofMinutes(5).toMillis(),
+                TimeUnit.MILLISECONDS);
+        // Insert a new notification to trigger the purging of obsolete notificatios.
+        zookeeperClient.insertAclChangeNotification(newNoticedResource);
+        retry(
+                Duration.ofMinutes(1),
+                () -> assertThat(zookeeperClient.getChildren(seqNodeRoot)).hasSize(2));
+    }
+
+    private static class TestingNotificationHandler
+            implements ZkNodeChangeNotificationWatcher.NotificationHandler {
+        public List<Resource> resourceNotifications = new ArrayList<>();
+
+        @Override
+        public void processNotification(byte[] notification) {
+            Resource resource = ZkData.AclChangeNotificationNode.decode(notification);
+            resourceNotifications.add(resource);
+        }
+    }
+}

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZkNodeChangeNotificationWatcherTest.java
@@ -31,6 +31,8 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
@@ -102,7 +104,7 @@ public class ZkNodeChangeNotificationWatcherTest {
         for (String node : nodesBeforeStart) {
             maxCtimeBeforeStart =
                     Math.max(
-                            zookeeperClient.getState(seqNodeRoot + "/" + node).get().getCtime(),
+                            zookeeperClient.getStat(seqNodeRoot + "/" + node).get().getCtime(),
                             maxCtimeBeforeStart);
         }
         // Advance the clock to make the initial notifications obsolete
@@ -118,7 +120,7 @@ public class ZkNodeChangeNotificationWatcherTest {
 
     private static class TestingNotificationHandler
             implements ZkNodeChangeNotificationWatcher.NotificationHandler {
-        public List<Resource> resourceNotifications = new ArrayList<>();
+        public BlockingQueue<Resource> resourceNotifications = new LinkedBlockingQueue<>();
 
         @Override
         public void processNotification(byte[] notification) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/authorizer/ZooKeeperBasedAuthorizerTest.java
@@ -1,0 +1,750 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.authorizer;
+
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.rpc.netty.server.Session;
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.AccessControlEntryFilter;
+import com.alibaba.fluss.security.acl.AclBinding;
+import com.alibaba.fluss.security.acl.AclBindingFilter;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.security.acl.Resource;
+import com.alibaba.fluss.security.acl.ResourceFilter;
+import com.alibaba.fluss.security.acl.ResourceType;
+import com.alibaba.fluss.server.zk.NOPErrorHandler;
+import com.alibaba.fluss.server.zk.ZooKeeperClient;
+import com.alibaba.fluss.server.zk.ZooKeeperExtension;
+import com.alibaba.fluss.server.zk.ZooKeeperUtils;
+import com.alibaba.fluss.testutils.common.AllCallbackWrapper;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.alibaba.fluss.security.acl.OperationType.CREATE;
+import static com.alibaba.fluss.security.acl.OperationType.DROP;
+import static com.alibaba.fluss.security.acl.OperationType.READ;
+import static com.alibaba.fluss.security.acl.OperationType.WRITE;
+import static com.alibaba.fluss.security.acl.ResourceType.DATABASE;
+import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Test for {@link ZooKeeperBasedAuthorizer}. */
+public class ZooKeeperBasedAuthorizerTest {
+    @RegisterExtension
+    public static final AllCallbackWrapper<ZooKeeperExtension> ZOO_KEEPER_EXTENSION_WRAPPER =
+            new AllCallbackWrapper<>(new ZooKeeperExtension());
+
+    private ZooKeeperBasedAuthorizer authorizer;
+    private ZooKeeperBasedAuthorizer authorizer2;
+    private ZooKeeperClient zooKeeperClient;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        Configuration configuration = new Configuration();
+        configuration.setString(
+                ConfigOptions.ZOOKEEPER_ADDRESS,
+                ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().getConnectString());
+        configuration.setString(ConfigOptions.SUPER_USERS, "USER:root");
+        zooKeeperClient = ZooKeeperUtils.startZookeeperClient(configuration, new NOPErrorHandler());
+        authorizer = new ZooKeeperBasedAuthorizer(configuration);
+        authorizer2 = new ZooKeeperBasedAuthorizer(configuration);
+        authorizer.startup();
+        authorizer2.startup();
+    }
+
+    @AfterEach
+    void tearDown() {
+        authorizer.dropAcls(Collections.singletonList(AclBindingFilter.ANY));
+        authorizer.close();
+        authorizer2.close();
+        zooKeeperClient.close();
+    }
+
+    @Test
+    void testSimpleAclOperation() {
+        assertThat(authorizer.listAcls(AclBindingFilter.ANY)).isEmpty();
+        List<AclBinding> database1Acls =
+                Arrays.asList(
+                        createAclBinding(Resource.database("database1"), "user1", "host-1", CREATE),
+                        createAclBinding(Resource.database("database1"), "user2", "host-1", DROP));
+
+        List<AclBinding> database2Acls =
+                Arrays.asList(
+                        createAclBinding(Resource.database("database2"), "user1", "host-1", CREATE),
+                        createAclBinding(Resource.database("database2"), "user2", "host-1", DROP));
+
+        authorizer.addAcls(database1Acls);
+        authorizer.addAcls(database2Acls);
+        // list by database
+        assertThat(
+                        authorizer.listAcls(
+                                new AclBindingFilter(
+                                        new ResourceFilter(DATABASE, "database2"),
+                                        AccessControlEntryFilter.ANY)))
+                .containsExactlyInAnyOrderElementsOf(database2Acls);
+        // list by user
+        assertThat(
+                        authorizer.listAcls(
+                                createAclBindingFilter(
+                                        ResourceFilter.ANY,
+                                        new FlussPrincipal("user1", "USER"),
+                                        null,
+                                        OperationType.ANY)))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(database1Acls.get(0), database2Acls.get(0)));
+        // list by operation
+        assertThat(
+                        authorizer.listAcls(
+                                createAclBindingFilter(
+                                        ResourceFilter.ANY,
+                                        FlussPrincipal.ANY,
+                                        null,
+                                        OperationType.CREATE)))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(database1Acls.get(0), database2Acls.get(0)));
+
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(DATABASE, "database2"),
+                                AccessControlEntryFilter.ANY)));
+        assertThat(authorizer.listAcls(AclBindingFilter.ANY))
+                .containsExactlyInAnyOrderElementsOf(database1Acls);
+    }
+
+    @Test
+    void testSimpleAuthorizations() throws Exception {
+        Session session = createSession("user1", "192.168.1.1");
+        List<Action> actions =
+                Arrays.asList(
+                        new Action(Resource.table("database1", "foo"), READ),
+                        new Action(Resource.database("database2"), WRITE));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(false, false);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.database("database2"),
+                                new AccessControlEntry(
+                                        session.getPrincipal(),
+                                        "192.168.1.1",
+                                        WRITE,
+                                        PermissionType.ALLOW))));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(false, true);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.table("database1", "foo"),
+                                new AccessControlEntry(
+                                        session.getPrincipal(), "*", READ, PermissionType.ALLOW))));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(true, true);
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(ResourceType.TABLE, "database1.foo"),
+                                new AccessControlEntryFilter(
+                                        null, null, READ, PermissionType.ANY))));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(false, true);
+    }
+
+    @Test
+    void testAuthorizerNoZkConfig() {
+        Configuration configuration = new Configuration();
+        ZooKeeperBasedAuthorizer zooKeeperBasedAuthorizer =
+                new ZooKeeperBasedAuthorizer(configuration);
+        assertThatThrownBy(zooKeeperBasedAuthorizer::startup)
+                .hasMessageContaining(
+                        "No valid ZooKeeper quorum has been specified. You can specify the quorum via the configuration key 'zookeeper.address");
+    }
+
+    @Test
+    void testSuperUserHasAccess() throws Exception {
+        Session normalUserSession = createSession("user1", "192.168.1.1");
+        Session superUserSession = createSession("root", "192.168.1.1");
+        assertThat(
+                        authorizer.authorize(
+                                normalUserSession,
+                                Collections.singletonList(
+                                        new Action(Resource.database("database1"), READ))))
+                .containsExactly(false);
+        assertThat(
+                        authorizer.authorize(
+                                superUserSession,
+                                Collections.singletonList(
+                                        new Action(Resource.database("database1"), READ))))
+                .containsExactly(true);
+    }
+
+    @Test
+    void testAclWithOperationAll() throws Exception {
+        Session session = createSession("user1", "192.168.1.1");
+        List<Action> actions =
+                Arrays.asList(
+                        new Action(Resource.database("database1"), READ),
+                        new Action(Resource.database("database1"), WRITE));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(false, false);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.database("database1"),
+                                new AccessControlEntry(
+                                        session.getPrincipal(),
+                                        "192.168.1.1",
+                                        OperationType.ALL,
+                                        PermissionType.ALLOW))));
+        assertThat(authorizer.authorize(session, actions)).containsExactly(true, true);
+    }
+
+    @Test
+    void testHostAddressAclValidation() throws Exception {
+        FlussPrincipal principal = new FlussPrincipal("user1", "USER");
+        Session session1 = createSession("user1", "192.168.1.1");
+        Session session2 = createSession("user1", "192.168.1.2");
+        List<Action> actions =
+                Collections.singletonList(new Action(Resource.database("database1"), READ));
+        assertThat(authorizer.authorize(session1, actions)).containsExactly(false);
+        assertThat(authorizer.authorize(session2, actions)).containsExactly(false);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.database("database1"),
+                                new AccessControlEntry(
+                                        principal,
+                                        session1.getInetAddress().getHostAddress(),
+                                        READ,
+                                        PermissionType.ALLOW))));
+        assertThat(authorizer.authorize(session1, actions)).containsExactly(true);
+        assertThat(authorizer.authorize(session2, actions)).containsExactly(false);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(
+                                Resource.database("database1"),
+                                new AccessControlEntry(
+                                        principal, "*", READ, PermissionType.ALLOW))));
+        assertThat(authorizer.authorize(session1, actions)).containsExactly(true);
+        assertThat(authorizer.authorize(session2, actions)).containsExactly(true);
+    }
+
+    /** Test ACL inheritance, as described in {@link OperationType}. */
+    @Test
+    void testAclInheritanceOnOperationType() throws Exception {
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                OperationType.ALL,
+                Arrays.asList(
+                        READ,
+                        WRITE,
+                        OperationType.CREATE,
+                        OperationType.DROP,
+                        OperationType.ALTER,
+                        OperationType.DESCRIBE,
+                        OperationType.IDEMPOTENT_WRITE,
+                        OperationType.FILESYSTEM_TOKEN));
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                OperationType.CREATE,
+                Collections.singleton(OperationType.DESCRIBE));
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                OperationType.DROP,
+                Collections.singleton(OperationType.DESCRIBE));
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                OperationType.ALTER,
+                Collections.singleton(OperationType.DESCRIBE));
+
+        // when we allow READ on any resource, we also allow DESCRIBE and FILESYSTEM_TOKEN on
+        // cluster.
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                READ,
+                Arrays.asList(OperationType.DESCRIBE, OperationType.FILESYSTEM_TOKEN));
+        testOperationTypeImplicationsOfAllow(
+                Resource.cluster(),
+                WRITE,
+                Arrays.asList(OperationType.DESCRIBE, OperationType.IDEMPOTENT_WRITE));
+        testOperationTypeImplicationsOfAllow(
+                Resource.database("database1"),
+                READ,
+                Arrays.asList(OperationType.DESCRIBE, OperationType.FILESYSTEM_TOKEN));
+        testOperationTypeImplicationsOfAllow(
+                Resource.table("database2", "table1"),
+                WRITE,
+                Arrays.asList(OperationType.DESCRIBE, OperationType.IDEMPOTENT_WRITE));
+    }
+
+    private void testOperationTypeImplicationsOfAllow(
+            Resource resource, OperationType parentOp, Collection<OperationType> allowedOps)
+            throws Exception {
+        Session session = createSession("user1", "192.168.1.1");
+        AccessControlEntry accessControlEntry =
+                new AccessControlEntry(session.getPrincipal(), "*", parentOp, PermissionType.ALLOW);
+        authorizer.addAcls(Collections.singletonList(new AclBinding(resource, accessControlEntry)));
+        Arrays.asList(OperationType.values())
+                .forEach(
+                        op -> {
+                            if (allowedOps.contains(op) || op == parentOp) {
+                                assertThat(authorizer.authorize(session, op, resource)).isTrue();
+                            } else if (op != OperationType.ANY) {
+                                assertThat(authorizer.authorize(session, op, resource)).isFalse();
+                            }
+                        });
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(resource.getType(), resource.getName()),
+                                new AccessControlEntryFilter(
+                                        session.getPrincipal(),
+                                        "*",
+                                        parentOp,
+                                        PermissionType.ALLOW))));
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(
+                                        Resource.cluster().getType(), Resource.cluster().getName()),
+                                new AccessControlEntryFilter(
+                                        session.getPrincipal(),
+                                        "*",
+                                        OperationType.IDEMPOTENT_WRITE,
+                                        PermissionType.ALLOW))));
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(
+                                        Resource.cluster().getType(), Resource.cluster().getName()),
+                                new AccessControlEntryFilter(
+                                        session.getPrincipal(),
+                                        "*",
+                                        OperationType.FILESYSTEM_TOKEN,
+                                        PermissionType.ALLOW))));
+    }
+
+    @Test
+    void testAclInheritanceOnResourceType() throws Exception {
+        testResourceTypeImplicationsOfAllow(
+                ResourceType.CLUSTER, Arrays.asList(DATABASE, ResourceType.TABLE));
+        testResourceTypeImplicationsOfAllow(DATABASE, Collections.singleton(ResourceType.TABLE));
+    }
+
+    private void testResourceTypeImplicationsOfAllow(
+            ResourceType parentType, Collection<ResourceType> allowedTypes) throws Exception {
+        FlussPrincipal user = new FlussPrincipal("user1", "USER");
+        Session session = createSession("user1", "192.168.1.1");
+        AccessControlEntry accessControlEntry =
+                new AccessControlEntry(user, "*", READ, PermissionType.ALLOW);
+        authorizer.addAcls(
+                Collections.singletonList(
+                        new AclBinding(mockResource(parentType), accessControlEntry)));
+        Arrays.asList(ResourceType.values())
+                .forEach(
+                        resourceType -> {
+                            if (allowedTypes.contains(resourceType) || resourceType == parentType) {
+                                assertThat(
+                                                authorizer.authorize(
+                                                        session, READ, mockResource(resourceType)))
+                                        .isTrue();
+                            } else if (resourceType != ResourceType.ANY) {
+                                assertThat(
+                                                authorizer.authorize(
+                                                        session, READ, mockResource(resourceType)))
+                                        .isFalse();
+                            }
+                        });
+        authorizer.dropAcls(
+                Collections.singletonList(
+                        new AclBindingFilter(
+                                new ResourceFilter(
+                                        mockResource(parentType).getType(),
+                                        mockResource(parentType).getName()),
+                                new AccessControlEntryFilter(
+                                        user, "*", READ, PermissionType.ALLOW))));
+    }
+
+    private Resource mockResource(ResourceType resourceType) {
+        switch (resourceType) {
+            case CLUSTER:
+                return Resource.cluster();
+            case DATABASE:
+                return Resource.database("database1");
+            case TABLE:
+                return Resource.table("database1", "table1");
+            default:
+                return null;
+        }
+    }
+
+    @Test
+    void testLoadCache() throws Exception {
+        Resource resource1 = Resource.database("foo-" + UUID.randomUUID());
+        Set<AccessControlEntry> acls1 =
+                Collections.singleton(
+                        new AccessControlEntry(
+                                new FlussPrincipal("user1", "User"),
+                                "host-1",
+                                READ,
+                                PermissionType.ANY));
+        addAcls(authorizer, resource1, acls1);
+
+        Resource resource2 = Resource.database("foo-" + UUID.randomUUID());
+        Set<AccessControlEntry> acls2 =
+                Collections.singleton(
+                        new AccessControlEntry(
+                                new FlussPrincipal("user2", "User"),
+                                "host-1",
+                                READ,
+                                PermissionType.ANY));
+        addAcls(authorizer, resource2, acls2);
+
+        // delete acl change notifications to test initial load.
+        zooKeeperClient.deleteAclChangeNotifications();
+        authorizer2.startup();
+        assertThat(listAcls(authorizer2, resource1)).isEqualTo(acls1);
+        assertThat(listAcls(authorizer2, resource2)).isEqualTo(acls2);
+
+        // test update cache later
+        final Set<AccessControlEntry> acls3 =
+                new HashSet<>(
+                        Arrays.asList(
+                                new AccessControlEntry(
+                                        new FlussPrincipal("user2", "User"),
+                                        "host-1",
+                                        READ,
+                                        PermissionType.ANY),
+                                new AccessControlEntry(
+                                        new FlussPrincipal("user3", "User"),
+                                        "host-2",
+                                        OperationType.IDEMPOTENT_WRITE,
+                                        PermissionType.ANY)));
+        addAcls(authorizer, resource2, acls3);
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer2, resource2)).isEqualTo(acls3);
+                });
+    }
+
+    // Authorizing the empty resource is not supported because we create a znode with the resource
+    // name.
+    @Test
+    void testEmptyAclThrowsException() {
+        assertThatThrownBy(
+                        () ->
+                                addAcls(
+                                        authorizer,
+                                        Resource.database(""),
+                                        Collections.singleton(
+                                                new AccessControlEntry(
+                                                        new FlussPrincipal("user1", "User"),
+                                                        "host-1",
+                                                        READ,
+                                                        PermissionType.ANY))))
+                .hasMessageContaining("Failed to update ACLs for Resource{type=DATABASE, name=''}");
+    }
+
+    @Test
+    void testLocalConcurrentModificationOfResourceAcls() {
+        Resource commonResource = Resource.database("foo-" + UUID.randomUUID());
+        FlussPrincipal user1 = new FlussPrincipal("user1", "User");
+        AccessControlEntry acl1 = new AccessControlEntry(user1, "host-1", READ, PermissionType.ANY);
+        FlussPrincipal user2 = new FlussPrincipal("user2", "User");
+        AccessControlEntry acl2 = new AccessControlEntry(user2, "host-2", READ, PermissionType.ANY);
+        addAcls(authorizer, commonResource, Collections.singleton(acl1));
+        addAcls(authorizer, commonResource, Collections.singleton(acl2));
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer, commonResource))
+                            .isEqualTo(new HashSet<>(Arrays.asList(acl1, acl2)));
+                });
+    }
+
+    @Test
+    void testDistributedConcurrentModificationOfResourceAcls() {
+        Resource commonResource = Resource.database("test");
+        FlussPrincipal user1 = new FlussPrincipal("user1", "User");
+        AccessControlEntry acl1 = new AccessControlEntry(user1, "host-1", READ, PermissionType.ANY);
+        FlussPrincipal user2 = new FlussPrincipal("user2", "User");
+        AccessControlEntry acl2 = new AccessControlEntry(user2, "host-2", READ, PermissionType.ANY);
+        // Add on each instance
+        addAcls(authorizer, commonResource, Collections.singleton(acl1));
+        addAcls(authorizer2, commonResource, Collections.singleton(acl2));
+
+        FlussPrincipal user3 = new FlussPrincipal("user3", "User");
+        AccessControlEntry acl3 = new AccessControlEntry(user3, "host-3", READ, PermissionType.ANY);
+
+        // Add on one instance and delete on another
+        addAcls(authorizer, commonResource, Collections.singleton(acl3));
+        removeAcls(authorizer2, commonResource, Collections.singleton(acl3));
+
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer, commonResource))
+                            .isEqualTo(new HashSet<>(Arrays.asList(acl1, acl2)));
+                });
+
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer2, commonResource))
+                            .isEqualTo(new HashSet<>(Arrays.asList(acl1, acl2)));
+                });
+    }
+
+    @Test
+    void testHighConcurrencyModificationOfResourceAcls() throws Exception {
+        Resource commonResource = Resource.database("foo-" + UUID.randomUUID());
+        Set<AccessControlEntry> acls =
+                IntStream.range(0, 50)
+                        .mapToObj(
+                                i ->
+                                        new AccessControlEntry(
+                                                new FlussPrincipal(String.valueOf(i), "User"),
+                                                "host-1",
+                                                READ,
+                                                PermissionType.ANY))
+                        .collect(Collectors.toSet());
+
+        List<Runnable> concurrentFunctions =
+                acls.stream()
+                        .map(
+                                acl ->
+                                        (Runnable)
+                                                () -> {
+                                                    if (Integer.parseInt(
+                                                                            acl.getPrincipal()
+                                                                                    .getName())
+                                                                    % 2
+                                                            == 0) {
+                                                        addAcls(
+                                                                authorizer,
+                                                                commonResource,
+                                                                Collections.singleton(acl));
+                                                    } else {
+                                                        addAcls(
+                                                                authorizer2,
+                                                                commonResource,
+                                                                Collections.singleton(acl));
+                                                    }
+
+                                                    if (Integer.parseInt(
+                                                                            acl.getPrincipal()
+                                                                                    .getName())
+                                                                    % 10
+                                                            == 0) {
+                                                        removeAcls(
+                                                                authorizer2,
+                                                                commonResource,
+                                                                Collections.singleton(acl));
+                                                    }
+                                                })
+                        .collect(Collectors.toList());
+
+        Set<AccessControlEntry> expectedAcls =
+                acls.stream()
+                        .filter(acl -> Integer.parseInt(acl.getPrincipal().getName()) % 10 != 0)
+                        .collect(Collectors.toSet());
+        assertConcurrent(concurrentFunctions, 30 * 1000);
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer, commonResource)).isEqualTo(expectedAcls);
+                });
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer2, commonResource)).isEqualTo(expectedAcls);
+                });
+    }
+
+    // todo: 无法保证，好奇为啥kafka可以保证，不应该把
+    @Test
+    @Disabled
+    void testHighConcurrencyDeletionOfResourceAcls() {
+        Resource commonResource = Resource.database("foo-" + UUID.randomUUID());
+        AccessControlEntry acl =
+                new AccessControlEntry(
+                        new FlussPrincipal("user1", "User"), "host-1", READ, PermissionType.ANY);
+        List<Runnable> concurrentFunctions =
+                IntStream.range(0, 50)
+                        .mapToObj(
+                                i ->
+                                        (Runnable)
+                                                () -> {
+                                                    addAcls(
+                                                            authorizer,
+                                                            commonResource,
+                                                            Collections.singleton(acl));
+                                                    removeAcls(
+                                                            authorizer2,
+                                                            commonResource,
+                                                            Collections.singleton(acl));
+                                                })
+                        .collect(Collectors.toList());
+        assertConcurrent(concurrentFunctions, 30 * 1000);
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer, commonResource))
+                            .isEqualTo(Collections.emptySet());
+                });
+
+        retry(
+                Duration.ofMinutes(1),
+                () -> {
+                    assertThat(listAcls(authorizer2, commonResource))
+                            .isEqualTo(Collections.emptySet());
+                });
+    }
+
+    // todo : add acl作为base测试类
+
+    void addAcls(Authorizer authorizer, Resource resource, Set<AccessControlEntry> entries) {
+        List<AclBinding> aclBindings =
+                entries.stream()
+                        .map(entry -> new AclBinding(resource, entry))
+                        .collect(Collectors.toList());
+        authorizer
+                .addAcls(aclBindings)
+                .forEach(
+                        result -> {
+                            if (result.exception().isPresent()) {
+                                throw result.exception().get();
+                            }
+                        });
+    }
+
+    Set<AccessControlEntry> listAcls(Authorizer authorizer, Resource resource) {
+        AclBindingFilter aclBindingFilter =
+                new AclBindingFilter(
+                        new ResourceFilter(resource.getType(), resource.getName()),
+                        AccessControlEntryFilter.ANY);
+        Collection<AclBinding> aclBindings = authorizer.listAcls(aclBindingFilter);
+        return aclBindings.stream()
+                .map(AclBinding::getAccessControlEntry)
+                .collect(Collectors.toSet());
+    }
+
+    void removeAcls(Authorizer authorizer, Resource resource, Set<AccessControlEntry> entries) {
+        List<AclBindingFilter> aclBindings =
+                entries.stream()
+                        .map(
+                                entry ->
+                                        new AclBindingFilter(
+                                                new ResourceFilter(
+                                                        resource.getType(), resource.getName()),
+                                                new AccessControlEntryFilter(
+                                                        entry.getPrincipal(),
+                                                        entry.getHost(),
+                                                        entry.getOperationType(),
+                                                        entry.getPermissionType())))
+                        .collect(Collectors.toList());
+        authorizer.dropAcls(aclBindings).stream()
+                .forEach(
+                        result -> {
+                            if (result.exception().isPresent()) {
+                                throw result.exception().get();
+                            }
+                        });
+    }
+
+    /**
+     * Asserts that a list of tasks can be executed concurrently within a given timeout.
+     *
+     * @param tasks the list of tasks to execute
+     * @param timeoutMs the timeout in milliseconds
+     */
+    private void assertConcurrent(List<Runnable> tasks, long timeoutMs) {
+        ExecutorService executor = Executors.newFixedThreadPool(tasks.size());
+        List<Future<?>> futures = tasks.stream().map(executor::submit).collect(Collectors.toList());
+
+        executor.shutdown();
+        try {
+            boolean completed = executor.awaitTermination(timeoutMs, TimeUnit.MILLISECONDS);
+            assertThat(completed).isTrue();
+            for (Future<?> future : futures) {
+                future.get(); // Ensure no exceptions were thrown
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Should support many concurrent calls"
+                            + " - Exception during concurrent execution",
+                    e);
+        }
+    }
+
+    private Session createSession(String username, String host) throws Exception {
+        return new Session(
+                (byte) 1,
+                "FLUSS",
+                false,
+                InetAddress.getByName(host),
+                new FlussPrincipal(username, "USER"));
+    }
+
+    private AclBinding createAclBinding(
+            ResourceType resourceType, String username, String host, OperationType operation) {
+        return new AclBinding(
+                mockResource(resourceType), createAclEntry(username, host, operation));
+    }
+
+    private AclBinding createAclBinding(
+            Resource resource, String username, String host, OperationType operation) {
+        return new AclBinding(resource, createAclEntry(username, host, operation));
+    }
+
+    private AccessControlEntry createAclEntry(
+            String username, String host, OperationType operation) {
+        return new AccessControlEntry(
+                new FlussPrincipal(username, "USER"), host, operation, PermissionType.ALLOW);
+    }
+
+    private AclBindingFilter createAclBindingFilter(
+            ResourceFilter resourceFilter,
+            FlussPrincipal flussPrincipal,
+            String host,
+            OperationType operation) {
+        return new AclBindingFilter(
+                resourceFilter,
+                new AccessControlEntryFilter(
+                        flussPrincipal, host, operation, PermissionType.ALLOW));
+    }
+}

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
@@ -29,6 +29,8 @@ import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestRequest;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestResponse;
+import com.alibaba.fluss.rpc.messages.CreateAclsRequest;
+import com.alibaba.fluss.rpc.messages.CreateAclsResponse;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.CreateDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.CreatePartitionRequest;
@@ -37,6 +39,8 @@ import com.alibaba.fluss.rpc.messages.CreateTableRequest;
 import com.alibaba.fluss.rpc.messages.CreateTableResponse;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsRequest;
 import com.alibaba.fluss.rpc.messages.DatabaseExistsResponse;
+import com.alibaba.fluss.rpc.messages.DropAclsRequest;
+import com.alibaba.fluss.rpc.messages.DropAclsResponse;
 import com.alibaba.fluss.rpc.messages.DropDatabaseRequest;
 import com.alibaba.fluss.rpc.messages.DropDatabaseResponse;
 import com.alibaba.fluss.rpc.messages.DropPartitionRequest;
@@ -57,6 +61,8 @@ import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableInfoResponse;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListPartitionInfosRequest;
@@ -285,6 +291,21 @@ public class TestCoordinatorGateway implements CoordinatorGateway {
     @Override
     public CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<CreateAclsResponse> createAcls(CreateAclsRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<DropAclsResponse> dropAcls(DropAclsRequest request) {
         throw new UnsupportedOperationException();
     }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImplTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImplTest.java
@@ -63,8 +63,8 @@ public class ServerMetadataCacheImplTest {
     }
 
     @Test
-    void testUpdateMetadataRequest() {
-        serverMetadataCache.updateMetadata(
+    void testUpdateClusterMetadataRequest() {
+        serverMetadataCache.updateClusterMetadata(
                 new ClusterMetadataInfo(Optional.of(coordinatorServer), aliveTableServers));
         assertThat(serverMetadataCache.getCoordinatorServer("CLIENT").get())
                 .isEqualTo(coordinatorServer.node("CLIENT"));

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/HighWatermarkPersistenceTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/HighWatermarkPersistenceTest.java
@@ -106,7 +106,8 @@ final class HighWatermarkPersistenceTest extends ReplicaTestBase {
                                         Collections.singletonList(TABLET_SERVER_ID),
                                         INITIAL_COORDINATOR_EPOCH,
                                         LeaderAndIsr.INITIAL_BUCKET_EPOCH))),
-                result -> {});
+                result -> {},
+                (tableId, tablePath) -> {});
 
         replicaManager.checkpointHighWatermarks();
         long highWatermark1 = highWatermarkFor(tableBucket1);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaManagerTest.java
@@ -1057,7 +1057,8 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         Arrays.asList(1, 2, 3),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                future::complete,
+                (tableId, path) -> {});
         assertThat(future.get()).containsOnly(new NotifyLeaderAndIsrResultForBucket(tb));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 1, INITIAL_BUCKET_EPOCH);
@@ -1077,7 +1078,8 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         Arrays.asList(1, 2, 3),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                future::complete,
+                (tableId, path) -> {});
         assertThat(future.get())
                 .containsOnly(
                         new NotifyLeaderAndIsrResultForBucket(
@@ -1111,7 +1113,8 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         Arrays.asList(1, 2, 3),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                future::complete,
+                (tableId, path) -> {});
         assertThat(future.get()).containsOnly(new NotifyLeaderAndIsrResultForBucket(tb));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 1, INITIAL_BUCKET_EPOCH);
@@ -1142,7 +1145,8 @@ class ReplicaManagerTest extends ReplicaTestBase {
                                         Arrays.asList(1, 2, 3),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                future::complete);
+                future::complete,
+                (tableId, tablePath) -> {});
         assertThat(future.get()).containsOnly(new NotifyLeaderAndIsrResultForBucket(tb));
         assertReplicaEpochEquals(
                 replicaManager.getReplicaOrException(tb), true, 2, INITIAL_BUCKET_EPOCH);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -201,7 +201,7 @@ public class ReplicaTestBase {
     }
 
     private void initMetadataCache(ServerMetadataCache metadataCache) {
-        metadataCache.updateMetadata(
+        metadataCache.updateClusterMetadata(
                 new ClusterMetadataInfo(
                         Optional.of(
                                 new ServerInfo(
@@ -396,7 +396,8 @@ public class ReplicaTestBase {
     }
 
     protected void makeLeaderAndFollower(List<NotifyLeaderAndIsrData> notifyLeaderAndIsrDataList) {
-        replicaManager.becomeLeaderOrFollower(0, notifyLeaderAndIsrDataList, result -> {});
+        replicaManager.becomeLeaderOrFollower(
+                0, notifyLeaderAndIsrDataList, result -> {}, (tableId, path) -> {});
     }
 
     protected Replica makeLogReplica(PhysicalTablePath physicalTablePath, TableBucket tableBucket)

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherManagerTest.java
@@ -92,7 +92,8 @@ class ReplicaFetcherManagerTest extends ReplicaTestBase {
                                         Arrays.asList(leader.id(), TABLET_SERVER_ID),
                                         INITIAL_COORDINATOR_EPOCH,
                                         LeaderAndIsr.INITIAL_BUCKET_EPOCH))),
-                result -> {});
+                result -> {},
+                (tableId, path) -> {});
 
         InitialFetchStatus initialFetchStatus =
                 new InitialFetchStatus(DATA1_TABLE_ID, DATA1_TABLE_PATH, leader.id(), fetchOffset);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -63,6 +63,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import static com.alibaba.fluss.record.TestData.DATA1;
@@ -295,7 +296,8 @@ public class ReplicaFetcherThreadTest {
                                         Arrays.asList(leaderServerId, followerServerId),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                result -> {});
+                result -> {},
+                (tableId, path) -> {});
         followerRM.becomeLeaderOrFollower(
                 INITIAL_COORDINATOR_EPOCH,
                 Collections.singletonList(
@@ -309,7 +311,8 @@ public class ReplicaFetcherThreadTest {
                                         Arrays.asList(leaderServerId, followerServerId),
                                         INITIAL_COORDINATOR_EPOCH,
                                         INITIAL_BUCKET_EPOCH))),
-                result -> {});
+                result -> {},
+                (tableId, path) -> {});
     }
 
     private ReplicaManager createReplicaManager(int serverId) throws Exception {
@@ -374,7 +377,8 @@ public class ReplicaFetcherThreadTest {
         public void becomeLeaderOrFollower(
                 int requestCoordinatorEpoch,
                 List<NotifyLeaderAndIsrData> notifyLeaderAndIsrDataList,
-                Consumer<List<NotifyLeaderAndIsrResultForBucket>> responseCallback) {
+                Consumer<List<NotifyLeaderAndIsrResultForBucket>> responseCallback,
+                BiConsumer<Long, PhysicalTablePath> leaderBucketCallback) {
             for (NotifyLeaderAndIsrData data : notifyLeaderAndIsrDataList) {
                 Optional<Replica> replicaOpt = maybeCreateReplica(data);
                 if (replicaOpt.isPresent() && data.getReplicas().contains(serverId)) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
@@ -45,6 +45,8 @@ import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanRequest;
 import com.alibaba.fluss.rpc.messages.LimitScanResponse;
+import com.alibaba.fluss.rpc.messages.ListAclsRequest;
+import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
 import com.alibaba.fluss.rpc.messages.ListDatabasesResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
@@ -307,6 +309,11 @@ public class TestTabletServerGateway implements TabletServerGateway {
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<ListAclsResponse> listAcls(ListAclsRequest request) {
         throw new UnsupportedOperationException();
     }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -713,11 +713,11 @@ public final class FlussClusterExtension
     }
 
     private List<AdminReadOnlyGateway> collectAllRpcGateways() {
+        String internalListenerName = clusterConf.get(ConfigOptions.INTERNAL_LISTENER_NAME);
         List<AdminReadOnlyGateway> rpcServiceBases = new ArrayList<>();
-        rpcServiceBases.add(
-                newCoordinatorClient(clusterConf.get(ConfigOptions.INTERNAL_LISTENER_NAME)));
+        rpcServiceBases.add(newCoordinatorClient(internalListenerName));
         rpcServiceBases.addAll(
-                getTabletServerNodes(clusterConf.get(ConfigOptions.INTERNAL_LISTENER_NAME)).stream()
+                getTabletServerNodes(internalListenerName).stream()
                         .map(this::newTabletServerClientForNode)
                         .collect(Collectors.toList()));
         return rpcServiceBases;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -152,12 +152,12 @@ public final class FlussClusterExtension
     }
 
     @Override
-    public void afterEach(ExtensionContext extensionContext) {
+    public void afterEach(ExtensionContext extensionContext) throws Exception {
         String defaultDb = BUILTIN_DATABASE;
         // TODO: we need to cleanup all zk nodes, including the assignments,
         //  but currently, we don't have a good way to do it
         if (metadataManager != null) {
-            // drop all database and tables
+            // drop all database and tables.
             List<String> databases = metadataManager.listDatabases();
             for (String database : databases) {
                 if (!database.equals(defaultDb)) {
@@ -335,6 +335,10 @@ public final class FlussClusterExtension
     }
 
     public Configuration getClientConfig() {
+        return getClientConfig(null);
+    }
+
+    public Configuration getClientConfig(@Nullable String listenerName) {
         Configuration flussConf = new Configuration();
         // now, just use the coordinator server as the bootstrap server
         flussConf.set(
@@ -342,8 +346,8 @@ public final class FlussClusterExtension
                 Collections.singletonList(
                         String.format(
                                 "%s:%d",
-                                getCoordinatorServerNode().host(),
-                                getCoordinatorServerNode().port())));
+                                getCoordinatorServerNode(listenerName).host(),
+                                getCoordinatorServerNode(listenerName).port())));
 
         // set a small memory buffer for testing.
         flussConf.set(ConfigOptions.CLIENT_WRITER_BUFFER_MEMORY_SIZE, MemorySize.parse("2mb"));
@@ -418,6 +422,11 @@ public final class FlussClusterExtension
                 this::getCoordinatorServerNode, rpcClient, CoordinatorGateway.class);
     }
 
+    public CoordinatorGateway newCoordinatorClient(String listenerName) {
+        return GatewayClientProxy.createGatewayProxy(
+                () -> getCoordinatorServerNode(listenerName), rpcClient, CoordinatorGateway.class);
+    }
+
     public TabletServerGateway newTabletServerClientForNode(int serverId) {
         final ServerNode serverNode =
                 getTabletServerNodes().stream()
@@ -450,7 +459,11 @@ public final class FlussClusterExtension
                         ServerNode coordinatorNode =
                                 toServerNode(
                                         response.getCoordinatorServer(), ServerType.COORDINATOR);
-                        assertThat(coordinatorNode).isEqualTo(getCoordinatorServerNode());
+                        assertThat(coordinatorNode)
+                                .isEqualTo(
+                                        getCoordinatorServerNode(
+                                                clusterConf.get(
+                                                        ConfigOptions.INTERNAL_LISTENER_NAME)));
                         // check tablet server nodes
                         List<ServerNode> tsNodes =
                                 response.getTabletServersList().stream()
@@ -701,9 +714,10 @@ public final class FlussClusterExtension
 
     private List<AdminReadOnlyGateway> collectAllRpcGateways() {
         List<AdminReadOnlyGateway> rpcServiceBases = new ArrayList<>();
-        rpcServiceBases.add(newCoordinatorClient());
+        rpcServiceBases.add(
+                newCoordinatorClient(clusterConf.get(ConfigOptions.INTERNAL_LISTENER_NAME)));
         rpcServiceBases.addAll(
-                getTabletServerNodes().stream()
+                getTabletServerNodes(clusterConf.get(ConfigOptions.INTERNAL_LISTENER_NAME)).stream()
                         .map(this::newTabletServerClientForNode)
                         .collect(Collectors.toList()));
         return rpcServiceBases;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/TestingMetadataCache.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/TestingMetadataCache.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.server.testutils;
 
 import com.alibaba.fluss.cluster.MetadataCache;
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.metadata.PhysicalTablePath;
 
 import java.util.Collections;
 import java.util.Map;
@@ -61,5 +62,10 @@ public class TestingMetadataCache implements MetadataCache {
 
     public int[] getLiveServerIds() {
         return serverIds;
+    }
+
+    @Override
+    public PhysicalTablePath getTablePath(long tableId) {
+        return null;
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.server.zk.data;
+
+import com.alibaba.fluss.security.acl.AccessControlEntry;
+import com.alibaba.fluss.security.acl.FlussPrincipal;
+import com.alibaba.fluss.security.acl.OperationType;
+import com.alibaba.fluss.security.acl.PermissionType;
+import com.alibaba.fluss.utils.json.JsonSerdeTestBase;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+/** Test for {@link ResourceAclJsonSerde}. */
+public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
+
+    ResourceAclJsonSerdeTest() {
+        super(ResourceAclJsonSerde.INSTANCE);
+    }
+
+    @Override
+    protected ResourceAcl[] createObjects() {
+        return new ResourceAcl[] {
+            new ResourceAcl(
+                    Collections.singleton(
+                            new AccessControlEntry(
+                                    new FlussPrincipal("Mike", "USER"),
+                                    "*",
+                                    OperationType.ALL,
+                                    PermissionType.ANY))),
+            new ResourceAcl(
+                    new HashSet<>(
+                            Arrays.asList(
+                                    new AccessControlEntry(
+                                            new FlussPrincipal("John", "ROLE"),
+                                            "127.0.0.1",
+                                            OperationType.ALTER,
+                                            PermissionType.ANY),
+                                    new AccessControlEntry(
+                                            new FlussPrincipal("Mike1233", "ROLE"),
+                                            "1*",
+                                            OperationType.FILESYSTEM_TOKEN,
+                                            PermissionType.ANY)))),
+        };
+    }
+
+    @Override
+    protected String[] expectedJsons() {
+        return new String[] {
+            "{\"version\":1,\"acls\":[{\"principalType\":\"USER\",\"principalName\":\"Mike\",\"permissionType\":\"ALLOW\",\"host\":\"*\",\"host\":\"*\",\"operation\":\"ALL\"}]}",
+            "{\"version\":1,\"acls\":[{\"principalType\":\"ROLE\",\"principalName\":\"John\",\"permissionType\":\"ALLOW\",\"host\":\"127.0.0.1\",\"host\":\"127.0.0.1\",\"operation\":\"ALTER\"}"
+                    + ",{\"principalType\":\"ROLE\",\"principalName\":\"Mike1233\",\"permissionType\":\"ALLOW\",\"host\":\"1*\",\"host\":\"1*\",\"operation\":\"FILESYSTEM_TOKEN\"}]}"
+        };
+    }
+}

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
@@ -24,7 +24,7 @@ import com.alibaba.fluss.utils.json.JsonSerdeTestBase;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 /** Test for {@link ResourceAclJsonSerde}. */
 public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
@@ -44,7 +44,8 @@ public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
                                     OperationType.ALL,
                                     PermissionType.ALLOW))),
             new ResourceAcl(
-                    new HashSet<>(
+                    // use LinkedHashSet to ensure the order of the acls is preserved
+                    new LinkedHashSet<>(
                             Arrays.asList(
                                     new AccessControlEntry(
                                             new FlussPrincipal("John", "ROLE"),
@@ -62,9 +63,9 @@ public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
     @Override
     protected String[] expectedJsons() {
         return new String[] {
-            "{\"version\":1,\"acls\":[{\"principal_type\":\"USER\",\"principal_name\":\"Mike\",\"permission_type\":\"ALLOW\",\"host\":\"*\",\"host\":\"*\",\"operation\":\"ALL\"}]}",
-            "{\"version\":1,\"acls\":[{\"principal_type\":\"ROLE\",\"principal_name\":\"John\",\"permission_type\":\"ALLOW\",\"host\":\"127.0.0.1\",\"host\":\"127.0.0.1\",\"operation\":\"ALTER\"}"
-                    + ",{\"principal_type\":\"ROLE\",\"principal_name\":\"Mike1233\",\"permission_type\":\"ALLOW\",\"host\":\"1*\",\"host\":\"1*\",\"operation\":\"READ\"}]}"
+            "{\"version\":1,\"acls\":[{\"principal_type\":\"USER\",\"principal_name\":\"Mike\",\"permission_type\":\"ALLOW\",\"host\":\"*\",\"operation\":\"ALL\"}]}",
+            "{\"version\":1,\"acls\":[{\"principal_type\":\"ROLE\",\"principal_name\":\"John\",\"permission_type\":\"ALLOW\",\"host\":\"127.0.0.1\",\"operation\":\"ALTER\"}"
+                    + ",{\"principal_type\":\"ROLE\",\"principal_name\":\"Mike1233\",\"permission_type\":\"ALLOW\",\"host\":\"1*\",\"operation\":\"READ\"}]}"
         };
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/zk/data/ResourceAclJsonSerdeTest.java
@@ -42,7 +42,7 @@ public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
                                     new FlussPrincipal("Mike", "USER"),
                                     "*",
                                     OperationType.ALL,
-                                    PermissionType.ANY))),
+                                    PermissionType.ALLOW))),
             new ResourceAcl(
                     new HashSet<>(
                             Arrays.asList(
@@ -50,21 +50,21 @@ public class ResourceAclJsonSerdeTest extends JsonSerdeTestBase<ResourceAcl> {
                                             new FlussPrincipal("John", "ROLE"),
                                             "127.0.0.1",
                                             OperationType.ALTER,
-                                            PermissionType.ANY),
+                                            PermissionType.ALLOW),
                                     new AccessControlEntry(
                                             new FlussPrincipal("Mike1233", "ROLE"),
                                             "1*",
-                                            OperationType.FILESYSTEM_TOKEN,
-                                            PermissionType.ANY)))),
+                                            OperationType.READ,
+                                            PermissionType.ALLOW)))),
         };
     }
 
     @Override
     protected String[] expectedJsons() {
         return new String[] {
-            "{\"version\":1,\"acls\":[{\"principalType\":\"USER\",\"principalName\":\"Mike\",\"permissionType\":\"ALLOW\",\"host\":\"*\",\"host\":\"*\",\"operation\":\"ALL\"}]}",
-            "{\"version\":1,\"acls\":[{\"principalType\":\"ROLE\",\"principalName\":\"John\",\"permissionType\":\"ALLOW\",\"host\":\"127.0.0.1\",\"host\":\"127.0.0.1\",\"operation\":\"ALTER\"}"
-                    + ",{\"principalType\":\"ROLE\",\"principalName\":\"Mike1233\",\"permissionType\":\"ALLOW\",\"host\":\"1*\",\"host\":\"1*\",\"operation\":\"FILESYSTEM_TOKEN\"}]}"
+            "{\"version\":1,\"acls\":[{\"principal_type\":\"USER\",\"principal_name\":\"Mike\",\"permission_type\":\"ALLOW\",\"host\":\"*\",\"host\":\"*\",\"operation\":\"ALL\"}]}",
+            "{\"version\":1,\"acls\":[{\"principal_type\":\"ROLE\",\"principal_name\":\"John\",\"permission_type\":\"ALLOW\",\"host\":\"127.0.0.1\",\"host\":\"127.0.0.1\",\"operation\":\"ALTER\"}"
+                    + ",{\"principal_type\":\"ROLE\",\"principal_name\":\"Mike1233\",\"permission_type\":\"ALLOW\",\"host\":\"1*\",\"host\":\"1*\",\"operation\":\"READ\"}]}"
         };
     }
 }


### PR DESCRIPTION
### Purpose
Linked issue: close #485

This pr includes three things:
* ZkNodeChangeNotificationWatcher : watch zk node change notifications(also used for acl change notifications later).
* ServerMetadataCache: add upsertTableBucketMetadata. For leader node, can lookup table and database name from tableId.
* ACL operation:
     - [ ] Client side interface: com.alibaba.fluss.client.admin.Admin
     - [ ] Server side: maily com.alibaba.fluss.server.authorizer.ZooKeeperBasedAuthorizer


### Test
* com.alibaba.fluss.client.security.acl.FlussAuthorizationITCase:  ITCase to test each rpc request's authotization.
* com.alibaba.fluss.server.authorizer.ZooKeeperBasedAuthorizerTest: UT cases.
* com.alibaba.fluss.server.authorizer.ZkNodeChangeNotificationWatcherTest: test zk node change notifications.

