### PR TITLE
[hotfix] Fix an error which causes all replicas to become follower and rebuild replicaFetcher.

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -782,7 +782,6 @@ public class ReplicaManager {
                 // stop the remote log tiering tasks for followers
                 remoteLogManager.stopLogTiering(replica);
                 result.put(tb, new NotifyLeaderAndIsrResultForBucket(tb));
-                replicasBecomeFollower.add(replica);
             } catch (Exception e) {
                 LOG.error("Error make replica {} to follower", tb, e);
                 result.put(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/AdjustIsrITCase.java
@@ -150,10 +150,17 @@ public class AdjustIsrITCase {
                                                 .getHighWatermark())
                                 .isEqualTo(10L));
 
-        isr.add(stopFollower);
         currentLeaderAndIsr = zkClient.getLeaderAndIsr(tb).get();
+        LeaderAndIsr newLeaderAndIsr =
+                new LeaderAndIsr(
+                        currentLeaderAndIsr.leader(),
+                        currentLeaderAndIsr.leaderEpoch() + 1,
+                        isr,
+                        currentLeaderAndIsr.coordinatorEpoch(),
+                        currentLeaderAndIsr.bucketEpoch());
+        isr.add(stopFollower);
         followerGateway.notifyLeaderAndIsr(
-                makeNotifyLeaderAndIsrRequest(DATA1_TABLE_PATH, tb, currentLeaderAndIsr, isr));
+                makeNotifyLeaderAndIsrRequest(DATA1_TABLE_PATH, tb, newLeaderAndIsr, isr));
         // retry until the stop follower add back to ISR.
         retry(
                 Duration.ofMinutes(1),


### PR DESCRIPTION
### Purpose
Fix an error which causes all replicas to become follower and thus rebuild replicaFetcher.
<!-- Linking this pull request to the issue -->
Linked issue: close #620 

<!-- What is the purpose of the change -->

### Brief change log
Remove  
`replicasBecomeFollower.add(replica);`
because we have added replica there:
```
if (replica.makeFollower(data)) {
    replicasBecomeFollower.add(replica);
}
```
### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
