### PR TITLE
[server] Fix adjustIsr request re-send forever if encounter FencedLeaderEpochException error

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/IsrState.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/IsrState.java
@@ -66,6 +66,18 @@ public interface IsrState {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            CommittedIsrState that = (CommittedIsrState) o;
+            return isr.equals(that.isr);
+        }
+
+        @Override
         public String toString() {
             return "CommittedIsrState{" + "isr=" + isr + '}';
         }
@@ -135,6 +147,20 @@ public interface IsrState {
         }
 
         @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PendingExpandIsrState that = (PendingExpandIsrState) o;
+            return newInSyncReplicaId == that.newInSyncReplicaId
+                    && sentLeaderAndIsr.equals(that.sentLeaderAndIsr)
+                    && lastCommittedState.equals(that.lastCommittedState);
+        }
+
+        @Override
         public String toString() {
             return "PendingExpandIsrState{"
                     + "newInSyncReplicaId="
@@ -186,6 +212,20 @@ public interface IsrState {
         @Override
         public boolean isInflight() {
             return true;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            PendingShrinkIsrState that = (PendingShrinkIsrState) o;
+            return outOfSyncReplicaIds.equals(that.outOfSyncReplicaIds)
+                    && sentLeaderAndIsr.equals(that.sentLeaderAndIsr)
+                    && lastCommittedState.equals(that.lastCommittedState);
         }
 
         @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -1443,7 +1443,7 @@ public final class Replica {
     }
 
     @VisibleForTesting
-    public IsrState.PendingShrinkIsrState prepareIsrShrink(
+    IsrState.PendingShrinkIsrState prepareIsrShrink(
             IsrState.CommittedIsrState currentState,
             List<Integer> isrToSend,
             List<Integer> outOfSyncFollowerReplicas) {
@@ -1464,8 +1464,7 @@ public final class Replica {
     }
 
     @VisibleForTesting
-    public CompletableFuture<LeaderAndIsr> submitAdjustIsr(
-            IsrState.PendingIsrState proposedIsrState) {
+    CompletableFuture<LeaderAndIsr> submitAdjustIsr(IsrState.PendingIsrState proposedIsrState) {
         return submitAdjustIsr(proposedIsrState, new CompletableFuture<>());
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -1461,7 +1461,8 @@ public final class Replica {
         return updatedState;
     }
 
-    private CompletableFuture<LeaderAndIsr> submitAdjustIsr(
+    @VisibleForTesting
+    public CompletableFuture<LeaderAndIsr> submitAdjustIsr(
             IsrState.PendingIsrState proposedIsrState) {
         LOG.debug("Submitting ISR state change {}.", proposedIsrState);
         CompletableFuture<LeaderAndIsr> future =
@@ -1592,6 +1593,12 @@ public final class Replica {
                 LOG.debug(
                         "Failed to adjust isr to {} because the request is invalid. Replica state may be out of sync, "
                                 + "awaiting new the latest metadata.",
+                        proposedIsrState);
+                return false;
+            case FENCED_LEADER_EPOCH_EXCEPTION:
+                LOG.debug(
+                        "Failed to adjust isr to {} because the leader epoch is fenced which indicate this replica "
+                                + "maybe no long leader. Replica state may be out of sync, awaiting new the latest metadata.",
                         proposedIsrState);
                 return false;
             default:
@@ -1790,5 +1797,10 @@ public final class Replica {
     @VisibleForTesting
     public List<Integer> getIsr() {
         return isrState.isr();
+    }
+
+    @VisibleForTesting
+    public AdjustIsrManager getAdjustIsrManager() {
+        return adjustIsrManager;
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/log/remote/RemoteLogManagerTest.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.remote.RemoteLogFetchInfo;
 import com.alibaba.fluss.remote.RemoteLogSegment;
 import com.alibaba.fluss.rpc.entity.FetchLogResultForBucket;
 import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.server.coordinator.TestCoordinatorGateway;
 import com.alibaba.fluss.server.entity.FetchData;
 import com.alibaba.fluss.server.log.FetchParams;
 import com.alibaba.fluss.server.log.LogTablet;
@@ -110,7 +111,7 @@ class RemoteLogManagerTest extends RemoteLogTestBase {
 
         // rebuild a remote log manager.
         replicaManager.shutdown();
-        replicaManager = buildReplicaManager();
+        replicaManager = buildReplicaManager(new TestCoordinatorGateway());
         makeLogTableAsLeader(tb, partitionTable);
         // trigger reload remote log metadata from remote snapshot.
         remoteLogTaskScheduler.triggerPeriodicScheduledTasks();

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.fluss.record.TestData.DATA1;
 import static com.alibaba.fluss.record.TestData.DATA1_TABLE_ID;
@@ -134,7 +135,10 @@ public class AdjustIsrTest extends ReplicaTestBase {
         // Set leader epoch of this bucket in coordinatorServer gateway to 1 to mock leader epoch is
         // fenced.
         testCoordinatorGateway.setCurrentLeaderEpoch(tb, 1);
-        assertThatThrownBy(() -> replica.submitAdjustIsr(pendingShrinkIsrState).get())
+        assertThatThrownBy(
+                        () ->
+                                replica.submitAdjustIsr(pendingShrinkIsrState)
+                                        .get(1, TimeUnit.MINUTES))
                 .rootCause()
                 .isInstanceOf(FencedLeaderEpochException.class)
                 .hasMessageContaining("request leader epoch is fenced.");

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrTest.java
@@ -23,7 +23,6 @@ import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.rpc.entity.ProduceLogResultForBucket;
 import com.alibaba.fluss.server.entity.FetchData;
 import com.alibaba.fluss.server.log.FetchParams;
-import com.alibaba.fluss.server.zk.data.LeaderAndIsr;
 
 import org.junit.jupiter.api.Test;
 
@@ -118,45 +117,24 @@ public class AdjustIsrTest extends ReplicaTestBase {
 
     @Test
     void testSubmitShrinkIsrAsLeaderFenced() throws Exception {
-        // replica set is 1,2,3 , isr set is 1.
+        // replica set is 1,2,3 , isr set is 1,2,3.
         TableBucket tb = new TableBucket(DATA1_TABLE_ID, 1);
-        makeLogTableAsLeader(tb, Arrays.asList(1, 2, 3), Collections.singletonList(1), false);
+        makeLogTableAsLeader(tb, Arrays.asList(1, 2, 3), Arrays.asList(1, 2, 3), false);
 
         Replica replica = replicaManager.getReplicaOrException(tb);
-        assertThat(replica.getIsr()).containsExactlyInAnyOrder(1);
+        assertThat(replica.getIsr()).containsExactlyInAnyOrder(1, 2, 3);
 
-        AdjustIsrManager adjustIsrManager = replica.getAdjustIsrManager();
-        // 1. isr with correct leader epoch.
-        LeaderAndIsr tryToAdjustIsr = new LeaderAndIsr(1, 0, Collections.singletonList(1), 0, 1);
-        LeaderAndIsr adjustedIsr = adjustIsrManager.submit(tb, tryToAdjustIsr).get();
-        assertThat(adjustedIsr.leaderEpoch()).isEqualTo(tryToAdjustIsr.leaderEpoch());
-        assertThat(adjustedIsr.bucketEpoch()).isEqualTo(2);
-        adjustedIsr =
-                replica.submitAdjustIsr(
-                                new IsrState.PendingShrinkIsrState(
-                                        Collections.singletonList(1),
-                                        tryToAdjustIsr,
-                                        new IsrState.CommittedIsrState(Collections.emptyList())))
-                        .get();
-        assertThat(adjustedIsr.leaderEpoch()).isEqualTo(tryToAdjustIsr.leaderEpoch());
-        assertThat(adjustedIsr.bucketEpoch()).isEqualTo(2);
+        // To mock we prepare an isr shrink in Replica#maybeShrinkIsr();
+        IsrState.PendingShrinkIsrState pendingShrinkIsrState =
+                replica.prepareIsrShrink(
+                        new IsrState.CommittedIsrState(Arrays.asList(1, 2, 3)),
+                        Arrays.asList(1, 2),
+                        Collections.singletonList(3));
 
+        // Set leader epoch of this bucket in coordinatorServer gateway to 1 to mock leader epoch is
+        // fenced.
         testCoordinatorGateway.setCurrentLeaderEpoch(tb, 1);
-        // 2. isr with fenced leader epoch.
-        assertThatThrownBy(() -> adjustIsrManager.submit(tb, tryToAdjustIsr).get())
-                .rootCause()
-                .isInstanceOf(FencedLeaderEpochException.class)
-                .hasMessageContaining("request leader epoch is fenced.");
-
-        assertThatThrownBy(
-                        () ->
-                                replica.submitAdjustIsr(
-                                                new IsrState.PendingShrinkIsrState(
-                                                        Collections.singletonList(1),
-                                                        tryToAdjustIsr,
-                                                        new IsrState.CommittedIsrState(
-                                                                Collections.emptyList())))
-                                        .get())
+        assertThatThrownBy(() -> replica.submitAdjustIsr(pendingShrinkIsrState).get())
                 .rootCause()
                 .isInstanceOf(FencedLeaderEpochException.class)
                 .hasMessageContaining("request leader epoch is fenced.");

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/HighWatermarkPersistenceTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/HighWatermarkPersistenceTest.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.server.replica;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.server.coordinator.TestCoordinatorGateway;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrData;
 import com.alibaba.fluss.server.log.checkpoint.OffsetCheckpointFile;
 import com.alibaba.fluss.server.zk.data.LeaderAndIsr;
@@ -169,7 +170,7 @@ final class HighWatermarkPersistenceTest extends ReplicaTestBase {
         assertThat(highWatermarkFor(tb2)).isEqualTo(10L);
 
         // 1. replicaManager shutdown after tb1/tb2 become leader.
-        replicaManager = buildReplicaManager();
+        replicaManager = buildReplicaManager(new TestCoordinatorGateway());
         replicaManager.startup();
         assertThat(highWatermarkFor(tb1)).isEqualTo(10L);
         assertThat(highWatermarkFor(tb2)).isEqualTo(10L);
@@ -182,7 +183,7 @@ final class HighWatermarkPersistenceTest extends ReplicaTestBase {
         assertThat(highWatermarkFor(tb2)).isEqualTo(10L);
 
         // 2. replicaManager shutdown before tb1/tb2 become leader.
-        replicaManager = buildReplicaManager();
+        replicaManager = buildReplicaManager(new TestCoordinatorGateway());
         replicaManager.startup();
         replicaManager.shutdown();
         assertThat(highWatermarkFor(tb1)).isEqualTo(20L);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -29,6 +29,7 @@ import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
 import com.alibaba.fluss.rpc.metrics.TestingClientMetricGroup;
 import com.alibaba.fluss.server.coordinator.TestCoordinatorGateway;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrData;
@@ -192,7 +193,7 @@ public class ReplicaTestBase {
         initRemoteLogEnv();
 
         // init replica manager
-        replicaManager = buildReplicaManager();
+        replicaManager = buildReplicaManager(testCoordinatorGateway);
         replicaManager.startup();
 
         // We will register all tables in TestData in zk client previously.
@@ -264,7 +265,8 @@ public class ReplicaTestBase {
         return tableId;
     }
 
-    protected ReplicaManager buildReplicaManager() throws Exception {
+    protected ReplicaManager buildReplicaManager(CoordinatorGateway coordinatorGateway)
+            throws Exception {
         return new ReplicaManager(
                 conf,
                 scheduler,
@@ -274,7 +276,7 @@ public class ReplicaTestBase {
                 TABLET_SERVER_ID,
                 serverMetadataCache,
                 rpcClient,
-                new TestCoordinatorGateway(),
+                coordinatorGateway,
                 snapshotReporter,
                 NOPErrorHandler.INSTANCE,
                 TestingMetricGroups.TABLET_SERVER_METRICS,


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #624 

<!-- What is the purpose of the change -->

### Brief change log

This pr is aims to fix adjustIsr request re-send forever if encounter FencedLeaderEpochException error.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
