### PR TITLE
[hotfix] Fix unstable testIOExceptionShouldStopTabletServer

### DIFF
--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerFailOverITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerFailOverITCase.java
@@ -88,7 +88,6 @@ class TabletServerFailOverITCase {
                         .waitAndGetLeaderReplica(tb)
                         .getLogTablet()
                         .activeLogSegment();
-        logSegment.flush();
         logSegment.deleteIfExists();
 
         // should get RetriableException since the leader server is shutdown


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #739

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

I found in `testIOExceptionShouldStopTabletServer`, it'll try to write data to a old tablet server. Then I found `newTabletServerClientForNode` will get the client for old server. We should use `Map` to keep `tabletServerInfos` instead of `List` which will cause it contains two different serverNodes with same tablet id

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
