### PR TITLE
[client] Fix sender in block when retry after resetting writer id.

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/RecordAccumulator.java
@@ -660,9 +660,9 @@ public final class RecordAccumulator {
             // flight request count to 1.
             int firstInFlightSequence = idempotenceManager.firstInFlightBatchSequence(tableBucket);
             boolean isFirstInFlightBatch =
-                    firstInFlightSequence != LogRecordBatch.NO_BATCH_SEQUENCE
-                            && first.hasBatchSequence()
-                            && first.batchSequence() == firstInFlightSequence;
+                    firstInFlightSequence == LogRecordBatch.NO_BATCH_SEQUENCE
+                            || (first.hasBatchSequence()
+                                    && first.batchSequence() == firstInFlightSequence);
 
             if (isFirstInFlightBatch) {
                 return false;


### PR DESCRIPTION

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #706 .

Currently, If we send multiple write batch requests. 
1. The first request is responsed with an retry RetriableException(such as TimeoutException), then it will be reEnqueue.
```java

Set<PhysicalTablePath> invalidMetadataTables = new HashSet<>();
        if (canRetry(writeBatch, error.error())) {
            if (!idempotenceManager.idempotenceEnabled()) {
                reEnqueueBatch(writeBatch);
            } else if (idempotenceManager.hasWriterId(writeBatch.writerId())) {
                reEnqueueBatch(writeBatch);
     }
```
2. The later requests are responsed with OutOfOrderSequenceException or UnknownWriterIdException. Then will reset writer id.
```java
    synchronized void handleFailedBatch(
            WriteBatch batch, Exception exception, boolean adjustSequenceNumbers) {
        if (exception instanceof OutOfOrderSequenceException
                || exception instanceof UnknownWriterIdException) {

            resetWriterId();
        } 
    }
```

3. Then retry the first request, will be stucked because shouldStopDrainBatchesForBucket always return true. The reason is that  firstInFlightSequence is NO_BATCH_SEQUENCE.
```java
int firstInFlightSequence = idempotenceManager.firstInFlightBatchSequence(tableBucket);
            boolean isFirstInFlightBatch =
                    firstInFlightSequence != LogRecordBatch.NO_BATCH_SEQUENCE
                            && first.hasBatchSequence()
                            && first.batchSequence() == firstInFlightSequence;
 if (isFirstInFlightBatch) {
                return false;
            } else {
                if (!first.hasBatchSequence()) {
                    // For batches that haven't been assigned a batchSequence, we consider them as
                    // new batches. In this case, we need to ensure that the number of inflight
                    // requests does not exceed maxInflightRequestsPerBucket.
                    return !idempotenceManager.canSendMoreRequests(tableBucket);
                } else {
                    // For batches that have been assigned a batchSequence, we consider that these
                    // batches have encountered a retriable error. In such cases, only the first
                    // batch  allow to be sent until the retriable error is resolved. This
                    // approach helps reduce the number of requests sent over the network.
                    return true;
                }
            }
        }
```

More details see com.alibaba.fluss.client.write.SenderTest#testRetryAfterResettingInFlightBatchSequence.
