### PR TITLE
[Client] Fix Sender retry forever error while MetadataUtils.getOneAvailableTabletServerNode() throw FlussRuntimeException

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -17,7 +17,6 @@
 package com.alibaba.fluss.client.metadata;
 
 import com.alibaba.fluss.annotation.VisibleForTesting;
-import com.alibaba.fluss.client.utils.ClientUtils;
 import com.alibaba.fluss.cluster.BucketLocation;
 import com.alibaba.fluss.cluster.Cluster;
 import com.alibaba.fluss.cluster.ServerNode;
@@ -53,6 +52,7 @@ import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
+import static com.alibaba.fluss.client.utils.ClientUtils.parseAndValidateAddresses;
 import static com.alibaba.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster;
 
 /** The updater to initialize and update client metadata. */
@@ -61,16 +61,18 @@ public class MetadataUpdater {
 
     private static final int MAX_RETRY_TIMES = 5;
 
+    private final Configuration conf;
     private final RpcClient rpcClient;
     protected volatile Cluster cluster;
 
     public MetadataUpdater(Configuration configuration, RpcClient rpcClient) {
-        this(rpcClient, initializeCluster(configuration, rpcClient));
+        this(rpcClient, configuration, initializeCluster(configuration, rpcClient));
     }
 
     @VisibleForTesting
-    public MetadataUpdater(RpcClient rpcClient, Cluster cluster) {
+    public MetadataUpdater(RpcClient rpcClient, Configuration conf, Cluster cluster) {
         this.rpcClient = rpcClient;
+        this.conf = conf;
         this.cluster = cluster;
     }
 
@@ -275,7 +277,7 @@ public class MetadataUpdater {
      */
     private static Cluster initializeCluster(Configuration conf, RpcClient rpcClient) {
         List<InetSocketAddress> inetSocketAddresses =
-                ClientUtils.parseAndValidateAddresses(conf.get(ConfigOptions.BOOTSTRAP_SERVERS));
+                parseAndValidateAddresses(conf.get(ConfigOptions.BOOTSTRAP_SERVERS));
         Cluster cluster = null;
         for (InetSocketAddress address : inetSocketAddresses) {
             cluster = tryToInitializeCluster(rpcClient, address);
@@ -294,6 +296,13 @@ public class MetadataUpdater {
         }
 
         return cluster;
+    }
+
+    /** Re-initialize the cluster. */
+    public void reInitializeCluster() {
+        synchronized (this) {
+            cluster = initializeCluster(conf, rpcClient);
+        }
     }
 
     private static @Nullable Cluster tryToInitializeCluster(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.client.metrics.ScannerMetricGroup;
 import com.alibaba.fluss.client.table.scanner.RemoteFileDownloader;
 import com.alibaba.fluss.client.table.scanner.ScanRecord;
 import com.alibaba.fluss.cluster.BucketLocation;
+import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidMetadataException;
@@ -192,6 +193,12 @@ public class LogFetcher implements Closeable {
     }
 
     private void sendFetchRequest(int destination, FetchLogRequest fetchLogRequest) {
+        ServerNode tabletServer = metadataUpdater.getTabletServer(destination);
+        if (tabletServer == null) {
+            LOG.debug("Tablet server not found for id {}", destination);
+            return;
+        }
+
         // TODO cache the tablet server gateway.
         TabletServerGateway gateway =
                 GatewayClientProxy.createGatewayProxy(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
@@ -145,6 +145,8 @@ public class Sender implements Runnable {
             try {
                 runOnce();
             } catch (Throwable t) {
+                // if an unexpected error occurs, we first to try to reinitialize the metadata.
+                metadataUpdater.reInitializeCluster();
                 LOG.error("Uncaught error in Fluss write sender thread: ", t);
             }
         }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
@@ -63,6 +63,7 @@ public class TestingMetadataUpdater extends MetadataUpdater {
             Map<TablePath, TableInfo> tableInfos) {
         super(
                 RpcClient.create(new Configuration(), TestingClientMetricGroup.newInstance()),
+                new Configuration(),
                 Cluster.empty());
         initializeCluster(coordinatorServer, tabletServers, tableInfos);
         coordinatorGateway = new TestCoordinatorGateway();

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/NettyClient.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/client/NettyClient.java
@@ -45,6 +45,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.fluss.utils.Preconditions.checkArgument;
+import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 
 /**
  * A network client for asynchronous request/response network i/o. This is an internal class used to
@@ -148,6 +149,7 @@ public final class NettyClient implements RpcClient {
     @Override
     public CompletableFuture<ApiMessage> sendRequest(
             ServerNode node, ApiKeys apiKey, ApiMessage request) {
+        checkNotNull(node, "node is null.");
         checkArgument(!isClosed, "Netty client is closed.");
         return getOrCreateConnection(node).send(apiKey, request);
     }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #605 

<!-- What is the purpose of the change -->

Fix Sender retry forever error while MetadataUtils.getOneAvailableTabletServerNode() throw FlussRuntimeException

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
