### PR TITLE
646: Provided wrapper for histogram

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/metrics/FlinkHistogram.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/metrics/FlinkHistogram.java
@@ -23,9 +23,11 @@ import org.apache.flink.metrics.HistogramStatistics;
 public class FlinkHistogram implements Histogram {
 
     private final com.alibaba.fluss.metrics.Histogram wrapped;
+    private final FlinkHistogramStatistics statistics;
 
     public FlinkHistogram(com.alibaba.fluss.metrics.Histogram wrapped) {
         this.wrapped = wrapped;
+        this.statistics = new FlinkHistogramStatistics(wrapped.getStatistics());
     }
 
     @Override
@@ -40,10 +42,7 @@ public class FlinkHistogram implements Histogram {
 
     @Override
     public HistogramStatistics getStatistics() {
-
-        wrapped.getStatistics();
-
-        return null;
+        return statistics;
     }
 
     private static class FlinkHistogramStatistics extends HistogramStatistics {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkCounterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkCounterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.metrics;
+
+import com.alibaba.fluss.metrics.Counter;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.Mockito.mock;
+
+class FlinkCounterTest extends WrapperMetricsTestSuite<Counter, FlinkCounter> {
+
+    private FlinkCounter flinkCounter;
+    private Counter counter;
+
+    @BeforeEach
+    void setUp() {
+        counter = mock(Counter.class);
+        flinkCounter = new FlinkCounter(counter);
+    }
+
+    @Override
+    protected Counter getWrappedMetricInstance() throws Exception {
+        return counter;
+    }
+
+    @Override
+    protected FlinkCounter getMetricInstance() throws Exception {
+        return flinkCounter;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkHistogramStatisticsTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkHistogramStatisticsTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.metrics;
+
+import com.alibaba.fluss.metrics.Histogram;
+
+import org.apache.flink.metrics.HistogramStatistics;
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class FlinkHistogramStatisticsTest
+        extends WrapperMetricsTestSuite<
+                com.alibaba.fluss.metrics.HistogramStatistics, HistogramStatistics> {
+
+    private com.alibaba.fluss.metrics.HistogramStatistics wrapped;
+    private HistogramStatistics wrapper;
+
+    @BeforeEach
+    void setUp() {
+        Histogram histogram = mock(Histogram.class);
+        wrapped = mock(com.alibaba.fluss.metrics.HistogramStatistics.class);
+        when(histogram.getStatistics()).thenReturn(wrapped);
+
+        wrapper = new FlinkHistogram(histogram).getStatistics();
+    }
+
+    @Override
+    protected com.alibaba.fluss.metrics.HistogramStatistics getWrappedMetricInstance()
+            throws Exception {
+        return wrapped;
+    }
+
+    @Override
+    protected HistogramStatistics getMetricInstance() throws Exception {
+        return wrapper;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkHistogramTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkHistogramTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.metrics;
+
+import com.alibaba.fluss.metrics.Histogram;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.Mockito.mock;
+
+public class FlinkHistogramTest extends WrapperMetricsTestSuite<Histogram, FlinkHistogram> {
+
+    private FlinkHistogram flinkHistogram;
+    private Histogram histogram;
+
+    @BeforeEach
+    void setUp() {
+        histogram = mock(Histogram.class);
+        flinkHistogram = new FlinkHistogram(histogram);
+    }
+
+    @Override
+    protected Histogram getWrappedMetricInstance() throws Exception {
+        return histogram;
+    }
+
+    @Override
+    protected FlinkHistogram getMetricInstance() throws Exception {
+        return flinkHistogram;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMeterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMeterTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.metrics;
+
+import com.alibaba.fluss.metrics.Meter;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.mockito.Mockito.mock;
+
+public class FlinkMeterTest extends WrapperMetricsTestSuite<Meter, FlinkMeter> {
+
+    private FlinkMeter flinkMeter;
+    private Meter meter;
+
+    @BeforeEach
+    void setUp() {
+        meter = mock(Meter.class);
+        flinkMeter = new FlinkMeter(meter);
+    }
+
+    @Override
+    protected Meter getWrappedMetricInstance() throws Exception {
+        return meter;
+    }
+
+    @Override
+    protected FlinkMeter getMetricInstance() throws Exception {
+        return flinkMeter;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/WrapperMetricsTestSuite.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/WrapperMetricsTestSuite.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.metrics;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockingDetails;
+import org.mockito.invocation.Invocation;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+import static org.mockito.Mockito.mockingDetails;
+
+public abstract class WrapperMetricsTestSuite<T, E> {
+
+    @Test
+    void testPublicMethods() throws Exception {
+        T wrapped = getWrappedMetricInstance();
+
+        E object = getMetricInstance();
+
+        Method[] methods = object.getClass().getMethods();
+
+        for (Method method : methods) {
+            if (method.getDeclaringClass().equals(object.getClass())) {
+                Object[] arguments = createParams(method);
+                method.invoke(object, arguments);
+                MockingDetails mockingDetails = mockingDetails(wrapped);
+
+                boolean invoked =
+                        mockingDetails.getInvocations().stream()
+                                .anyMatch(iv -> invocationFilter(method, arguments, iv));
+
+                Assertions.assertThat(invoked).isTrue();
+            }
+        }
+    }
+
+    private static boolean invocationFilter(Method method, Object[] arguments, Invocation iv) {
+        return Arrays.equals(arguments, iv.getArguments())
+                && iv.getMethod().getName().equals(method.getName());
+    }
+
+    private static Object[] createParams(Method method) {
+        Object[] params = new Object[] {};
+        if (method.getParameterTypes().length > 0) {
+            if (method.getParameterTypes()[0].equals(double.class)) {
+                params = new Object[] {0.0d};
+            } else {
+                params = new Object[] {0L};
+            }
+        }
+        return params;
+    }
+
+    protected abstract T getWrappedMetricInstance() throws Exception;
+
+    protected abstract E getMetricInstance() throws Exception;
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #646

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Increased coverage for `FlinkCounter`, `FlinkGauge`, `FlinkHistogram`, `FlinkHistogramStatistics`, `FlinkMeter`.

### Tests

<!-- List UT and IT cases to verify this change -->
`FlinkCounterTest`, `FlinkHistogramStatisticsTest`, `FlinkHistogramTest`, `FlinkMeterTest`, `FlinkMetricsITCase`
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
I initially went for the direction of increasing the coverage through FlinkMetricsITCase, 
Yet could not find ways to invoke the creation of `Counter` or the methods missing coverage from the other metric classes.

I went to implement tests per metric.

One option was to test each class and verify invocations, for example:

```bash
        Counter counter = mock(Counter.class);
        FlinkCounter flinkCounter = new FlinkCounter(counter);
        flinkCounter.inc();
        verify(counter, times(1)).inc();
        flinkCounter.inc(1);
        verify(counter, times(1)).inc(1);
```

Since those classes are wrapper classes (`FlinkCounter`, `FlinkGauge` `FlinkHistogram` `FlinkMeter`) I proceeded on testing their proxy behaviour.
I created WrapperMetricsTestSuite which lists all the public methods expected to be proxied and invokes those methods.
Onwards it checks if the underlying wrapped metric instance has been invoked for the corresponding method.

The FlinkHistogramStatistics class was not used.
I proceeded to create an instances of it during the initialization of FlinkHistogram, thus wrapping the original statistics instance.
Whenever `FlinkHistogram.getStatistics` is called it returns back the Wrapper instance of `FlinkHistogramStatistics`.

