### PR TITLE
[server] Fix CorruptIndexException for cached remote log index

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/exception/CorruptIndexException.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/exception/CorruptIndexException.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.exception;
+package com.alibaba.fluss.server.exception;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
 
@@ -25,7 +25,7 @@ import com.alibaba.fluss.annotation.PublicEvolving;
  * @since 0.1
  */
 @PublicEvolving
-public class CorruptIndexException extends RetriableException {
+public class CorruptIndexException extends RuntimeException {
     public CorruptIndexException(String message) {
         super(message);
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/AbstractIndex.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/AbstractIndex.java
@@ -16,8 +16,8 @@
 
 package com.alibaba.fluss.server.log;
 
-import com.alibaba.fluss.exception.CorruptIndexException;
 import com.alibaba.fluss.exception.IndexOffsetOverflowException;
+import com.alibaba.fluss.server.exception.CorruptIndexException;
 import com.alibaba.fluss.utils.FileUtils;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.OperatingSystem;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/OffsetIndex.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/OffsetIndex.java
@@ -16,9 +16,9 @@
 
 package com.alibaba.fluss.server.log;
 
-import com.alibaba.fluss.exception.CorruptIndexException;
 import com.alibaba.fluss.exception.IndexOffsetOverflowException;
 import com.alibaba.fluss.exception.InvalidOffsetException;
+import com.alibaba.fluss.server.exception.CorruptIndexException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/TimeIndex.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/TimeIndex.java
@@ -16,8 +16,8 @@
 
 package com.alibaba.fluss.server.log;
 
-import com.alibaba.fluss.exception.CorruptIndexException;
 import com.alibaba.fluss.exception.InvalidOffsetException;
+import com.alibaba.fluss.server.exception.CorruptIndexException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogIndexCache.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/RemoteLogIndexCache.java
@@ -17,10 +17,10 @@
 package com.alibaba.fluss.server.log.remote;
 
 import com.alibaba.fluss.annotation.VisibleForTesting;
-import com.alibaba.fluss.exception.CorruptIndexException;
 import com.alibaba.fluss.exception.FlussRuntimeException;
 import com.alibaba.fluss.exception.RemoteStorageException;
 import com.alibaba.fluss.remote.RemoteLogSegment;
+import com.alibaba.fluss.server.exception.CorruptIndexException;
 import com.alibaba.fluss.server.log.OffsetIndex;
 import com.alibaba.fluss.server.log.OffsetPosition;
 import com.alibaba.fluss.server.log.StorageAction;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/log/TimeIndexTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/log/TimeIndexTest.java
@@ -16,8 +16,8 @@
 
 package com.alibaba.fluss.server.log;
 
-import com.alibaba.fluss.exception.CorruptIndexException;
 import com.alibaba.fluss.exception.InvalidOffsetException;
+import com.alibaba.fluss.server.exception.CorruptIndexException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #561

<!-- What is the purpose of the change -->
To fix the `CorruptIndexException` thrown by tablet server.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Catch `CorruptIndexException` of `RemoteLogIndexCache`, and delete the corrupt index.

### Tests

<!-- List UT and IT cases to verify this change -->
`RemoteLogIndexCacheTest#testInitWithCorruptIndex`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
