### PR TITLE
add deserialization schema and FlussRecord

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
@@ -19,6 +19,8 @@ package com.alibaba.fluss.flink.row;
 import org.apache.flink.types.Row;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 
 /**
  * Helper class for converting a Flink Row to a POJO using reflection
@@ -30,7 +32,16 @@ public class FlinkRowToPojo {
     public static <T> T convert(Row row, Class<T> pojoClass) {
         try {
             T pojo = pojoClass.getDeclaredConstructor().newInstance();
-            Field[] fields = pojoClass.getDeclaredFields();
+            Field[] allFields = pojoClass.getDeclaredFields();
+
+            // Filter out synthetic fields (like JaCoCo's $jacocoData)
+            Field[] fields =
+                    Arrays.stream(allFields)
+                            .filter(
+                                    field ->
+                                            !field.isSynthetic()
+                                                    && !Modifier.isStatic(field.getModifiers()))
+                            .toArray(Field[]::new);
 
             if (row.getArity() != fields.length) {
                 throw new IllegalArgumentException(

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.row;
+
+import org.apache.flink.types.Row;
+
+import java.lang.reflect.Field;
+
+/**
+ * Helper class for converting a Flink Row to a POJO using reflection
+ *
+ * <p>Note: Can be used for testing on the datastream source api and users can use it if they wish
+ * to convert Flink rows to POJOs.
+ */
+public class FlinkRowToPojo {
+
+    public static <T> T convert(Row row, Class<T> pojoClass) {
+        try {
+            T pojo = pojoClass.getDeclaredConstructor().newInstance();
+            Field[] fields = pojoClass.getDeclaredFields();
+
+            for (int i = 0; i < fields.length; i++) {
+                Field field = fields[i];
+                field.setAccessible(true);
+                Object value = row.getField(i);
+
+                // Convert types if necessary
+                if (value != null && !field.getType().isAssignableFrom(value.getClass())) {
+                    if (field.getType() == Integer.class || field.getType() == int.class) {
+                        value = ((Number) value).intValue();
+                    } else if (field.getType() == Long.class || field.getType() == long.class) {
+                        value = ((Number) value).longValue();
+                    } else if (field.getType() == Double.class || field.getType() == double.class) {
+                        value = ((Number) value).doubleValue();
+                    } else if (field.getType() == Float.class || field.getType() == float.class) {
+                        value = ((Number) value).floatValue();
+                    } else if (field.getType() == Short.class || field.getType() == short.class) {
+                        value = ((Number) value).shortValue();
+                    } else if (field.getType() == Byte.class || field.getType() == byte.class) {
+                        value = ((Number) value).byteValue();
+                    }
+                }
+
+                field.set(pojo, value);
+            }
+
+            return pojo;
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting Flink Row to POJO", e);
+        }
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlinkRowToPojo.java
@@ -34,7 +34,12 @@ public class FlinkRowToPojo {
 
             if (row.getArity() != fields.length) {
                 throw new IllegalArgumentException(
-                        "Row arity does not match the number of fields in the POJO class");
+                        "Row arity ("
+                                + row.getArity()
+                                + ") does not match the number of fields ("
+                                + fields.length
+                                + ") in the POJO class: "
+                                + pojoClass.getName());
             }
 
             for (int i = 0; i < fields.length; i++) {
@@ -84,8 +89,15 @@ public class FlinkRowToPojo {
             }
 
             return pojo;
+        } catch (IllegalArgumentException e) {
+            throw e;
         } catch (Exception e) {
-            throw new RuntimeException("Error converting Flink Row to POJO", e);
+            throw new RuntimeException(
+                    "Error converting Flink Row to POJO. Row: "
+                            + row
+                            + ", POJO class: "
+                            + pojoClass.getName(),
+                    e);
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
@@ -35,6 +35,7 @@ public class FlussRecord {
         this.row = row;
     }
 
+    /** The position of this record in the corresponding fluss table bucket. */
     public long getOffset() {
         return offset;
     }
@@ -51,7 +52,6 @@ public class FlussRecord {
         return row;
     }
 
-    /** The position of this record in the corresponding fluss table bucket. */
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
@@ -35,12 +35,11 @@ public class FlussRecord {
         this.row = row;
     }
 
-    /** The position of this record in the corresponding fluss table bucket. */
-    public long logOffset() {
+    public long getOffset() {
         return offset;
     }
 
-    public long timestamp() {
+    public long getTimestamp() {
         return timestamp;
     }
 
@@ -52,6 +51,7 @@ public class FlussRecord {
         return row;
     }
 
+    /** The position of this record in the corresponding fluss table bucket. */
     @Override
     public boolean equals(Object o) {
         if (o == null || getClass() != o.getClass()) {

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/row/FlussRecord.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.row;
+
+import com.alibaba.fluss.record.ChangeType;
+
+import org.apache.flink.types.Row;
+
+import java.util.Objects;
+
+public class FlussRecord {
+    private final long offset;
+    private final long timestamp;
+    private final ChangeType changeType;
+    private final Row row;
+
+    public FlussRecord(long offset, long timestamp, ChangeType changeType, Row row) {
+        this.offset = offset;
+        this.timestamp = timestamp;
+        this.changeType = changeType;
+        this.row = row;
+    }
+
+    /** The position of this record in the corresponding fluss table bucket. */
+    public long logOffset() {
+        return offset;
+    }
+
+    public long timestamp() {
+        return timestamp;
+    }
+
+    public ChangeType getChangeType() {
+        return changeType;
+    }
+
+    public Row getRow() {
+        return row;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        FlussRecord that = (FlussRecord) o;
+        return offset == that.offset
+                && timestamp == that.timestamp
+                && changeType == that.changeType
+                && Objects.equals(row, that.row);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(offset, timestamp, changeType, row);
+    }
+
+    @Override
+    public String toString() {
+        return "FlussRecord{"
+                + "offset="
+                + offset
+                + ", timestamp="
+                + timestamp
+                + ", changeType="
+                + changeType
+                + ", row="
+                + row
+                + '}';
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchema.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchema.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.serdes;
+
+import com.alibaba.fluss.flink.row.FlussRecord;
+
+import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
+
+import java.io.Serializable;
+
+/**
+ * Interface for deserialization schema used to deserialize {@link FlussRecord} objects into
+ * specific data types.
+ *
+ * @param <T> The type created by the deserialization schema.
+ */
+public interface FlussDeserializationSchema<T> extends Serializable, ResultTypeQueryable<T> {
+
+    /**
+     * Deserializes a {@link FlussRecord} into an object of type T.
+     *
+     * @param flussRecord The record to deserialize.
+     * @return The deserialized object.
+     * @throws Exception If the deserialization fails.
+     */
+    T deserialize(FlussRecord flussRecord) throws Exception;
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/helper/Order.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/helper/Order.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.helper;
+
+public class Order {
+    private long orderId;
+    private long itemId;
+    private int amount;
+    private String address;
+
+    public Order() {}
+
+    public Order(long orderId, long itemId, int amount, String address) {
+        this.orderId = orderId;
+        this.itemId = itemId;
+        this.amount = amount;
+        this.address = address;
+    }
+
+    public long getOrderId() {
+        return orderId;
+    }
+
+    public void setOrderId(long orderId) {
+        this.orderId = orderId;
+    }
+
+    public long getItemId() {
+        return itemId;
+    }
+
+    public void setItemId(long itemId) {
+        this.itemId = itemId;
+    }
+
+    public int getAmount() {
+        return amount;
+    }
+
+    public void setAmount(int amount) {
+        this.amount = amount;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    @Override
+    public String toString() {
+        return "Order{"
+                + "order_id="
+                + orderId
+                + ", item_id="
+                + itemId
+                + ", amount="
+                + amount
+                + ", address='"
+                + address
+                + '\''
+                + '}';
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/helper/OrderDeserializationSchema.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/helper/OrderDeserializationSchema.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.helper;
+
+import com.alibaba.fluss.flink.row.FlussRecord;
+import com.alibaba.fluss.flink.serdes.FlussDeserializationSchema;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+
+public class OrderDeserializationSchema implements FlussDeserializationSchema<Order> {
+    @Override
+    public Order deserialize(FlussRecord flussRecord) throws Exception {
+        long orderId = (long) flussRecord.getRow().getField(0);
+        long itemId = (long) flussRecord.getRow().getField(1);
+        int amount = (int) flussRecord.getRow().getField(2);
+        String address = (String) flussRecord.getRow().getField(3);
+
+        return new Order(orderId, itemId, amount, address);
+    }
+
+    @Override
+    public TypeInformation<Order> getProducedType() {
+        return TypeInformation.of(Order.class);
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -82,7 +82,7 @@ public class FlinkRowToPojoTest {
     @Test
     public void testConvertWithExtraFields() {
         // Create a Row with extra fields
-        Row row = new Row(5); // Set arity to 5
+        Row row = new Row(5);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -29,7 +29,7 @@ public class FlinkRowToPojoTest {
     @Test
     public void testConvert() {
         // Create a Row
-        Row row = new Row(5);
+        Row row = new Row(4);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
@@ -46,13 +46,66 @@ public class FlinkRowToPojoTest {
     }
 
     @Test
+    public void testConvertWithNullValues() {
+        // Create a Row with null values
+        Row row = new Row(4);
+        row.setField(0, null);
+        row.setField(1, null);
+        row.setField(2, null);
+        row.setField(3, null);
+
+        // Convert the row to an Order object
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        // Verify the converted object
+        assertThat(order.getOrderId()).isEqualTo(0L);
+        assertThat(order.getItemId()).isEqualTo(0L);
+        assertThat(order.getAmount()).isEqualTo(0);
+        assertThat(order.getAddress()).isNull();
+    }
+
+    @Test
     public void testConvertWithTypeMismatch() {
         // Create a Row with type mismatch
-        Row row = new Row(5);
+        Row row = new Row(4);
         row.setField(0, "1");
         row.setField(1, "100");
         row.setField(2, "5");
         row.setField(3, 123);
+
+        // Verify that an exception is thrown
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error converting Flink Row to POJO");
+    }
+
+    @Test
+    public void testConvertWithExtraFields() {
+        // Create a Row with extra fields
+        Row row = new Row(4);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+        row.setField(4, "extra");
+
+        // Convert the row to an Order object
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        // Verify the converted object
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("123 Test St");
+    }
+
+    @Test
+    public void testConvertWithMissingFields() {
+        // Create a Row with missing fields
+        Row row = new Row(3);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
 
         // Verify that an exception is thrown
         assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -29,7 +29,7 @@ public class FlinkRowToPojoTest {
     @Test
     public void testConvert() {
         // Create a Row
-        Row row = new Row(4);
+        Row row = new Row(5);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
@@ -48,7 +48,7 @@ public class FlinkRowToPojoTest {
     @Test
     public void testConvertWithTypeMismatch() {
         // Create a Row with type mismatch
-        Row row = new Row(4);
+        Row row = new Row(5);
         row.setField(0, "1");
         row.setField(1, "100");
         row.setField(2, "5");

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.row;
+
+import com.alibaba.fluss.flink.helper.Order;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class FlinkRowToPojoTest {
+
+    @Test
+    public void testConvert() {
+        // Create a Row
+        Row row = new Row(4);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+
+        // Convert the row to an Order object
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        // Verify the converted object
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("123 Test St");
+    }
+
+    @Test
+    public void testConvertWithTypeMismatch() {
+        // Create a Row with type mismatch
+        Row row = new Row(4);
+        row.setField(0, "1");
+        row.setField(1, "100");
+        row.setField(2, "5");
+        row.setField(3, 123);
+
+        // Verify that an exception is thrown
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error converting Flink Row to POJO");
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -82,21 +82,18 @@ public class FlinkRowToPojoTest {
     @Test
     public void testConvertWithExtraFields() {
         // Create a Row with extra fields
-        Row row = new Row(4);
+        Row row = new Row(5); // Set arity to 5
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
         row.setField(3, "123 Test St");
         row.setField(4, "extra");
 
-        // Convert the row to an Order object
-        Order order = FlinkRowToPojo.convert(row, Order.class);
-
-        // Verify the converted object
-        assertThat(order.getOrderId()).isEqualTo(1L);
-        assertThat(order.getItemId()).isEqualTo(100L);
-        assertThat(order.getAmount()).isEqualTo(5);
-        assertThat(order.getAddress()).isEqualTo("123 Test St");
+        // Verify that an exception is thrown
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Row arity (5) does not match the number of fields (4) in the POJO class");
     }
 
     @Test
@@ -109,7 +106,8 @@ public class FlinkRowToPojoTest {
 
         // Verify that an exception is thrown
         assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
-                .isInstanceOf(RuntimeException.class)
-                .hasMessageContaining("Error converting Flink Row to POJO");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(
+                        "Row arity (3) does not match the number of fields (4) in the POJO class");
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlinkRowToPojoTest.java
@@ -21,24 +21,25 @@ import com.alibaba.fluss.flink.helper.Order;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class FlinkRowToPojoTest {
 
     @Test
-    public void testConvert() {
-        // Create a Row
+    public void testBasicConversion() {
         Row row = new Row(4);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
         row.setField(3, "123 Test St");
 
-        // Convert the row to an Order object
         Order order = FlinkRowToPojo.convert(row, Order.class);
 
-        // Verify the converted object
         assertThat(order.getOrderId()).isEqualTo(1L);
         assertThat(order.getItemId()).isEqualTo(100L);
         assertThat(order.getAmount()).isEqualTo(5);
@@ -46,68 +47,324 @@ public class FlinkRowToPojoTest {
     }
 
     @Test
-    public void testConvertWithNullValues() {
-        // Create a Row with null values
+    public void testNullValues() {
         Row row = new Row(4);
         row.setField(0, null);
         row.setField(1, null);
         row.setField(2, null);
         row.setField(3, null);
 
-        // Convert the row to an Order object
         Order order = FlinkRowToPojo.convert(row, Order.class);
 
-        // Verify the converted object
-        assertThat(order.getOrderId()).isEqualTo(0L);
-        assertThat(order.getItemId()).isEqualTo(0L);
+        assertThat(order.getOrderId()).isEqualTo(0);
+        assertThat(order.getItemId()).isEqualTo(0);
         assertThat(order.getAmount()).isEqualTo(0);
         assertThat(order.getAddress()).isNull();
     }
 
     @Test
-    public void testConvertWithTypeMismatch() {
-        // Create a Row with type mismatch
-        Row row = new Row(4);
-        row.setField(0, "1");
-        row.setField(1, "100");
-        row.setField(2, "5");
-        row.setField(3, 123);
+    public void testInvalidRowArity() {
+        Row row = new Row(3);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
 
-        // Verify that an exception is thrown
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Row arity (3) does not match");
+    }
+
+    @Test
+    public void testPrimitiveTypeConversions() {
+        Row row = new Row(4);
+        row.setField(0, (byte) 1);
+        row.setField(1, (short) 100);
+        row.setField(2, (float) 5.7);
+        row.setField(3, "Test Address");
+
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("Test Address");
+    }
+
+    @Test
+    public void testNumberTypeConversions() {
+        Row row = new Row(4);
+        row.setField(0, Integer.valueOf(1));
+        row.setField(1, Double.valueOf(100.5));
+        row.setField(2, Long.valueOf(5));
+        row.setField(3, "Test Address");
+
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("Test Address");
+    }
+
+    @Test
+    public void testInvalidTypeConversion() {
+        Row row = new Row(4);
+        row.setField(0, "not a number");
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "Test Address");
+
         assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
                 .isInstanceOf(RuntimeException.class)
                 .hasMessageContaining("Error converting Flink Row to POJO");
     }
 
     @Test
-    public void testConvertWithExtraFields() {
-        // Create a Row with extra fields
-        Row row = new Row(5);
-        row.setField(0, 1L);
-        row.setField(1, 100L);
-        row.setField(2, 5);
-        row.setField(3, "123 Test St");
-        row.setField(4, "extra");
+    public void testBigNumberConversions() {
+        Row row = new Row(4);
+        row.setField(0, java.math.BigInteger.valueOf(1));
+        row.setField(1, java.math.BigDecimal.valueOf(100));
+        row.setField(2, Integer.MAX_VALUE);
+        row.setField(3, "Test Address");
 
-        // Verify that an exception is thrown
-        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(
-                        "Row arity (5) does not match the number of fields (4) in the POJO class");
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(order.getAddress()).isEqualTo("Test Address");
     }
 
     @Test
-    public void testConvertWithMissingFields() {
-        // Create a Row with missing fields
-        Row row = new Row(3);
+    public void testNonAccessibleClassInstantiation() {
+        class InaccessibleOrder {
+            private Long orderId;
+        }
+
+        Row row = new Row(1);
+        row.setField(0, 1L);
+
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, InaccessibleOrder.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error converting Flink Row to POJO");
+    }
+
+    @Test
+    public void testNullRow() {
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(null, Order.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error converting Flink Row to POJO");
+    }
+
+    @Test
+    public void testMaxValues() {
+        Row row = new Row(4);
+        row.setField(0, Long.MAX_VALUE);
+        row.setField(1, Long.MIN_VALUE);
+        row.setField(2, Integer.MAX_VALUE);
+        row.setField(3, "Test Address");
+
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        assertThat(order.getOrderId()).isEqualTo(Long.MAX_VALUE);
+        assertThat(order.getItemId()).isEqualTo(Long.MIN_VALUE);
+        assertThat(order.getAmount()).isEqualTo(Integer.MAX_VALUE);
+        assertThat(order.getAddress()).isEqualTo("Test Address");
+    }
+
+    @Test
+    public void testMissingNoArgsConstructor() {
+        class NoDefaultConstructorOrder {
+            private final Long orderId;
+
+            public NoDefaultConstructorOrder(Long orderId) {
+                this.orderId = orderId;
+            }
+        }
+
+        Row row = new Row(1);
+        row.setField(0, 1L);
+
+        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, NoDefaultConstructorOrder.class))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("Error converting Flink Row to POJO");
+    }
+
+    @Test
+    public void testBinaryStringToStringConversion() {
+        class CustomBinaryString {
+            @Override
+            public String toString() {
+                return "Test Address";
+            }
+
+            // Make sure the class name check works
+            public String getClassName() {
+                return "com.alibaba.fluss.row.BinaryString";
+            }
+        }
+
+        CustomBinaryString binaryString = new CustomBinaryString();
+
+        Row row = new Row(4);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
+        row.setField(3, binaryString);
 
-        // Verify that an exception is thrown
-        assertThatThrownBy(() -> FlinkRowToPojo.convert(row, Order.class))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining(
-                        "Row arity (3) does not match the number of fields (4) in the POJO class");
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        assertThat(order.getAddress()).isEqualTo("Test Address");
+    }
+
+    @Test
+    public void testBooleanConversions() {
+        Row row = new Row(2);
+        row.setField(0, 1); // Should convert to true
+        row.setField(1, "Test");
+
+        BooleanTestPojo booleanPojo = FlinkRowToPojo.convert(row, BooleanTestPojo.class);
+        assertThat(booleanPojo.isActive()).isTrue();
+
+        Row row2 = new Row(2);
+        row2.setField(0, 0); // Should convert to false
+        row2.setField(1, "Test");
+
+        BooleanTestPojo booleanPojo2 = FlinkRowToPojo.convert(row2, BooleanTestPojo.class);
+        assertThat(booleanPojo2.isActive()).isFalse();
+
+        Row row3 = new Row(2);
+        row3.setField(0, "true"); // String "true" to boolean
+        row3.setField(1, "Test");
+
+        BooleanTestPojo booleanPojo3 = FlinkRowToPojo.convert(row3, BooleanTestPojo.class);
+        assertThat(booleanPojo3.isActive()).isTrue();
+    }
+
+    @Test
+    public void testTimestampConversions() {
+        LocalDateTime now = LocalDateTime.now();
+
+        Row row = new Row(3);
+        row.setField(0, now);
+        row.setField(1, 100L);
+        row.setField(2, now.toLocalDate());
+
+        DateTestPojo dateTestPojo = FlinkRowToPojo.convert(row, DateTestPojo.class);
+
+        assertThat(dateTestPojo.getTimestamp()).isNotNull();
+        assertThat(dateTestPojo.getTimestamp().getYear()).isEqualTo(now.getYear());
+        assertThat(dateTestPojo.getLocalDate()).isNotNull();
+    }
+
+    @Test
+    public void testStaticFieldsFiltering() {
+        Row row = new Row(1);
+        row.setField(0, 1L);
+
+        StaticFieldPojo result = FlinkRowToPojo.convert(row, StaticFieldPojo.class);
+        assertThat(result.id).isEqualTo(1L);
+        assertThat(StaticFieldPojo.STATIC_FIELD).isEqualTo("static");
+    }
+
+    @Test
+    public void testLocalDateTimeFromLong() {
+        Row row = new Row(3);
+        long currentTimeMillis = System.currentTimeMillis();
+        row.setField(0, currentTimeMillis); // Long to LocalDateTime
+        row.setField(1, 100L);
+        row.setField(2, LocalDate.now().toString());
+
+        DateTestPojo dateTestPojo = FlinkRowToPojo.convert(row, DateTestPojo.class);
+        assertThat(dateTestPojo.getTimestamp()).isNotNull();
+    }
+
+    @Test
+    public void testDateConversions() {
+        Row row = new Row(3);
+        LocalDateTime now = LocalDateTime.now();
+        row.setField(0, now);
+        row.setField(1, 100L);
+        row.setField(2, "2023-01-01");
+
+        DateTestPojo dateTestPojo = FlinkRowToPojo.convert(row, DateTestPojo.class);
+        assertThat(dateTestPojo.getLocalDate().getYear()).isEqualTo(2023);
+    }
+
+    @Test
+    public void testUtilDateConversion() {
+        Row row = new Row(4);
+        row.setField(0, LocalDateTime.now());
+        row.setField(1, System.currentTimeMillis());
+        row.setField(2, 1L);
+        row.setField(3, LocalDate.now().toString());
+
+        UtilDatePojo utilDatePojo = FlinkRowToPojo.convert(row, UtilDatePojo.class);
+        assertThat(utilDatePojo.getDateFromDateTime()).isNotNull();
+        assertThat(utilDatePojo.getDateFromLong()).isNotNull();
+    }
+
+    // Helper test classes
+    public static class BooleanTestPojo {
+        private boolean active;
+        private String name;
+
+        public boolean isActive() {
+            return active;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+    public static class DateTestPojo {
+        private LocalDateTime timestamp;
+        private Long value;
+        private LocalDate localDate;
+
+        public LocalDateTime getTimestamp() {
+            return timestamp;
+        }
+
+        public Long getValue() {
+            return value;
+        }
+
+        public LocalDate getLocalDate() {
+            return localDate;
+        }
+    }
+
+    public static class StaticFieldPojo {
+        public static final String STATIC_FIELD = "static";
+        private Long id;
+
+        public Long getId() {
+            return id;
+        }
+    }
+
+    public static class UtilDatePojo {
+        private Date dateFromDateTime;
+        private Date dateFromLong;
+        private Long id;
+        private String dateStr;
+
+        public Date getDateFromDateTime() {
+            return dateFromDateTime;
+        }
+
+        public Date getDateFromLong() {
+            return dateFromLong;
+        }
+
+        public Long getId() {
+            return id;
+        }
+
+        public String getDateStr() {
+            return dateStr;
+        }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlussRecordTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlussRecordTest.java
@@ -39,7 +39,7 @@ public class FlussRecordTest {
                 new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row);
 
         // Verify the FlussRecord properties
-        assertThat(flussRecord.logOffset()).isEqualTo(0);
+        assertThat(flussRecord.getOffset()).isEqualTo(0);
         assertThat(flussRecord.getChangeType()).isEqualTo(ChangeType.INSERT);
         assertThat(flussRecord.getRow()).isEqualTo(row);
     }
@@ -59,11 +59,12 @@ public class FlussRecordTest {
         row2.setField(2, 5);
         row2.setField(3, "123 Test St");
 
+        // Use the same timestamp for both records
+        long timestamp = System.currentTimeMillis();
+
         // Create two identical FlussRecords
-        FlussRecord flussRecord1 =
-                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row1);
-        FlussRecord flussRecord2 =
-                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row2);
+        FlussRecord flussRecord1 = new FlussRecord(0, timestamp, ChangeType.INSERT, row1);
+        FlussRecord flussRecord2 = new FlussRecord(0, timestamp, ChangeType.INSERT, row2);
 
         assertThat(flussRecord1).isEqualTo(flussRecord2);
         assertThat(flussRecord1.hashCode()).isEqualTo(flussRecord2.hashCode());

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlussRecordTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/row/FlussRecordTest.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.row;
+
+import com.alibaba.fluss.record.ChangeType;
+
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlussRecordTest {
+
+    @Test
+    public void testFlussRecordCreation() {
+        // Create a Row
+        Row row = new Row(4);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+
+        // Create a FlussRecord
+        FlussRecord flussRecord =
+                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row);
+
+        // Verify the FlussRecord properties
+        assertThat(flussRecord.logOffset()).isEqualTo(0);
+        assertThat(flussRecord.getChangeType()).isEqualTo(ChangeType.INSERT);
+        assertThat(flussRecord.getRow()).isEqualTo(row);
+    }
+
+    @Test
+    public void testFlussRecordEqualsAndHashCode() {
+        // Create two identical Rows
+        Row row1 = new Row(4);
+        row1.setField(0, 1L);
+        row1.setField(1, 100L);
+        row1.setField(2, 5);
+        row1.setField(3, "123 Test St");
+
+        Row row2 = new Row(4);
+        row2.setField(0, 1L);
+        row2.setField(1, 100L);
+        row2.setField(2, 5);
+        row2.setField(3, "123 Test St");
+
+        // Create two identical FlussRecords
+        FlussRecord flussRecord1 =
+                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row1);
+        FlussRecord flussRecord2 =
+                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row2);
+
+        assertThat(flussRecord1).isEqualTo(flussRecord2);
+        assertThat(flussRecord1.hashCode()).isEqualTo(flussRecord2.hashCode());
+    }
+
+    @Test
+    public void testFlussRecordToString() {
+        // Create a Row
+        Row row = new Row(4);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+
+        // Create a FlussRecord
+        FlussRecord flussRecord =
+                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row);
+
+        // Verify the toString method
+        assertThat(flussRecord.toString()).contains("FlussRecord{");
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.serdes;
+
+import com.alibaba.fluss.flink.helper.Order;
+import com.alibaba.fluss.flink.helper.OrderDeserializationSchema;
+import com.alibaba.fluss.flink.row.FlinkRowToPojo;
+import com.alibaba.fluss.flink.row.FlussRecord;
+import com.alibaba.fluss.record.ChangeType;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.types.Row;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FlussDeserializationSchemaTest {
+    @Test
+    public void testDeserialize() throws Exception {
+        // Create a mock FlussRecord from a Row object
+        Row row = new Row(4);
+        row.setField(0, 1L);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+
+        FlussRecord flussRecord =
+                new FlussRecord(0, System.currentTimeMillis(), ChangeType.INSERT, row);
+
+        // Create the deserialization schema
+        OrderDeserializationSchema schema = new OrderDeserializationSchema();
+
+        // Deserialize the record
+        Order order = schema.deserialize(flussRecord);
+
+        // Verify the deserialized object
+        assertThat(order.getOrderId()).isEqualTo(1L);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("123 Test St");
+    }
+
+    @Test
+    public void testGetProducedType() {
+        OrderDeserializationSchema schema = new OrderDeserializationSchema();
+        TypeInformation<Order> typeInfo = schema.getProducedType();
+        assertThat(typeInfo).isEqualTo(TypeInformation.of(Order.class));
+    }
+
+    @Test
+    public void testConvertPojoToOrder() {
+        // Create a Row
+        Row row = new Row(4);
+        row.setField(0, 1);
+        row.setField(1, 100L);
+        row.setField(2, 5);
+        row.setField(3, "123 Test St");
+
+        // Convert the row to an Order object
+        Order order = FlinkRowToPojo.convert(row, Order.class);
+
+        // Verify the converted object
+        assertThat(order.getOrderId()).isEqualTo(1);
+        assertThat(order.getItemId()).isEqualTo(100L);
+        assertThat(order.getAmount()).isEqualTo(5);
+        assertThat(order.getAddress()).isEqualTo("123 Test St");
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
@@ -64,7 +64,7 @@ public class FlussDeserializationSchemaTest {
     @Test
     public void testConvertPojoToOrder() {
         // Create a Row
-        Row row = new Row(4);
+        Row row = new Row(5);
         row.setField(0, 1);
         row.setField(1, 100L);
         row.setField(2, 5);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
@@ -32,7 +32,7 @@ public class FlussDeserializationSchemaTest {
     @Test
     public void testDeserialize() throws Exception {
         // Create a mock FlussRecord from a Row object
-        Row row = new Row(4);
+        Row row = new Row(5);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/serdes/FlussDeserializationSchemaTest.java
@@ -32,7 +32,7 @@ public class FlussDeserializationSchemaTest {
     @Test
     public void testDeserialize() throws Exception {
         // Create a mock FlussRecord from a Row object
-        Row row = new Row(5);
+        Row row = new Row(4);
         row.setField(0, 1L);
         row.setField(1, 100L);
         row.setField(2, 5);
@@ -64,7 +64,7 @@ public class FlussDeserializationSchemaTest {
     @Test
     public void testConvertPojoToOrder() {
         // Create a Row
-        Row row = new Row(5);
+        Row row = new Row(4);
         row.setField(0, 1);
         row.setField(1, 100L);
         row.setField(2, 5);


### PR DESCRIPTION
This PR introduces:
- [x] a new FlussRecord to be used from the FlussSource
- [x] a FlussDeserializationSchema to be used from the FlussSource
- [x] some helper utils
