### PR TITLE
Adapt tooling for `bind.listeners` config option

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -18,6 +18,8 @@
 CONF_FILE="${FLUSS_HOME}/conf/server.yaml"
 
 prepare_configuration() {
+    # backward compatability: allow to use old [coordinator|tablet-server].host option in FLUSS_PROPERTIES
+    sed -i '/bind.listeners:/d' "${CONF_FILE}"
     if [ -n "${FLUSS_PROPERTIES}" ]; then
         echo "${FLUSS_PROPERTIES}" >> "${CONF_FILE}"
     fi

--- a/fluss-dist/src/main/resources/bin/local-cluster.sh
+++ b/fluss-dist/src/main/resources/bin/local-cluster.sh
@@ -39,14 +39,15 @@ case $STARTSTOP in
     (start)
         echo "Starting cluster."
 
-        # start zookeeper
+        # Start zookeeper
         "$FLUSS_BIN_DIR"/fluss-daemon.sh start zookeeper "${FLUSS_CONF_DIR}"/zookeeper.properties
 
         # Start single Coordinator Server on this machine
         "$FLUSS_BIN_DIR"/coordinator-server.sh start
 
-        # Start single Tablet Server on this machine
-        "${FLUSS_BIN_DIR}"/tablet-server.sh start
+        # Start single Tablet Server on this machine.
+        # Set bind.listeners as config option to avoid port binding conflict with coordinator server
+        "${FLUSS_BIN_DIR}"/tablet-server.sh start -D bind.listeners=FLUSS://localhost:0
     ;;
 
     (stop)

--- a/fluss-dist/src/main/resources/bin/local-cluster.sh
+++ b/fluss-dist/src/main/resources/bin/local-cluster.sh
@@ -16,14 +16,9 @@
 #
 
 
-USAGE="Usage: $0 (start [args])|stop"
+USAGE="Usage: $0 start|stop"
 
 STARTSTOP=$1
-
-if [ -z $2 ] || [[ $2 == -D* ]]; then
-    # start [-D...]
-    args=("${@:2}")
-fi
 
 if [[ $STARTSTOP != "start" ]] && [[ $STARTSTOP != "stop" ]]; then
   echo $USAGE
@@ -47,7 +42,7 @@ case $STARTSTOP in
 
         # Start single Tablet Server on this machine.
         # Set bind.listeners as config option to avoid port binding conflict with coordinator server
-        "${FLUSS_BIN_DIR}"/tablet-server.sh start -D bind.listeners=FLUSS://localhost:0
+        "${FLUSS_BIN_DIR}"/tablet-server.sh start -Dbind.listeners=FLUSS://localhost:0
     ;;
 
     (stop)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #618

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

`fluss-dist`

- Set `bind.listeners` as dynamic property in `local-cluster.sh` and choose random port to avoid port collision with `bind.listeners` option in `server.yaml` that is used by coordinator server
- Remove dead code

`docker`

Remove `bind.listeners` option from `server.yaml` in docker image to ensure backward compatibility with `[coordinator|tablet-server].host` option

### Tests

<!-- List UT and IT cases to verify this change -->

n/a

### API and Format

<!-- Does this change affect API or storage format -->

n/a

### Documentation

<!-- Does this change introduce a new feature -->

n/a