### PR TITLE
[flink] FlinkSink implements SupportsPreWriteTopology instead of WithPreWriteTopology

### DIFF
--- a/fluss-flink/fluss-flink-1.18/pom.xml
+++ b/fluss-flink/fluss-flink-1.18/pom.xml
@@ -69,6 +69,13 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java</artifactId>
+            <version>${flink.minor.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- test dependency -->
         <dependency>
             <groupId>com.alibaba.fluss</groupId>

--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
@@ -17,4 +17,4 @@
 package org.apache.flink.streaming.api.connector.sink2;
 
 /** Placeholder class to resolve compatibility issues. */
-public interface SupportsPreWriteTopology {}
+public interface SupportsPreWriteTopology<InputT> extends WithPreWriteTopology<InputT> {}

--- a/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
+++ b/fluss-flink/fluss-flink-1.18/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreWriteTopology.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.connector.sink2;
+
+/** Placeholder class to resolve compatibility issues. */
+public interface SupportsPreWriteTopology {}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
@@ -28,6 +28,7 @@ import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
+import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
 import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
@@ -42,13 +43,9 @@ import java.util.List;
 import static com.alibaba.fluss.flink.sink.FlinkStreamPartitioner.partition;
 import static com.alibaba.fluss.flink.utils.FlinkConversions.toFlussRowType;
 
-/**
- * Flink sink for Fluss.
- *
- * <p>TODO: WithPreWriteTopology need to be changed to supportsPreWriteTopology in Flink 1.20. Trace
- * by https://github.com/alibaba/fluss/issues/622.
- */
-class FlinkSink implements Sink<RowData>, WithPreWriteTopology<RowData> {
+/** Flink sink for Fluss. */
+class FlinkSink
+        implements Sink<RowData>, SupportsPreWriteTopology<RowData>, WithPreWriteTopology<RowData> {
 
     private static final long serialVersionUID = 1L;
 

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
@@ -29,7 +29,6 @@ import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.runtime.metrics.groups.InternalSinkWriterMetricGroup;
 import org.apache.flink.streaming.api.connector.sink2.SupportsPreWriteTopology;
-import org.apache.flink.streaming.api.connector.sink2.WithPreWriteTopology;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.RowType;
@@ -44,8 +43,7 @@ import static com.alibaba.fluss.flink.sink.FlinkStreamPartitioner.partition;
 import static com.alibaba.fluss.flink.utils.FlinkConversions.toFlussRowType;
 
 /** Flink sink for Fluss. */
-class FlinkSink
-        implements Sink<RowData>, SupportsPreWriteTopology<RowData>, WithPreWriteTopology<RowData> {
+class FlinkSink implements Sink<RowData>, SupportsPreWriteTopology<RowData> {
 
     private static final long serialVersionUID = 1L;
 


### PR DESCRIPTION
### Purpose

Linked issue: close #622.


### Brief change log

`FlinkSink` implements `SupportsPreWriteTopology` instead of `WithPreWriteTopology`.

### Tests

CI.

### API and Format

No.

### Documentation

No.