### PR TITLE
[log] Follower fetch offset need truncate to leaderEndOffsetSnapshot if we found duplicated batch or out of sequence batch

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/ListOffsetsParam.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/ListOffsetsParam.java
@@ -41,6 +41,9 @@ public class ListOffsetsParam {
      */
     public static final int TIMESTAMP_OFFSET_TYPE = 2;
 
+    /** The offset type indicate the end offset snapshot when become leader. */
+    public static final int LEADER_END_OFFSET_SNAPSHOT_TYPE = 3;
+
     private final int followerServerId;
     private final Integer offsetType;
     private @Nullable final Long startTimestamp;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/LogTablet.java
@@ -20,6 +20,7 @@ import com.alibaba.fluss.annotation.VisibleForTesting;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.CorruptRecordException;
+import com.alibaba.fluss.exception.DuplicateSequenceException;
 import com.alibaba.fluss.exception.FlussRuntimeException;
 import com.alibaba.fluss.exception.InvalidTimestampException;
 import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
@@ -104,6 +105,9 @@ public final class LogTablet {
 
     @GuardedBy("lock")
     private volatile LogOffsetMetadata highWatermarkMetadata;
+
+    /** The leader end offset snapshot when become leader. */
+    private volatile long leaderEndOffsetSnapshot = -1L;
 
     // The minimum offset that should be retained in the local log. This is used to ensure that,
     // the offset of kv snapshot should be retained, otherwise, kv recovery will fail.
@@ -259,6 +263,10 @@ public final class LogTablet {
         return logFormat;
     }
 
+    public long getLeaderEndOffsetSnapshot() {
+        return leaderEndOffsetSnapshot;
+    }
+
     @VisibleForTesting
     public WriterStateManager writerStateManager() {
         return writerStateManager;
@@ -334,6 +342,16 @@ public final class LogTablet {
         metricGroup.meter(MetricNames.LOG_FLUSH_RATE, new MeterView(localLog.getFlushCount()));
         metricGroup.histogram(
                 MetricNames.LOG_FLUSH_LATENCY_MS, localLog.getFlushLatencyHistogram());
+    }
+
+    public void updateLeaderEndOffsetSnapshot() {
+        synchronized (lock) {
+            LOG.info(
+                    "Update leaderEndOffsetSnapshot to {} for tb {} while become leader",
+                    localLogEndOffset(),
+                    localLog.getTableBucket());
+            leaderEndOffsetSnapshot = localLog.getLocalLogEndOffset();
+        }
     }
 
     /**
@@ -582,10 +600,10 @@ public final class LogTablet {
      * segment if necessary.
      *
      * <p>This method will generally be responsible for assigning offsets to the messages, however
-     * if the needAssignOffsetAndTimestamp=false flag is passed we will only check that the existing
-     * offsets are valid.
+     * if the appendAsLeader=false flag is passed we will only check that the existing offsets are
+     * valid.
      */
-    private LogAppendInfo append(MemoryLogRecords records, boolean needAssignOffsetAndTimestamp)
+    private LogAppendInfo append(MemoryLogRecords records, boolean appendAsLeader)
             throws Exception {
         LogAppendInfo appendInfo = analyzeAndValidateRecords(records);
 
@@ -599,7 +617,7 @@ public final class LogTablet {
 
         synchronized (lock) {
             localLog.checkIfMemoryMappedBufferClosed();
-            if (needAssignOffsetAndTimestamp) {
+            if (appendAsLeader) {
                 long offset = localLog.getLocalLogEndOffset();
                 // assign offsets to the message set.
                 appendInfo.setFirstOffset(offset);
@@ -630,11 +648,24 @@ public final class LogTablet {
                 // have duplicated batch metadata, skip the append and update append info.
                 WriterStateEntry.BatchMetadata duplicatedBatch = validateResult.left();
                 long startOffset = duplicatedBatch.firstOffset();
-                appendInfo.setFirstOffset(startOffset);
-                appendInfo.setLastOffset(duplicatedBatch.lastOffset);
-                appendInfo.setMaxTimestamp(duplicatedBatch.timestamp);
-                appendInfo.setStartOffsetOfMaxTimestamp(startOffset);
-                appendInfo.setDuplicated(true);
+                if (appendAsLeader) {
+                    appendInfo.setFirstOffset(startOffset);
+                    appendInfo.setLastOffset(duplicatedBatch.lastOffset);
+                    appendInfo.setMaxTimestamp(duplicatedBatch.timestamp);
+                    appendInfo.setStartOffsetOfMaxTimestamp(startOffset);
+                    appendInfo.setDuplicated(true);
+                } else {
+                    String errorMsg =
+                            String.format(
+                                    "Found duplicated batch for table bucket %s, duplicated offset is %s, "
+                                            + "writer id is %s and batch sequence is: %s",
+                                    getTableBucket(),
+                                    duplicatedBatch.lastOffset,
+                                    duplicatedBatch.writerId,
+                                    duplicatedBatch.batchSequence);
+                    LOG.error(errorMsg);
+                    throw new DuplicateSequenceException(errorMsg);
+                }
             } else {
                 // Append the records, and increment the local log end offset immediately after
                 // append because write to the transaction index below may fail, and we want to

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateEntry.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateEntry.java
@@ -86,7 +86,8 @@ public class WriterStateEntry {
     }
 
     public void addBath(int batchSequence, long lastOffset, int offsetDelta, long timestamp) {
-        addBatchMetadata(new BatchMetadata(batchSequence, lastOffset, offsetDelta, timestamp));
+        addBatchMetadata(
+                new BatchMetadata(writerId, batchSequence, lastOffset, offsetDelta, timestamp));
         this.lastTimestamp = timestamp;
     }
 
@@ -129,12 +130,19 @@ public class WriterStateEntry {
 
     /** Metadata of a batch. */
     public static final class BatchMetadata {
+        public final long writerId;
         public final int batchSequence;
         public final long lastOffset;
         public final int offsetDelta;
         public final long timestamp;
 
-        public BatchMetadata(int batchSequence, long lastOffset, int offsetDelta, long timestamp) {
+        public BatchMetadata(
+                long writerId,
+                int batchSequence,
+                long lastOffset,
+                int offsetDelta,
+                long timestamp) {
+            this.writerId = writerId;
             this.batchSequence = batchSequence;
             this.lastOffset = lastOffset;
             this.offsetDelta = offsetDelta;

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/log/WriterStateManager.java
@@ -437,6 +437,7 @@ public class WriterStateManager {
                                             snapshotEntry.writerId,
                                             snapshotEntry.lastBatchTimestamp,
                                             new WriterStateEntry.BatchMetadata(
+                                                    snapshotEntry.writerId,
                                                     snapshotEntry.lastBatchSequence,
                                                     snapshotEntry.lastBatchBaseOffset,
                                                     snapshotEntry.lastBatchOffsetDelta,

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -506,6 +506,8 @@ public final class Replica {
     // -------------------------------------------------------------------------------------------
 
     private void onBecomeNewLeader() {
+        updateLeaderEndOffsetSnapshot();
+
         if (isKvTable()) {
             // if it's become new leader, we must
             // first destroy the old kv tablet
@@ -521,6 +523,11 @@ public final class Replica {
             // it should be from leader to follower, we need to destroy the kv tablet
             dropKv();
         }
+    }
+
+    @VisibleForTesting
+    public void updateLeaderEndOffsetSnapshot() {
+        logTablet.updateLeaderEndOffsetSnapshot();
     }
 
     private void createKv() {
@@ -790,6 +797,10 @@ public final class Replica {
         } catch (Exception e) {
             LOG.error("init kv periodic snapshot failed.", e);
         }
+    }
+
+    public long getLeaderEndOffsetSnapshot() {
+        return logTablet.getLeaderEndOffsetSnapshot();
     }
 
     public LogAppendInfo appendRecordsToLeader(MemoryLogRecords memoryLogRecords, int requiredAcks)
@@ -1235,6 +1246,8 @@ public final class Replica {
                         }
                     } else if (offsetType == ListOffsetsParam.LATEST_OFFSET_TYPE) {
                         return getLatestOffset(listOffsetsParam.getFollowerServerId());
+                    } else if (offsetType == ListOffsetsParam.LEADER_END_OFFSET_SNAPSHOT_TYPE) {
+                        return logTablet.getLeaderEndOffsetSnapshot();
                     } else {
                         throw new IllegalArgumentException(
                                 "Invalid list offset type: " + offsetType);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/LeaderEndpoint.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/LeaderEndpoint.java
@@ -36,6 +36,8 @@ interface LeaderEndpoint {
     /** Fetches the local log start offset of the given table bucket. */
     CompletableFuture<Long> fetchLocalLogStartOffset(TableBucket tableBucket);
 
+    CompletableFuture<Long> fetchLeaderEndOffsetSnapshot(TableBucket tableBucket);
+
     /**
      * Given a fetchLogRequest, carries out the expected request and returns the results from
      * fetching from the leader.

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/RemoteLeaderEndpoint.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/RemoteLeaderEndpoint.java
@@ -82,6 +82,11 @@ final class RemoteLeaderEndpoint implements LeaderEndpoint {
     }
 
     @Override
+    public CompletableFuture<Long> fetchLeaderEndOffsetSnapshot(TableBucket tableBucket) {
+        return fetchLogOffset(tableBucket, ListOffsetsParam.LEADER_END_OFFSET_SNAPSHOT_TYPE);
+    }
+
+    @Override
     public CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> fetchLog(
             FetchLogRequest fetchLogRequest) {
         return tabletServerGateway

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/TestingLeaderEndpoint.java
@@ -76,6 +76,12 @@ public class TestingLeaderEndpoint implements LeaderEndpoint {
     }
 
     @Override
+    public CompletableFuture<Long> fetchLeaderEndOffsetSnapshot(TableBucket tableBucket) {
+        Replica replica = replicaManager.getReplicaOrException(tableBucket);
+        return CompletableFuture.completedFuture(replica.getLeaderEndOffsetSnapshot());
+    }
+
+    @Override
     public CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> fetchLog(
             FetchLogRequest fetchLogRequest) {
         CompletableFuture<Map<TableBucket, FetchLogResultForBucket>> response =


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #704 

<!-- What is the purpose of the change -->

This pr is aims to address the issue where a `DuplicateSequenceException` or `OutOfOrderSequenceException` may occur when the follower fetches data from the leader for sync. The root cause of this problem lies in our current approach of updating the` follower's HW (HighWatermark)` before updating the `leader's HW`. This update mechanism may lead to the issues illustrated in the diagram below:

![image](https://github.com/user-attachments/assets/5ca0615f-40f1-4307-8a58-ec6c98224bea)

As in case 1, for example. In this scenario, when the leader, follower1, and follower2 are all offline, follower1 has written batch1 (WriterId=1, batchSequence=10), but the leader did not write this batch. When the tabletServer recover, follower2 is elected as the new leader. At this point, another writer, such as writer2 or writer3, quickly writes new batches and closes the gap with follower1. If the client then writes batch1, when follower1 pulls the updates, a `DuplicateSequenceException` will occur.

To fix this error, we introduce a variable named `LeaderEndOffsetSnapshot` to remember the endOffset snapshot when the replica become leader. If follower encounter `DuplicateSequenceException`, it need to truncate to leader's `LeaderEndOffsetSnapshot`, by this way, it can be continue to fetch data from leader.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
