### PR TITLE
[hotfix] Change writerState flush from async to sync while rolling log to avoid conflicts with the writerState flush during logTablet close

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
@@ -782,16 +782,12 @@ public final class LogTablet {
             // current writer state end offset (which corresponds to the log end offset),
             // we manually override the state offset here prior to taking the snapshot.
             writerStateManager.updateMapEndOffset(segment.getBaseOffset());
-            // We avoid potentially-costly fsync call, since we acquire UnifiedLog#lock here which
-            // could block subsequent produces in the meantime.
-            // flush is done in the scheduler thread along with segment flushing below.
-            Optional<File> maybeSnapshot = writerStateManager.takeSnapshot(false);
+            writerStateManager.takeSnapshot();
             updateHighWatermarkWithLogEndOffset();
 
             scheduler.scheduleOnce(
                     "flush-log",
                     () -> {
-                        maybeSnapshot.ifPresent(f -> flushWriterStateSnapshot(f.toPath()));
                         flushUptoOffsetExclusive(segment.getBaseOffset());
                     });
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
@@ -182,20 +182,12 @@ public class WriterStateManager {
      * change to the device.
      */
     public void takeSnapshot() throws IOException {
-        takeSnapshot(true);
-    }
-
-    /**
-     * Take a snapshot at the current end offset if one does not already exist, then return the
-     * snapshot file if taken.
-     */
-    public Optional<File> takeSnapshot(boolean sync) throws IOException {
         // If not a new offset, then it is not worth taking another snapshot
         if (lastMapOffset > lastSnapOffset) {
             SnapshotFile snapshotFile =
                     new SnapshotFile(writerSnapshotFile(logTabletDir, lastMapOffset));
             long start = System.currentTimeMillis();
-            writeSnapshot(snapshotFile.file(), writers, sync);
+            writeSnapshot(snapshotFile.file(), writers);
             LOG.info(
                     "Wrote writer snapshot at offset {} with {} producer ids for table bucket {} in {} ms.",
                     lastMapOffset,
@@ -207,10 +199,7 @@ public class WriterStateManager {
 
             // Update the last snap offset according to the serialized map
             lastSnapOffset = lastMapOffset;
-
-            return Optional.of(snapshotFile.file());
         }
-        return Optional.empty();
     }
 
     /**
@@ -447,7 +436,7 @@ public class WriterStateManager {
         }
     }
 
-    private static void writeSnapshot(File file, Map<Long, WriterStateEntry> entries, boolean sync)
+    private static void writeSnapshot(File file, Map<Long, WriterStateEntry> entries)
             throws IOException {
         List<WriterSnapshotEntry> snapshotEntries = new ArrayList<>();
         entries.forEach(
@@ -469,9 +458,7 @@ public class WriterStateManager {
                 FileChannel.open(
                         file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.WRITE)) {
             fileChannel.write(buffer);
-            if (sync) {
-                fileChannel.force(true);
-            }
+            fileChannel.force(true);
         }
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -1397,11 +1397,14 @@ public class ReplicaManager {
 
     private void truncateToHighWatermark(List<Replica> replicas) {
         for (Replica replica : replicas) {
+            long highWatermark = replica.getLogTablet().getHighWatermark();
             LOG.info(
-                    "Truncating the log end offset fot replica id {} of table bucket {} to local high watermark as it becomes the follower",
+                    "Truncating the logEndOffset for replica id {} of table bucket {} to local "
+                            + "highWatermark {} as it becomes the follower",
                     serverId,
-                    replica.getTableBucket());
-            replica.truncateTo(replica.getLogTablet().getHighWatermark());
+                    replica.getTableBucket(),
+                    highWatermark);
+            replica.truncateTo(highWatermark);
         }
     }
 


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
This pr is aims to change `writerState` flush from async to sync while rolling log to avoid conflicts with the `writerState` flush during logTablet close.  

In the `LogTablet#roll()` method, the current implementation `writes the writerState` while holding the lock, but the `file flush operation` is performed outside the lock. However, this could potentially conflict with the `writerState write operation `in the `LogTablet#close() method`. Considering that the `writerState flush operation` itself is not very resource-intensive and the `roll()` method isn't called frequently, we consider change it to a sync flush approach.


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
