### PR TITLE
[client] Fix Sender maybe block forever error if inflightBatchSize in IdempotenceManager exceed maxInflightRequestsPerBucket

### DIFF
--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
@@ -306,6 +306,10 @@ public class TestTabletServerGateway implements TabletServerGateway {
         throw new UnsupportedOperationException();
     }
 
+    public int pendingRequestSize() {
+        return requests.size();
+    }
+
     public ApiMessage getRequest(int index) {
         if (requests.isEmpty()) {
             throw new IllegalStateException("No requests pending for inbound response.");


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #655 

<!-- What is the purpose of the change -->

This pr is aims to fix `Sender` maybe block forever error if `inflightBatchSize` in `IdempotenceManager` exceed `maxInflightRequestsPerBucket`.

In our current implementation, when the `inflightBatchSize` exceeds `maxInflightRequestsPerBucket`, no further requests can be sent. This is incorrect. We should allow the batch with the` smallest (first) batchSequence` to always be in a sendable state. This ensures that when the server can handle the retriable error, the client can recover.



### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
