### PR TITLE
[hotfix] remove redundant "wait" for CompletableFuture

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
@@ -456,7 +456,7 @@ public final class LogTablet {
         if (remoteLogEndOffset > this.remoteLogEndOffset) {
             this.remoteLogEndOffset = remoteLogEndOffset;
 
-            // try to delete these segments already exists in remote storage.
+            // try to delete these segments already exist in remote storage.
             deleteSegmentsAlreadyExistsInRemote();
         }
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
@@ -456,7 +456,7 @@ public final class LogTablet {
         if (remoteLogEndOffset > this.remoteLogEndOffset) {
             this.remoteLogEndOffset = remoteLogEndOffset;
 
-            // try to delete these segments already exits in remote storage.
+            // try to delete these segments already exists in remote storage.
             deleteSegmentsAlreadyExistsInRemote();
         }
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/DefaultRemoteLogStorage.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/remote/DefaultRemoteLogStorage.java
@@ -105,9 +105,6 @@ public class DefaultRemoteLogStorage implements RemoteLogStorage {
             List<CompletableFuture<Void>> futures =
                     createUploadFutures(remoteLogSegment, logSegmentFiles);
             FutureUtils.waitForAll(futures).get();
-            for (CompletableFuture<Void> future : futures) {
-                future.get();
-            }
         } catch (ExecutionException e) {
             Throwable throwable = ExceptionUtils.stripExecutionException(e);
             throwable = ExceptionUtils.stripException(throwable, RuntimeException.class);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

Remove unnecessary code in `DefaultRemoteLogStorage`

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Remove redundant `CompletableFuture.get()` in `DefaultRemoteLogStorage`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
