### PR TITLE
[coordinator] Send notifyOffset request to all followers instead of in-sync-followers

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorContext.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorContext.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -271,6 +272,13 @@ public class CoordinatorContext {
         } else {
             return Collections.emptyList();
         }
+    }
+
+    public List<Integer> getFollowers(TableBucket tableBucket, Integer leaderReplica) {
+        List<Integer> replicas = new ArrayList<>(getAssignment(tableBucket));
+        // remove leaderReplica
+        replicas.remove(leaderReplica);
+        return replicas;
     }
 
     public Map<TableBucket, BucketState> getBucketStates() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -896,7 +896,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
                         leaderAndIsr ->
                                 coordinatorRequestBatch
                                         .addNotifyKvSnapshotOffsetRequestForTabletServers(
-                                                leaderAndIsr.followers(),
+                                                coordinatorContext.getFollowers(
+                                                        tb, leaderAndIsr.leader()),
                                                 tb,
                                                 completedSnapshot.getLogOffset()));
         coordinatorRequestBatch.sendNotifyKvSnapshotOffsetRequest(
@@ -934,7 +935,8 @@ public class CoordinatorEventProcessor implements EventProcessor {
                         leaderAndIsr ->
                                 coordinatorRequestBatch
                                         .addNotifyRemoteLogOffsetsRequestForTabletServers(
-                                                leaderAndIsr.followers(),
+                                                coordinatorContext.getFollowers(
+                                                        tb, leaderAndIsr.leader()),
                                                 tb,
                                                 manifestData.getRemoteLogStartOffset(),
                                                 manifestData.getRemoteLogEndOffset()));
@@ -988,7 +990,9 @@ public class CoordinatorEventProcessor implements EventProcessor {
                                 leaderAndIsr ->
                                         coordinatorRequestBatch
                                                 .addNotifyLakeTableOffsetRequestForTableServers(
-                                                        leaderAndIsr.isr(), tb, lakeTableSnapshot));
+                                                        coordinatorContext.getAssignment(tb),
+                                                        tb,
+                                                        lakeTableSnapshot));
             }
         }
         coordinatorRequestBatch.sendNotifyLakeTableOffsetRequest(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/LeaderAndIsr.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/LeaderAndIsr.java
@@ -19,7 +19,6 @@ package com.alibaba.fluss.server.zk.data;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 
@@ -87,10 +86,6 @@ public class LeaderAndIsr {
 
     public int[] isrArray() {
         return isr.stream().mapToInt(Integer::intValue).toArray();
-    }
-
-    public List<Integer> followers() {
-        return isr.stream().filter(i -> i != leader).collect(Collectors.toList());
     }
 
     public int bucketEpoch() {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
@@ -291,13 +291,17 @@ public class TestTabletServerGateway implements TabletServerGateway {
     @Override
     public CompletableFuture<NotifyRemoteLogOffsetsResponse> notifyRemoteLogOffsets(
             NotifyRemoteLogOffsetsRequest request) {
-        throw new UnsupportedOperationException();
+        CompletableFuture<NotifyRemoteLogOffsetsResponse> response = new CompletableFuture<>();
+        requests.add(Tuple2.of(request, response));
+        return response;
     }
 
     @Override
     public CompletableFuture<NotifyKvSnapshotOffsetResponse> notifyKvSnapshotOffset(
             NotifyKvSnapshotOffsetRequest request) {
-        throw new UnsupportedOperationException();
+        CompletableFuture<NotifyKvSnapshotOffsetResponse> response = new CompletableFuture<>();
+        requests.add(Tuple2.of(request, response));
+        return response;
     }
 
     @Override


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #623 

<!-- What is the purpose of the change -->
To enable out of sync replica to clean logs that has been uploaded.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Send to all the followers instead the follower in isr the offset notification.

### Tests
Added test `testNotifyOffsetsWithShrinkISR`

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
