### PR TITLE
Fix an exception when create and drop a table with the same name multiple times

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
@@ -353,4 +353,9 @@ public class AutoPartitionManager implements AutoCloseable {
             periodicExecutor.shutdownNow();
         }
     }
+
+    @VisibleForTesting
+    public Map<Long, TableInfo> getAutoPartitionTables() {
+        return autoPartitionTables;
+    }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -519,9 +519,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
                 tableInfo.getTablePath(),
                 tableInfo.getTableId(),
                 createTableEvent.getTableAssignment());
-        if (createTableEvent.isAutoPartitionTable()) {
-            autoPartitionManager.addAutoPartitionTable(tableInfo);
-        }
     }
 
     private void processCreatePartition(CreatePartitionEvent createPartitionEvent) {
@@ -554,9 +551,6 @@ public class CoordinatorEventProcessor implements EventProcessor {
 
         coordinatorContext.queueTableDeletion(Collections.singleton(dropTableEvent.getTableId()));
         tableManager.onDeleteTable(dropTableEvent.getTableId());
-        if (dropTableEvent.isAutoPartitionTable()) {
-            autoPartitionManager.removeAutoPartitionTable(dropTableEvent.getTableId());
-        }
     }
 
     private void processDropPartition(DropPartitionEvent dropPartitionEvent) {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -153,6 +153,8 @@ public class CoordinatorServer extends ServerBase {
             this.metadataCache = new ServerMetadataCacheImpl();
 
             MetadataManager metadataManager = new MetadataManager(zkClient, conf);
+            this.autoPartitionManager =
+                    new AutoPartitionManager(metadataCache, metadataManager, conf);
             this.coordinatorService =
                     new CoordinatorService(
                             conf,
@@ -160,7 +162,8 @@ public class CoordinatorServer extends ServerBase {
                             zkClient,
                             this::getCoordinatorEventManager,
                             metadataCache,
-                            metadataManager);
+                            metadataManager,
+                            autoPartitionManager);
 
             this.rpcServer =
                     RpcServer.create(
@@ -179,8 +182,6 @@ public class CoordinatorServer extends ServerBase {
 
             this.coordinatorChannelManager = new CoordinatorChannelManager(rpcClient);
 
-            this.autoPartitionManager =
-                    new AutoPartitionManager(metadataCache, metadataManager, conf);
             autoPartitionManager.start();
 
             int ioExecutorPoolSize = conf.get(ConfigOptions.COORDINATOR_IO_POOL_SIZE);
@@ -365,6 +366,11 @@ public class CoordinatorServer extends ServerBase {
     @VisibleForTesting
     public CoordinatorService getCoordinatorService() {
         return coordinatorService;
+    }
+
+    @VisibleForTesting
+    public AutoPartitionManager getAutoPartitionManager() {
+        return autoPartitionManager;
     }
 
     @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -322,7 +322,7 @@ public class ReplicaManager {
 
     /**
      * Receive a request to make these replicas to become leader or follower, if the replica doesn't
-     * exit, we will create it.
+     * exist, we will create it.
      */
     public void becomeLeaderOrFollower(
             int requestCoordinatorEpoch,

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -57,7 +57,6 @@ import com.alibaba.fluss.server.zk.data.PartitionAssignment;
 import com.alibaba.fluss.server.zk.data.RemoteLogManifestHandle;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
 import com.alibaba.fluss.utils.FileUtils;
-
 import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -67,7 +66,6 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.annotation.Nullable;
-
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -517,7 +515,7 @@ public final class FlussClusterExtension
     public void waitUtilAllReplicaReady(TableBucket tableBucket) {
         ZooKeeperClient zkClient = getZooKeeperClient();
         retry(
-                Duration.ofMinutes(1),
+                Duration.ofSeconds(90),
                 () -> {
                     Optional<LeaderAndIsr> leaderAndIsrOpt = zkClient.getLeaderAndIsr(tableBucket);
                     assertThat(leaderAndIsrOpt).isPresent();

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -57,6 +57,7 @@ import com.alibaba.fluss.server.zk.data.PartitionAssignment;
 import com.alibaba.fluss.server.zk.data.RemoteLogManifestHandle;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
 import com.alibaba.fluss.utils.FileUtils;
+
 import org.apache.curator.test.TestingServer;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -66,6 +67,7 @@ import org.junit.jupiter.api.extension.Extension;
 import org.junit.jupiter.api.extension.ExtensionContext;
 
 import javax.annotation.Nullable;
+
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -517,7 +517,7 @@ public final class FlussClusterExtension
     public void waitUtilAllReplicaReady(TableBucket tableBucket) {
         ZooKeeperClient zkClient = getZooKeeperClient();
         retry(
-                Duration.ofSeconds(90),
+                Duration.ofMinutes(2),
                 () -> {
                     Optional<LeaderAndIsr> leaderAndIsrOpt = zkClient.getLeaderAndIsr(tableBucket);
                     assertThat(leaderAndIsrOpt).isPresent();


### PR DESCRIPTION
### Purpose

Linked issue: close #712


### Brief change log
Drop table's all partitions when coordinator listens a partitioned table dropped.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
