### PR TITLE
[client] Fix StackOverflowError after rebuilding Cluster N times

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/metadata/MetadataUpdater.java
@@ -278,43 +278,37 @@ public class MetadataUpdater {
         List<InetSocketAddress> inetSocketAddresses =
                 ClientUtils.parseAndValidateAddresses(conf.get(ConfigOptions.BOOTSTRAP_SERVERS));
         Cluster cluster = null;
+        Exception exception = null;
         for (InetSocketAddress address : inetSocketAddresses) {
-            cluster = tryToInitializeCluster(rpcClient, address);
-            if (cluster != null) {
+            try {
+                cluster = tryToInitializeCluster(rpcClient, address);
                 break;
+            } catch (Exception e) {
+                exception = e;
             }
         }
 
-        if (cluster == null) {
+        if (cluster == null && exception != null) {
             String errorMsg =
                     "Failed to initialize fluss client connection to server because no "
                             + "bootstrap server is validate. bootstrap servers: "
                             + inetSocketAddresses;
             LOG.error(errorMsg);
-            throw new IllegalStateException(errorMsg);
+            throw new IllegalStateException(errorMsg, exception);
         }
 
         return cluster;
     }
 
-    private static @Nullable Cluster tryToInitializeCluster(
-            RpcClient rpcClient, InetSocketAddress address) {
+    private static Cluster tryToInitializeCluster(RpcClient rpcClient, InetSocketAddress address)
+            throws Exception {
         ServerNode serverNode =
                 new ServerNode(
                         -1, address.getHostString(), address.getPort(), ServerType.COORDINATOR);
-        try {
-            AdminReadOnlyGateway adminReadOnlyGateway =
-                    GatewayClientProxy.createGatewayProxy(
-                            () -> serverNode, rpcClient, AdminReadOnlyGateway.class);
-            return sendMetadataRequestAndRebuildCluster(
-                    adminReadOnlyGateway, Collections.emptySet());
-        } catch (Exception e) {
-            LOG.error(
-                    "Failed to initialize fluss client connection to bootstrap server: {}",
-                    address,
-                    e);
-            return null;
-        }
+        AdminReadOnlyGateway adminReadOnlyGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        () -> serverNode, rpcClient, AdminReadOnlyGateway.class);
+        return sendMetadataRequestAndRebuildCluster(adminReadOnlyGateway, Collections.emptySet());
     }
 
     /** Invalid the bucket metadata for the given physical table paths. */

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
@@ -16,8 +16,14 @@
 
 package com.alibaba.fluss.client.metadata;
 
+import com.alibaba.fluss.client.Connection;
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.admin.Admin;
+import com.alibaba.fluss.client.utils.MetadataUtils;
 import com.alibaba.fluss.cluster.Cluster;
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.rpc.RpcClient;
 import com.alibaba.fluss.server.testutils.FlussClusterExtension;
 
@@ -27,6 +33,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import java.util.Collections;
 import java.util.List;
 
+import static com.alibaba.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for update metadata of {@link MetadataUpdater}. */
@@ -35,6 +42,36 @@ class MetadataUpdaterTest {
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
             FlussClusterExtension.builder().setNumOfTabletServers(2).build();
+
+    @Test
+    void testRebuildClusterNTimes() throws Exception {
+        Configuration clientConf = FLUSS_CLUSTER_EXTENSION.getClientConfig();
+        Connection conn = ConnectionFactory.createConnection(clientConf);
+        Admin admin = conn.getAdmin();
+        TablePath tablePath = TablePath.of("fluss", "test");
+        admin.createTable(tablePath, DATA1_TABLE_DESCRIPTOR, true).get();
+        admin.close();
+        conn.close();
+
+        RpcClient rpcClient = FLUSS_CLUSTER_EXTENSION.getRpcClient();
+        MetadataUpdater metadataUpdater = new MetadataUpdater(clientConf, rpcClient);
+        // update metadata
+        metadataUpdater.updateMetadata(Collections.singleton(tablePath), null, null);
+        Cluster cluster = metadataUpdater.getCluster();
+
+        // repeat 20K times to reproduce StackOverflowError if there is
+        // any N levels UnmodifiableCollection
+        for (int i = 0; i < 20000; i++) {
+            cluster =
+                    MetadataUtils.sendMetadataRequestAndRebuildCluster(
+                            FLUSS_CLUSTER_EXTENSION.newCoordinatorClient(),
+                            true,
+                            cluster,
+                            null,
+                            null,
+                            null);
+        }
+    }
 
     @Test
     void testUpdateWithEmptyMetadataResponse() throws Exception {

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/MetadataUpdaterTest.java
@@ -116,5 +116,8 @@ class MetadataUpdaterTest {
         assertThat(metadataUpdater.getCluster().getAliveTabletServers())
                 .isEqualTo(newCluster.getAliveTabletServers())
                 .hasSize(1);
+
+        // recover the coordinator
+        FLUSS_CLUSTER_EXTENSION.startCoordinatorServer();
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/Cluster.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/Cluster.java
@@ -80,7 +80,9 @@ public final class Cluster {
         for (Map.Entry<PhysicalTablePath, List<BucketLocation>> entry :
                 bucketLocationsByPath.entrySet()) {
             PhysicalTablePath physicalTablePath = entry.getKey();
-            List<BucketLocation> bucketsForTable = entry.getValue();
+            // avoid StackOverflowError on N levels UnmodifiableCollection,
+            // see https://stackoverflow.com/a/29027474
+            List<BucketLocation> bucketsForTable = new ArrayList<>(entry.getValue());
             // Optimise for the common case where all buckets are available.
             boolean foundUnavailableBucket = false;
             List<BucketLocation> availableBucketsForTable = new ArrayList<>(bucketsForTable.size());


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #699

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Construct `bucketsForTable` with a new `ArrayList` instead of reusing the previous list which might be a `unmodifiableList`.  This leads to nested `unmodifiableList`.

### Tests

<!-- List UT and IT cases to verify this change -->

Added `com.alibaba.fluss.client.metadata.MetadataUpdaterTest#testRebuildClusterNTimes` which can reproduce the StackOverflowError. 

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
