### PR TITLE
[Flink] Make flink sink generic

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/FlinkSink.java
@@ -106,7 +106,6 @@ class FlinkSink<InputT> implements Sink<InputT>, SupportsPreWriteTopology<InputT
                         (MapFunction<InputT, RowData>) converter::convert,
                         org.apache.flink.api.common.typeinfo.TypeInformation.of(RowData.class));
 
-        // Process with the builder
         DataStream<RowData> processed = builder.addPreWriteTopology(rowDataInput);
 
         // Convert back to original type.

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/ConvertingSinkWriter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/ConvertingSinkWriter.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.sink.converter;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.RowData;
+
+import java.io.IOException;
+
+/**
+ * A {@link SinkWriter} implementation that converts input elements to {@link RowData} before
+ * writing.
+ *
+ * <p>This class acts as an adapter between a source-provided data type {@code InputT} and the
+ * internal {@link RowData} format required by Fluss sink writers. It delegates actual writing
+ * operations to an underlying {@link RowData}-based sink writer after performing the conversion.
+ *
+ * <p>The conversion is handled by a {@link RowDataConverter} which is responsible for transforming
+ * objects of type {@code InputT} into Flink's internal {@link RowData} representation. If the input
+ * element is already a {@link RowData} instance, it's used directly without conversion.
+ *
+ * <p>This allows Fluss sinks to work with various input types while maintaining a consistent
+ * internal representation for data processing and storage operations.
+ *
+ * @param <InputT> The type of elements accepted by this sink writer
+ * @see RowDataConverter
+ * @see RowData
+ * @see SinkWriter
+ */
+public class ConvertingSinkWriter<InputT> implements SinkWriter<InputT> {
+    private final SinkWriter<RowData> rowDataWriter;
+    private final RowDataConverter<InputT> converter;
+
+    public ConvertingSinkWriter(
+            SinkWriter<RowData> rowDataWriter, RowDataConverter<InputT> converter) {
+        this.rowDataWriter = rowDataWriter;
+        this.converter = converter;
+    }
+
+    @Override
+    public void write(InputT element, Context context) throws IOException {
+        RowData rowData;
+        try {
+            if (!(element instanceof RowData)) {
+                rowData = converter.convert(element);
+
+            } else {
+                rowData = (RowData) element;
+            }
+            rowDataWriter.write(rowData, context);
+        } catch (Exception e) {
+            throw new IOException(
+                    String.format(
+                            "Failed to convert element of type '%s' to RowData: %s",
+                            element != null ? element.getClass().getName() : "null",
+                            e.getMessage()),
+                    e);
+        }
+    }
+
+    @Override
+    public void flush(boolean endOfInput) throws IOException, InterruptedException {
+        rowDataWriter.flush(endOfInput);
+    }
+
+    @Override
+    public void close() throws Exception {
+        rowDataWriter.close();
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/RowDataConverter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/RowDataConverter.java
@@ -1,18 +1,20 @@
-package com.alibaba.fluss.flink.sink.converter; /*
-                                                 * Copyright (c) 2025 Alibaba Group Holding Ltd.
-                                                 *
-                                                 * Licensed under the Apache License, Version 2.0 (the "License");
-                                                 * you may not use this file except in compliance with the License.
-                                                 * You may obtain a copy of the License at
-                                                 *
-                                                 *      http://www.apache.org/licenses/LICENSE-2.0
-                                                 *
-                                                 * Unless required by applicable law or agreed to in writing, software
-                                                 * distributed under the License is distributed on an "AS IS" BASIS,
-                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                                                 * See the License for the specific language governing permissions and
-                                                 * limitations under the License.
-                                                 */
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.sink.converter;
 
 import org.apache.flink.table.data.RowData;
 

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/RowDataConverter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/sink/converter/RowDataConverter.java
@@ -1,0 +1,51 @@
+package com.alibaba.fluss.flink.sink.converter; /*
+                                                 * Copyright (c) 2025 Alibaba Group Holding Ltd.
+                                                 *
+                                                 * Licensed under the Apache License, Version 2.0 (the "License");
+                                                 * you may not use this file except in compliance with the License.
+                                                 * You may obtain a copy of the License at
+                                                 *
+                                                 *      http://www.apache.org/licenses/LICENSE-2.0
+                                                 *
+                                                 * Unless required by applicable law or agreed to in writing, software
+                                                 * distributed under the License is distributed on an "AS IS" BASIS,
+                                                 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                                                 * See the License for the specific language governing permissions and
+                                                 * limitations under the License.
+                                                 */
+
+import org.apache.flink.table.data.RowData;
+
+import java.io.Serializable;
+
+/**
+ * Converter that transforms objects of type T into Flink's internal {@link RowData} representation.
+ *
+ * <p>This interface serves as a key component in Fluss data sink operations, enabling custom
+ * transformation logic when writing application objects to Fluss tables.
+ *
+ * <p>Implementations of this interface must be serializable as they may be distributed across a
+ * Flink cluster during job execution.
+ *
+ * <p>Usage examples:
+ *
+ * <ul>
+ *   <li>Converting POJO objects to {@link RowData} for sink operations
+ *   <li>Transforming data during the write process (e.g., field mapping, data filtering)
+ *   <li>Implementing custom serialization strategies for complex data types
+ * </ul>
+ *
+ * @param <T> The input type to be converted to {@link RowData}
+ * @see org.apache.flink.table.data.RowData
+ * @see com.alibaba.fluss.flink.sink.FlinkSink
+ */
+public interface RowDataConverter<T> extends Serializable {
+    /**
+     * Converts an element of type T to Flink's internal {@link RowData} representation.
+     *
+     * @param element The input element to convert
+     * @return The converted {@link RowData} representation of the input element
+     * @throws Exception If any error occurs during conversion
+     */
+    RowData convert(T element) throws Exception;
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/converter/ConvertingSinkWriterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/converter/ConvertingSinkWriterTest.java
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.sink.converter;
+
+import com.alibaba.fluss.flink.source.deserializer.Order;
+
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for the {@link ConvertingSinkWriter}. */
+class ConvertingSinkWriterTest {
+
+    private ConvertingSinkWriter<Order> convertingSinkWriter;
+    private TestSinkWriter testSinkWriter;
+    private RowDataConverter<Order> converter;
+    private SinkWriter.Context testContext;
+
+    @BeforeEach
+    void setUp() {
+        testSinkWriter = new TestSinkWriter();
+        converter = new OrderRecordConverter();
+        convertingSinkWriter = new ConvertingSinkWriter<>(testSinkWriter, converter);
+
+        // Simple implementation of Context
+        testContext =
+                new SinkWriter.Context() {
+                    @Override
+                    public long currentWatermark() {
+                        return 0;
+                    }
+
+                    @Override
+                    public Long timestamp() {
+                        return 0L;
+                    }
+                };
+    }
+
+    @Test
+    void testWriteWithSuccessfulConversion() throws IOException {
+        // Given
+        Order record = new Order(1000L, 101L, 20, "Test 123 Main St");
+
+        // When
+        convertingSinkWriter.write(record, testContext);
+
+        // Then
+        List<RowData> writtenRows = testSinkWriter.getWrittenRows();
+        assertThat(writtenRows).hasSize(1);
+
+        RowData writtenRow = writtenRows.get(0);
+        assertThat(writtenRow.getLong(0)).isEqualTo(1000L);
+        assertThat(writtenRow.getLong(1)).isEqualTo(101L);
+        assertThat(writtenRow.getInt(2)).isEqualTo(20);
+        assertThat(writtenRow.getString(3).toString()).isEqualTo("Test 123 Main St");
+    }
+
+    @Test
+    void testWriteWithRowDataInput() throws IOException {
+        // Given
+        GenericRowData rowData = new GenericRowData(4);
+        rowData.setField(0, 1000L);
+        rowData.setField(1, 101L);
+        rowData.setField(2, 20);
+        rowData.setField(3, StringData.fromString("Test 123 Main St"));
+
+        ConvertingSinkWriter<RowData> rowDataWriter =
+                new ConvertingSinkWriter<>(
+                        testSinkWriter,
+                        // Identity converter that just returns the row data
+                        (RowDataConverter<RowData>) input -> input);
+
+        // When
+        rowDataWriter.write(rowData, testContext);
+
+        // Then
+        List<RowData> writtenRows = testSinkWriter.getWrittenRows();
+        assertThat(writtenRows).hasSize(1);
+        assertThat(writtenRows.get(0)).isSameAs(rowData);
+    }
+
+    @Test
+    void testWriteMultipleRecords() throws IOException {
+        // Given
+        Order record1 = new Order(1000L, 101L, 20, "Test 123 Main St");
+        Order record2 = new Order(1001L, 102L, 45, "Test 123 Main St");
+        Order record3 = new Order(1002L, 103L, 38, "Test 123 Main St");
+
+        // When
+        convertingSinkWriter.write(record1, testContext);
+        convertingSinkWriter.write(record2, testContext);
+        convertingSinkWriter.write(record3, testContext);
+
+        // Then
+        List<RowData> writtenRows = testSinkWriter.getWrittenRows();
+        assertThat(writtenRows).hasSize(3);
+
+        assertThat(writtenRows.get(0).getLong(0)).isEqualTo(1000L);
+        assertThat(writtenRows.get(0).getLong(1)).isEqualTo(101L);
+        assertThat(writtenRows.get(0).getInt(2)).isEqualTo(20);
+        assertThat(writtenRows.get(0).getString(3).toString()).isEqualTo("Test 123 Main St");
+
+        assertThat(writtenRows.get(1).getLong(0)).isEqualTo(1001L);
+        assertThat(writtenRows.get(1).getLong(1)).isEqualTo(102L);
+        assertThat(writtenRows.get(1).getInt(2)).isEqualTo(45);
+        assertThat(writtenRows.get(1).getString(3).toString()).isEqualTo("Test 123 Main St");
+
+        assertThat(writtenRows.get(2).getLong(0)).isEqualTo(1002L);
+        assertThat(writtenRows.get(2).getLong(1)).isEqualTo(103L);
+        assertThat(writtenRows.get(2).getInt(2)).isEqualTo(38);
+        assertThat(writtenRows.get(2).getString(3).toString()).isEqualTo("Test 123 Main St");
+    }
+
+    @Test
+    void testWriteWithNullElement() throws IOException {
+        // When
+        convertingSinkWriter.write(null, testContext);
+
+        // Then
+        List<RowData> writtenRows = testSinkWriter.getWrittenRows();
+        assertThat(writtenRows).hasSize(1);
+        assertThat(writtenRows.get(0)).isNull();
+    }
+
+    @Test
+    void testFlush() throws IOException, InterruptedException {
+        // When
+        convertingSinkWriter.flush(true);
+
+        // Then
+        assertThat(testSinkWriter.isFlushed()).isTrue();
+    }
+
+    @Test
+    void testClose() throws Exception {
+        // When
+        convertingSinkWriter.close();
+
+        // Then
+        assertThat(testSinkWriter.isClosed()).isTrue();
+    }
+
+    // Custom RowDataConverter implementation
+    static class OrderRecordConverter implements RowDataConverter<Order> {
+        @Override
+        public RowData convert(Order order) throws Exception {
+            if (order == null) {
+                return null;
+            }
+
+            //            if (order.getName().equals("error")) {
+            //                throw new RuntimeException("Simulated conversion error");
+            //            }
+
+            GenericRowData rowData = new GenericRowData(4);
+            rowData.setField(0, order.getOrderId());
+            rowData.setField(1, order.getItemId());
+            rowData.setField(2, order.getAmount());
+            rowData.setField(3, StringData.fromString(order.getAddress()));
+            return rowData;
+        }
+    }
+
+    // Test implementation of SinkWriter that stores written records
+    static class TestSinkWriter implements SinkWriter<RowData> {
+        private final List<RowData> writtenRows = new ArrayList<>();
+        private boolean flushed = false;
+        private boolean closed = false;
+        private boolean failOnWrite = false;
+
+        @Override
+        public void write(RowData element, Context context) throws IOException {
+            if (failOnWrite) {
+                throw new IOException("Simulated write error");
+            }
+            writtenRows.add(element);
+        }
+
+        @Override
+        public void flush(boolean endOfInput) {
+            flushed = true;
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+        }
+
+        public List<RowData> getWrittenRows() {
+            return writtenRows;
+        }
+
+        public boolean isFlushed() {
+            return flushed;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+
+        public void setFailOnWrite(boolean failOnWrite) {
+            this.failOnWrite = failOnWrite;
+        }
+    }
+}


### PR DESCRIPTION
This PR makes the Flink Sink generic so it can later be used by the `FlussSink` for the datastream API and handle various data types. It also introduces a `ConvertingSinkWriter` for converting between various types and `RowData`.