### PR TITLE
[server/kv] Fix KvTablet can't restore when a snapshot is discarded

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/fs/utils/FileDownloadUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/fs/utils/FileDownloadUtils.java
@@ -69,7 +69,7 @@ public class FileDownloadUtils {
                     transferDataToDirectoryAsync(fileDownloadSpecs, internalCloser, executorService)
                             .collect(Collectors.toList());
             // Wait until either all futures completed successfully or one failed exceptionally.
-            FutureUtils.completeAll(futures, new DownloadProgressAction(fileDownloadSpecs.size()))
+            FutureUtils.waitForAll(futures, new DownloadProgressAction(fileDownloadSpecs.size()))
                     .get();
         } catch (Exception e) {
             fileDownloadSpecs.stream()

--- a/fluss-common/src/main/java/com/alibaba/fluss/fs/utils/FileDownloadUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/fs/utils/FileDownloadUtils.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -64,14 +65,16 @@ public class FileDownloadUtils {
         CloseableRegistry internalCloser = new CloseableRegistry();
         // Make sure we also react to external close signals.
         closeableRegistry.registerCloseable(internalCloser);
+        List<CompletableFuture<Long>> futures = new ArrayList<>();
         try {
-            List<CompletableFuture<Long>> futures =
+            futures =
                     transferDataToDirectoryAsync(fileDownloadSpecs, internalCloser, executorService)
                             .collect(Collectors.toList());
             // Wait until either all futures completed successfully or one failed exceptionally.
             FutureUtils.waitForAll(futures, new DownloadProgressAction(fileDownloadSpecs.size()))
                     .get();
         } catch (Exception e) {
+            futures.forEach(future -> future.cancel(true));
             fileDownloadSpecs.stream()
                     .map(FileDownloadSpec::getTargetDirectory)
                     .map(Path::toFile)

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachine.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachine.java
@@ -339,10 +339,20 @@ public class ReplicaStateMachine {
     }
 
     private String stringifyReplica(TableBucketReplica replica) {
-        return String.format(
-                "TableBucketReplica{tableBucket=%s, replica=%d, tablePath=%s}",
-                replica.getTableBucket(),
-                replica.getReplica(),
-                coordinatorContext.getTablePathById(replica.getTableBucket().getTableId()));
+        TableBucket tableBucket = replica.getTableBucket();
+        if (tableBucket.getPartitionId() == null) {
+            return String.format(
+                    "TableBucketReplica{tableBucket=%s, replica=%d, tablePath=%s}",
+                    tableBucket,
+                    replica.getReplica(),
+                    coordinatorContext.getTablePathById(tableBucket.getTableId()));
+        } else {
+            return String.format(
+                    "TableBucketReplica{tableBucket=%s, replica=%d, tablePath=%s, partition=%s}",
+                    tableBucket,
+                    replica.getReplica(),
+                    coordinatorContext.getTablePathById(replica.getTableBucket().getTableId()),
+                    coordinatorContext.getPartitionName(tableBucket.getPartitionId()));
+        }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/TableBucketStateMachine.java
@@ -379,11 +379,21 @@ public class TableBucketStateMachine {
     }
 
     private String stringifyBucket(TableBucket tableBucket) {
-        return String.format(
-                "TableBucket{tableId=%d, bucket=%d, tablePath=%s}",
-                tableBucket.getTableId(),
-                tableBucket.getBucket(),
-                coordinatorContext.getTablePathById(tableBucket.getTableId()));
+        if (tableBucket.getPartitionId() == null) {
+            return String.format(
+                    "TableBucket{tableId=%d, bucket=%d, tablePath=%s}",
+                    tableBucket.getTableId(),
+                    tableBucket.getBucket(),
+                    coordinatorContext.getTablePathById(tableBucket.getTableId()));
+        } else {
+            return String.format(
+                    "TableBucket{tableId=%d, partitionId=%d, bucket=%d, tablePath=%s, partition=%s}",
+                    tableBucket.getTableId(),
+                    tableBucket.getPartitionId(),
+                    tableBucket.getBucket(),
+                    coordinatorContext.getTablePathById(tableBucket.getTableId()),
+                    coordinatorContext.getPartitionName(tableBucket.getPartitionId()));
+        }
     }
 
     /**

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
@@ -236,11 +236,11 @@ public class PeriodicSnapshotManager implements Closeable {
                                             "TableBucket {} snapshot finished successfully, cost {} ms.",
                                             tableBucket,
                                             System.currentTimeMillis() - triggerTime);
-                                } catch (Exception e) {
+                                } catch (Throwable t) {
                                     LOG.warn(
                                             "Fail to handle snapshot result during snapshot of TableBucket {}",
                                             tableBucket,
-                                            e);
+                                            t);
                                 }
                                 scheduleNextSnapshot();
                             } else {
@@ -339,7 +339,7 @@ public class PeriodicSnapshotManager implements Closeable {
                 int bucketLeaderEpoch,
                 SnapshotLocation snapshotLocation,
                 SnapshotResult snapshotResult)
-                throws Exception;
+                throws Throwable;
 
         /** Called when the snapshot is fail. */
         void handleSnapshotFailure(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PlaceholderKvFileHandler.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/kv/snapshot/PlaceholderKvFileHandler.java
@@ -27,4 +27,9 @@ public class PlaceholderKvFileHandler extends KvFileHandle {
     public PlaceholderKvFileHandler(KvFileHandle kvFileHandle) {
         super(kvFileHandle.getFilePath(), kvFileHandle.getSize());
     }
+
+    @Override
+    public void discard() throws Exception {
+        // do nothing
+    }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -369,8 +369,8 @@ public final class Replica {
                             int requestLeaderEpoch = data.getLeaderEpoch();
                             if (requestLeaderEpoch > leaderEpoch) {
                                 leaderEpoch = requestLeaderEpoch;
-                                leaderReplicaIdOpt.set(localTabletServerId);
                                 onBecomeNewLeader();
+                                leaderReplicaIdOpt.set(localTabletServerId);
                                 LOG.info(
                                         "TabletServer {} becomes leader for bucket {}",
                                         localTabletServerId,

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -368,9 +368,9 @@ public final class Replica {
 
                             int requestLeaderEpoch = data.getLeaderEpoch();
                             if (requestLeaderEpoch > leaderEpoch) {
-                                onBecomeNewLeader();
                                 leaderEpoch = requestLeaderEpoch;
                                 leaderReplicaIdOpt.set(localTabletServerId);
+                                onBecomeNewLeader();
                                 LOG.info(
                                         "TabletServer {} becomes leader for bucket {}",
                                         localTabletServerId,

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/StopReplicaITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/StopReplicaITCase.java
@@ -158,12 +158,8 @@ public class StopReplicaITCase {
                 // wait the replica become leader, so that we can get the kv tablet
                 Replica kvReplica =
                         FLUSS_CLUSTER_EXTENSION.waitAndGetLeaderReplica(replica.getTableBucket());
-                retry(
-                        Duration.ofMinutes(1),
-                        () -> {
-                            assertThat(kvReplica.getKvTablet()).isNotNull();
-                            assertThat(kvReplica.getKvTablet().getKvTabletDir()).exists();
-                        });
+                assertThat(kvReplica.getKvTablet()).isNotNull();
+                assertThat(kvReplica.getKvTablet().getKvTabletDir()).exists();
             }
         }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/StopReplicaITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/StopReplicaITCase.java
@@ -156,9 +156,14 @@ public class StopReplicaITCase {
             assertThat(replica.getLogTablet().getLogDir()).exists();
             if (isKvTable) {
                 // wait the replica become leader, so that we can get the kv tablet
-                replica = FLUSS_CLUSTER_EXTENSION.waitAndGetLeaderReplica(replica.getTableBucket());
-                assertThat(replica.getKvTablet()).isNotNull();
-                assertThat(replica.getKvTablet().getKvTabletDir()).exists();
+                Replica kvReplica =
+                        FLUSS_CLUSTER_EXTENSION.waitAndGetLeaderReplica(replica.getTableBucket());
+                retry(
+                        Duration.ofMinutes(1),
+                        () -> {
+                            assertThat(kvReplica.getKvTablet()).isNotNull();
+                            assertThat(kvReplica.getKvTablet().getKvTabletDir()).exists();
+                        });
             }
         }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/RocksIncrementalSnapshotTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/kv/snapshot/RocksIncrementalSnapshotTest.java
@@ -128,6 +128,22 @@ class RocksIncrementalSnapshotTest {
                 assertThat(rocksDBKv.get("key2".getBytes())).isEqualTo("val2".getBytes());
                 assertThat(rocksDBKv.get("key3".getBytes())).isEqualTo("val3".getBytes());
             }
+
+            // write some data again
+            rocksDB.put("key3".getBytes(), "val3_1".getBytes());
+            KvSnapshotHandle kvSnapshotHandle5 =
+                    snapshot(5L, incrementalSnapshot, snapshotLocation, closeableRegistry);
+            // discard the snapshot handle
+            kvSnapshotHandle5.discard();
+
+            // we can still restore from cp4
+            Path dest3 = snapshotDownDir.resolve("restore3");
+            try (RocksDBKv rocksDBKv =
+                    KvTestUtils.buildFromSnapshotHandle(kvSnapshotHandle4, dest3)) {
+                assertThat(rocksDBKv.get("key1".getBytes())).isEqualTo("val1".getBytes());
+                assertThat(rocksDBKv.get("key2".getBytes())).isEqualTo("val2".getBytes());
+                assertThat(rocksDBKv.get("key3".getBytes())).isEqualTo("val3".getBytes());
+            }
         }
     }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
@@ -101,7 +101,13 @@ final class ReplicaTest extends ReplicaTestBase {
         assertThat(kvReplica.getLogTablet()).isNotNull();
         makeKvReplicaAsLeader(kvReplica);
         assertThat(kvReplica.getLogTablet()).isNotNull();
-        // TODO get kv is true.
+        assertThat(kvReplica.getKvTablet()).isNotNull();
+
+        // make as leader with leader epoch change
+        int expectedLeaderEpoch = 1;
+        makeKvReplicaAsLeader(kvReplica, expectedLeaderEpoch);
+        assertThat(kvReplica.getLeaderEpoch()).isEqualTo(expectedLeaderEpoch);
+        assertThat(kvReplica.getLogTablet()).isNotNull();
         assertThat(kvReplica.getKvTablet()).isNotNull();
     }
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTest.java
@@ -52,6 +52,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import static com.alibaba.fluss.compression.ArrowCompressionInfo.DEFAULT_COMPRESSION;
 import static com.alibaba.fluss.record.LogRecordBatch.NO_BATCH_SEQUENCE;
@@ -100,13 +102,6 @@ final class ReplicaTest extends ReplicaTestBase {
         assertThat(kvReplica.isKvTable()).isTrue();
         assertThat(kvReplica.getLogTablet()).isNotNull();
         makeKvReplicaAsLeader(kvReplica);
-        assertThat(kvReplica.getLogTablet()).isNotNull();
-        assertThat(kvReplica.getKvTablet()).isNotNull();
-
-        // make as leader with leader epoch change
-        int expectedLeaderEpoch = 1;
-        makeKvReplicaAsLeader(kvReplica, expectedLeaderEpoch);
-        assertThat(kvReplica.getLeaderEpoch()).isEqualTo(expectedLeaderEpoch);
         assertThat(kvReplica.getLogTablet()).isNotNull();
         assertThat(kvReplica.getKvTablet()).isNotNull();
     }
@@ -317,7 +312,7 @@ final class ReplicaTest extends ReplicaTestBase {
 
         // create test context
         TestSnapshotContext testKvSnapshotContext =
-                new TestSnapshotContext(tableBucket, snapshotKvTabletDir.getPath());
+                new TestSnapshotContext(snapshotKvTabletDir.getPath());
         ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
                 testKvSnapshotContext.scheduledExecutorService;
         TestingCompletedKvSnapshotCommitter kvSnapshotStore =
@@ -377,8 +372,7 @@ final class ReplicaTest extends ReplicaTestBase {
 
         // make a new kv replica
         testKvSnapshotContext =
-                new TestSnapshotContext(
-                        tableBucket, snapshotKvTabletDir.getPath(), kvSnapshotStore);
+                new TestSnapshotContext(snapshotKvTabletDir.getPath(), kvSnapshotStore);
         kvReplica = makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket, testKvSnapshotContext);
         scheduledExecutorService = testKvSnapshotContext.scheduledExecutorService;
         kvSnapshotStore = testKvSnapshotContext.testKvSnapshotStore;
@@ -412,10 +406,43 @@ final class ReplicaTest extends ReplicaTestBase {
     }
 
     @Test
+    void testSnapshotUseLatestLeaderEpoch(@TempDir File snapshotKvTabletDir) throws Exception {
+        TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID_PK, 1);
+        // create test context
+        ImmediateTriggeredScheduledExecutorService immediateTriggeredScheduledExecutorService =
+                new ImmediateTriggeredScheduledExecutorService();
+        TestSnapshotContext testKvSnapshotContext =
+                new TestSnapshotContext(
+                        snapshotKvTabletDir.getPath(), immediateTriggeredScheduledExecutorService);
+        TestingCompletedKvSnapshotCommitter kvSnapshotStore =
+                testKvSnapshotContext.testKvSnapshotStore;
+
+        // make a kv replica
+        Replica kvReplica =
+                makeKvReplica(DATA1_PHYSICAL_TABLE_PATH_PK, tableBucket, testKvSnapshotContext);
+        // now, make the replica as leader
+        makeKvReplicaAsLeader(kvReplica, 0);
+        KvRecordBatch kvRecords =
+                genKvRecordBatch(
+                        Tuple2.of("k1", new Object[] {1, "a"}),
+                        Tuple2.of("k2", new Object[] {2, "b"}));
+        putRecordsToLeader(kvReplica, kvRecords);
+
+        // make leader again with a new epoch, check the snapshot should use the new epoch
+        immediateTriggeredScheduledExecutorService.reset();
+        int latestLeaderEpoch = 1;
+        int snapshot = 0;
+        makeKvReplicaAsLeader(kvReplica, latestLeaderEpoch);
+        kvSnapshotStore.waitUtilSnapshotComplete(tableBucket, snapshot);
+        assertThat(kvSnapshotStore.getSnapshotLeaderEpoch(tableBucket, snapshot))
+                .isEqualTo(latestLeaderEpoch);
+    }
+
+    @Test
     void testRestore(@TempDir Path snapshotKvTabletDirPath) throws Exception {
         TableBucket tableBucket = new TableBucket(DATA1_TABLE_ID_PK, 1);
         TestSnapshotContext testKvSnapshotContext =
-                new TestSnapshotContext(tableBucket, snapshotKvTabletDirPath.toString());
+                new TestSnapshotContext(snapshotKvTabletDirPath.toString());
         ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
                 testKvSnapshotContext.scheduledExecutorService;
         TestingCompletedKvSnapshotCommitter kvSnapshotStore =
@@ -574,5 +601,28 @@ final class ReplicaTest extends ReplicaTestBase {
             expectValues.add(expectedKeyValue.f1);
         }
         assertThat(kvTablet.multiGet(keys)).containsExactlyElementsOf(expectValues);
+    }
+
+    /** A scheduledExecutorService that will execute the scheduled task immediately. */
+    private static class ImmediateTriggeredScheduledExecutorService
+            extends ManuallyTriggeredScheduledExecutorService {
+        private boolean isScheduled = false;
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            // we only schedule task for once, if has scheduled, return null to skip schedule
+            // the task
+            if (isScheduled) {
+                return null;
+            }
+            isScheduled = true;
+            ScheduledFuture<?> scheduledFuture = super.schedule(command, delay, unit);
+            triggerNonPeriodicScheduledTask();
+            return scheduledFuture;
+        }
+
+        public void reset() {
+            isScheduled = false;
+        }
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -423,8 +423,7 @@ public class ReplicaTestBase {
             throws Exception {
         if (snapshotContext == null) {
             snapshotContext =
-                    new TestSnapshotContext(
-                            tableBucket, conf.getString(ConfigOptions.REMOTE_DATA_DIR));
+                    new TestSnapshotContext(conf.getString(ConfigOptions.REMOTE_DATA_DIR));
         }
         BucketMetricGroup metricGroup =
                 replicaManager
@@ -531,25 +530,44 @@ public class ReplicaTestBase {
     protected class TestSnapshotContext implements SnapshotContext {
 
         private final FsPath remoteKvTabletDir;
-        protected final ManuallyTriggeredScheduledExecutorService scheduledExecutorService =
-                new ManuallyTriggeredScheduledExecutorService();
+        protected ManuallyTriggeredScheduledExecutorService scheduledExecutorService;
         protected final TestingCompletedKvSnapshotCommitter testKvSnapshotStore;
         private final ExecutorService executorService;
 
         public TestSnapshotContext(
-                TableBucket tableBucket,
+                String remoteKvTabletDir, TestingCompletedKvSnapshotCommitter testKvSnapshotStore)
+                throws Exception {
+            this(
+                    remoteKvTabletDir,
+                    testKvSnapshotStore,
+                    new ManuallyTriggeredScheduledExecutorService());
+        }
+
+        public TestSnapshotContext(String remoteKvTabletDir) throws Exception {
+            this(remoteKvTabletDir, new TestingCompletedKvSnapshotCommitter());
+        }
+
+        public TestSnapshotContext(
                 String remoteKvTabletDir,
-                TestingCompletedKvSnapshotCommitter testKvSnapshotStore)
+                ManuallyTriggeredScheduledExecutorService manuallyTriggeredScheduledExecutorService)
+                throws Exception {
+            this(
+                    remoteKvTabletDir,
+                    new TestingCompletedKvSnapshotCommitter(),
+                    manuallyTriggeredScheduledExecutorService);
+        }
+
+        private TestSnapshotContext(
+                String remoteKvTabletDir,
+                TestingCompletedKvSnapshotCommitter testKvSnapshotStore,
+                ManuallyTriggeredScheduledExecutorService manuallyTriggeredScheduledExecutorService)
                 throws Exception {
             this.remoteKvTabletDir = new FsPath(remoteKvTabletDir);
             this.testKvSnapshotStore = testKvSnapshotStore;
             this.executorService = Executors.newFixedThreadPool(1);
-            closeableRegistry.registerCloseable(scheduledExecutorService::shutdownNow);
-        }
-
-        public TestSnapshotContext(TableBucket tableBucket, String remoteKvTabletDir)
-                throws Exception {
-            this(tableBucket, remoteKvTabletDir, new TestingCompletedKvSnapshotCommitter());
+            this.scheduledExecutorService = manuallyTriggeredScheduledExecutorService;
+            closeableRegistry.registerCloseable(
+                    manuallyTriggeredScheduledExecutorService::shutdownNow);
         }
 
         @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #543

<!-- What is the purpose of the change -->
To fix the issue that  KvTablet can't restore when a snapshot is discarded

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
When the `KvFileHandler` is instance of `PlaceholderKvFileHandler`, shoudn't delete the file in method `discard`.  Flink Flink either doesn't delete for `PlaceholderState`.

### Tests

<!-- List UT and IT cases to verify this change -->
The added code in `RocksIncrementalSnapshotTest#testIncrementalSnapshot` will try to discard new snapshot with `PlaceholderKvFileHandler` and restore from previous snapshot. 


### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
