### PR TITLE
[hotfix][test] Fix testCreateDatabase any order.

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -45,6 +45,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BUCKET_KEY;
@@ -60,8 +61,8 @@ abstract class FlinkCatalogITCase {
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
             FlussClusterExtension.builder().setNumOfTabletServers(1).build();
 
-    private static final String CATALOG_NAME = "testcatalog";
-    private static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
     static Catalog catalog;
     static TableEnvironment tEnv;
 
@@ -349,8 +350,10 @@ abstract class FlinkCatalogITCase {
         tEnv.executeSql("create database test_db");
         List<Row> databases =
                 CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect());
-        assertThat(databases.toString())
-                .isEqualTo(String.format("[+I[%s], +I[test_db]]", DEFAULT_DB));
+
+        assertThat(databases.stream().map(Row::toString).collect(Collectors.toList()))
+                .containsExactlyInAnyOrderElementsOf(
+                        Arrays.asList(String.format("+I[%s]", DEFAULT_DB), "+I[test_db]"));
         tEnv.executeSql("drop database test_db");
         databases = CollectionUtil.iteratorToList(tEnv.executeSql("show databases").collect());
         assertThat(databases.toString()).isEqualTo(String.format("[+I[%s]]", DEFAULT_DB));

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -74,8 +74,8 @@ abstract class FlinkTableSinkITCase {
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
             FlussClusterExtension.builder().setNumOfTabletServers(3).build();
 
-    private static final String CATALOG_NAME = "testcatalog";
-    private static final String DEFAULT_DB = "defaultdb";
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = "defaultdb";
     static StreamExecutionEnvironment env;
     static StreamTableEnvironment tEnv;
     static TableEnvironment tBatchEnv;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -53,8 +53,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** IT case for using flink sql to read fluss table. */
 abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
 
-    private static final String CATALOG_NAME = "testcatalog";
-    private static final String DEFAULT_DB = "defaultdb";
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = "defaultdb";
     static StreamExecutionEnvironment execEnv;
     static StreamTableEnvironment tEnv;
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceFailOverITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceFailOverITCase.java
@@ -63,7 +63,7 @@ import static com.alibaba.fluss.testutils.DataTestUtils.row;
 /** IT case for flink table source fail over. */
 abstract class FlinkTableSourceFailOverITCase {
 
-    private static final String CATALOG_NAME = "testcatalog";
+    static final String CATALOG_NAME = "testcatalog";
 
     @TempDir public static File checkpointDir;
     @TempDir public static File savepointDir;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -72,8 +72,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 /** IT case for using flink sql to read fluss table. */
 abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
-    private static final String CATALOG_NAME = "testcatalog";
-    private static final String DEFAULT_DB = "defaultdb";
+    static final String CATALOG_NAME = "testcatalog";
+    static final String DEFAULT_DB = "defaultdb";
     static StreamExecutionEnvironment execEnv;
     static StreamTableEnvironment tEnv;
 


### PR DESCRIPTION

### Purpose
Hotfix of test:
1. Fix testCreateDatabase return database out of order.
2. As a abstract class, FlinkTableSourceITCase's variable be visitable by child class