### PR TITLE
[client] Consider empty tablet server metadata response as stale metadata & fix npe when detination to send and fetch can't be found in metadata

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -245,7 +245,8 @@ public class MetadataUpdater {
         updateMetadata(updateTablePaths, updatePartitionPath, null);
     }
 
-    private void updateMetadata(
+    @VisibleForTesting
+    protected void updateMetadata(
             @Nullable Set<TablePath> tablePaths,
             @Nullable Collection<PhysicalTablePath> tablePartitionNames,
             @Nullable Collection<Long> tablePartitionIds) {

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetcher.java
@@ -281,7 +281,7 @@ public class LogFetcher implements Closeable {
                         e);
                 invalidTableOrPartitions(tableOrPartitionsInFetchRequest);
             }
-        } catch (Exception ex) {
+        } finally {
             LOG.debug("Removing pending request for node: {}", destination);
             nodesWithPendingFetchRequests.remove(destination);
         }

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
@@ -271,6 +271,7 @@ public class MetadataUtils {
         return aliveTabletServers.get(offset);
     }
 
+    @Nullable
     private static ServerNode getCoordinatorServer(MetadataResponse response) {
         if (!response.hasCoordinatorServer()) {
             return null;

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
@@ -21,6 +21,7 @@ import com.alibaba.fluss.cluster.Cluster;
 import com.alibaba.fluss.cluster.ServerNode;
 import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.exception.FlussRuntimeException;
+import com.alibaba.fluss.exception.StaleMetadataException;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -103,11 +104,17 @@ public class MetadataUtils {
         return gateway.metadata(metadataRequest)
                 .thenApply(
                         response -> {
-                            ServerNode coordinatorServer = getCoordinatorServer(response);
-
                             // Update the alive table servers.
                             Map<Integer, ServerNode> newAliveTabletServers =
                                     getAliveTabletServers(response);
+                            // when talking to the startup tablet
+                            // server, it maybe receive empty metadata, we'll consider it as
+                            // stale metadata and throw StaleMetadataException which will cause
+                            // to retry later.
+                            if (newAliveTabletServers.isEmpty()) {
+                                throw new StaleMetadataException("Alive tablet server is empty.");
+                            }
+                            ServerNode coordinatorServer = getCoordinatorServer(response);
 
                             Map<TablePath, Long> newTablePathToTableId;
                             Map<TablePath, TableInfo> newTablePathToTableInfo;
@@ -266,7 +273,7 @@ public class MetadataUtils {
 
     private static ServerNode getCoordinatorServer(MetadataResponse response) {
         if (!response.hasCoordinatorServer()) {
-            throw new FlussRuntimeException("coordinator server is not found");
+            return null;
         } else {
             PbServerNode protoServerNode = response.getCoordinatorServer();
             return new ServerNode(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
@@ -329,25 +329,38 @@ public class Sender implements Runnable {
                             .add(batch);
                 });
 
-        TabletServerGateway gateway = metadataUpdater.newTabletServerClientForNode(destination);
-        writeBatchByTable.forEach(
-                (tableId, writeBatches) -> {
-                    TableInfo tableInfo = metadataUpdater.getTableInfoOrElseThrow(tableId);
-                    if (tableInfo.hasPrimaryKey()) {
-                        sendPutKvRequestAndHandleResponse(
-                                gateway,
-                                makePutKvRequest(tableId, acks, maxRequestTimeoutMs, writeBatches),
-                                tableId,
-                                recordsByBucket);
-                    } else {
-                        sendProduceLogRequestAndHandleResponse(
-                                gateway,
-                                makeProduceLogRequest(
-                                        tableId, acks, maxRequestTimeoutMs, writeBatches),
-                                tableId,
-                                recordsByBucket);
-                    }
-                });
+        ServerNode destinationNode = metadataUpdater.getTabletServer(destination);
+        if (destinationNode == null) {
+            LOG.warn(
+                    "Server {} is not found in metadata cache, "
+                            + "going to request metadata update.",
+                    destination);
+            // invalidate the metadata to request metadata
+            invalidBucketMetadata(batches);
+            // requeue the write batch
+            batches.forEach(this::reEnqueueBatch);
+        } else {
+            TabletServerGateway gateway = metadataUpdater.newTabletServerClientForNode(destination);
+            writeBatchByTable.forEach(
+                    (tableId, writeBatches) -> {
+                        TableInfo tableInfo = metadataUpdater.getTableInfoOrElseThrow(tableId);
+                        if (tableInfo.hasPrimaryKey()) {
+                            sendPutKvRequestAndHandleResponse(
+                                    gateway,
+                                    makePutKvRequest(
+                                            tableId, acks, maxRequestTimeoutMs, writeBatches),
+                                    tableId,
+                                    recordsByBucket);
+                        } else {
+                            sendProduceLogRequestAndHandleResponse(
+                                    gateway,
+                                    makeProduceLogRequest(
+                                            tableId, acks, maxRequestTimeoutMs, writeBatches),
+                                    tableId,
+                                    recordsByBucket);
+                        }
+                    });
+        }
     }
 
     private void sendProduceLogRequestAndHandleResponse(
@@ -435,6 +448,14 @@ public class Sender implements Runnable {
             } else {
                 completeBatch(writeBatch);
             }
+        }
+        metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
+    }
+
+    private void invalidBucketMetadata(List<WriteBatch> writeBatches) {
+        Set<PhysicalTablePath> invalidMetadataTablesSet = new HashSet<>();
+        for (WriteBatch writeBatch : writeBatches) {
+            invalidMetadataTablesSet.add(writeBatch.physicalTablePath());
         }
         metadataUpdater.invalidPhysicalTableBucketMeta(invalidMetadataTablesSet);
     }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.client.metadata;
+
+import com.alibaba.fluss.cluster.Cluster;
+import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.server.testutils.FlussClusterExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for update metadata of {@link MetadataUpdater}. */
+class MetadataUpdaterTest {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder().setNumOfTabletServers(1).build();
+
+    @Test
+    void testUpdateWithEmptyMetadataResponse() throws Exception {
+        RpcClient rpcClient = FLUSS_CLUSTER_EXTENSION.getRpcClient();
+        MetadataUpdater metadataUpdater =
+                new MetadataUpdater(FLUSS_CLUSTER_EXTENSION.getClientConfig(), rpcClient);
+
+        // update metadata
+        metadataUpdater.updateMetadata(null, null, null);
+        Cluster cluster = metadataUpdater.getCluster();
+
+        List<ServerNode> expectedServerNodes = FLUSS_CLUSTER_EXTENSION.getTabletServerNodes();
+        assertThat(cluster.getAliveTabletServerList()).isEqualTo(expectedServerNodes);
+
+        // then, stop coordinator server, can still update metadata
+        FLUSS_CLUSTER_EXTENSION.stopCoordinatorServer();
+        metadataUpdater.updateMetadata(null, null, null);
+        assertThat(cluster.getAliveTabletServerList()).isEqualTo(expectedServerNodes);
+
+        // start a new tablet server, the tablet server will return empty metadata
+        // response since no coordinator server to send newest metadata to the tablet server
+        FLUSS_CLUSTER_EXTENSION.startTabletServer(1);
+
+        // we mock a new cluster with only server 1 so that it'll only send request
+        // to server 1, which will return empty resonate
+        Cluster newCluster =
+                new Cluster(
+                        Collections.singletonMap(
+                                1, FLUSS_CLUSTER_EXTENSION.getTabletServerNodes().get(1)),
+                        null,
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap(),
+                        Collections.emptyMap());
+
+        metadataUpdater = new MetadataUpdater(rpcClient, newCluster);
+        // shouldn't update metadata to empty since the empty metadata will be ignored
+        metadataUpdater.updateMetadata(null, null, null);
+        assertThat(metadataUpdater.getCluster().getAliveTabletServers())
+                .isEqualTo(newCluster.getAliveTabletServers());
+    }
+}

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
@@ -72,6 +72,10 @@ public class TestingMetadataUpdater extends MetadataUpdater {
         }
     }
 
+    public void updateCluster(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
     @Override
     public void checkAndUpdateTableMetadata(Set<TablePath> tablePaths) {
         Set<TablePath> needUpdateTablePaths =

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/LeaderNotAvailableException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/LeaderNotAvailableException.java
@@ -1,0 +1,39 @@
+/*
+ *  Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+import com.alibaba.fluss.annotation.PublicEvolving;
+
+/**
+ * There is no currently available leader for the given partition (either because a leadership
+ * election is in progress or because all replicas are down).
+ *
+ * @since 0.7
+ */
+@PublicEvolving
+public class LeaderNotAvailableException extends InvalidMetadataException {
+
+    private static final long serialVersionUID = 1L;
+
+    public LeaderNotAvailableException(String message) {
+        super(message);
+    }
+
+    public LeaderNotAvailableException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/StaleMetadataException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/StaleMetadataException.java
@@ -16,10 +16,15 @@
 
 package com.alibaba.fluss.exception;
 
+import com.alibaba.fluss.annotation.PublicEvolving;
+
 /**
  * Thrown when current metadata cannot be used. This is often used to trigger a new update metadata
  * request.
+ *
+ * @since 0.7
  */
+@PublicEvolving
 public class StaleMetadataException extends InvalidMetadataException {
 
     private static final long serialVersionUID = 1L;

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/StaleMetadataException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/StaleMetadataException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/**
+ * Thrown when current metadata cannot be used. This is often used to trigger a new update metadata
+ * request.
+ */
+public class StaleMetadataException extends InvalidMetadataException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StaleMetadataException(String message) {
+        super(message);
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -38,6 +38,7 @@ import com.alibaba.fluss.exception.InvalidUpdateVersionException;
 import com.alibaba.fluss.exception.KvSnapshotNotExistException;
 import com.alibaba.fluss.exception.KvStorageException;
 import com.alibaba.fluss.exception.LakeStorageNotConfiguredException;
+import com.alibaba.fluss.exception.LeaderNotAvailableException;
 import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
 import com.alibaba.fluss.exception.LogStorageException;
 import com.alibaba.fluss.exception.NetworkException;
@@ -182,7 +183,11 @@ public enum Errors {
     PARTITION_ALREADY_EXISTS(
             42, "The partition already exists.", PartitionAlreadyExistsException::new),
     PARTITION_SPEC_INVALID_EXCEPTION(
-            43, "The partition spec is invalid.", InvalidPartitionException::new);
+            43, "The partition spec is invalid.", InvalidPartitionException::new),
+    LEADER_NOT_AVAILABLE_EXCEPTION(
+            44,
+            "There is no currently available leader for the given partition.",
+            LeaderNotAvailableException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #605 

<!-- What is the purpose of the change -->
The pr will to try fix three problems:

1. no any alive tablet available to request metadata
2. the destinaion to send write batch can't be found in  metadata cache to cause NPE
3. the destinaion to fetcj can't be found in  metadata cache to cause NPE

Note the lookup, limit scan will also have the problem of NPE, but now, let's foucus on write and read.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

1. some time, if client request metadata from a startingup tablet server, the tablet server will return empty metadata, we consider it as stale metadata and not to accept the metadata. Otherwise, we'll get into no alive tablet available to request metadata again
2. if the destinaion node can't be found in  metadata cache, invalid the metadata so that it can request metadata again to get the destinaion node  evetually


### Tests

<!-- List UT and IT cases to verify this change -->

1. `MetadataUpdaterTest` verify empty metadata is not accepted
2. `testFetchWhenDestinationIsNullInMetadata` verify fetch when destination node is null in Metadata
3. `testSendWhenDestinationIsNullInMetadata` verify send when destination node is null in Metadata

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
