### PR TITLE
[Docs] Adapt docs for `bind.listeners` config option

### DIFF
--- a/website/docs/install-deploy/deploying-distributed-cluster.md
+++ b/website/docs/install-deploy/deploying-distributed-cluster.md
@@ -30,15 +30,18 @@ This page provides instructions on how to deploy a *distributed cluster* for Flu
 
 Fluss runs on all *UNIX-like environments*, e.g. **Linux**, **Mac OS X**.
 To build a distributed cluster, you need to have at least two nodes.
-This doc provides a simple example of how to deploy a distributed cluster on three nodes.
+This doc provides a simple example of how to deploy a distributed cluster on four nodes.
 
 ### Software Requirements
 
-Before you start to set up the system, make sure you have the following software installed **on each node**:
-- **Java 17** or higher (Java 8 and Java 11 are not recommended)
-- **Zookeeper 3.6.0** or higher (It is not recommended to use zookeeper versions below 3.6.0)
+Before you start to set up the system, make sure you have installed **Java 17** or higher **on each node** in your cluster. 
+Java 8 and Java 11 are not recommended.
 
-If your cluster does not fulfill these software requirements you will need to install/upgrade it.
+Additionally, you need a running **ZooKeeper** cluster with version 3.6.0 or higher. 
+We do not recommend to use ZooKeeper versions below 3.6.0.
+For further information how to deploy a distributed ZooKeeper cluster, see [Running Replicated ZooKeeper](https://zookeeper.apache.org/doc/r3.6.0/zookeeperStarted.html#sc_RunningReplicatedZooKeeper).
+
+If your cluster does not fulfill these software requirements, you will need to install/upgrade them.
 
 ### `JAVA_HOME` Configuration
 
@@ -46,17 +49,18 @@ Flink requires the `JAVA_HOME` environment variable to be set on all nodes and p
 
 ## Fluss Setup
 
-This part will describe how to set up Fluss cluster consisting of one coordinator server and multiple tablet servers
-across three machines. Suppose you have three nodes in a `192.168.10/24` subnet with the following IP address assignment:
-- Node1: `192.168.10.1`
-- Node2: `192.168.10.2`
-- Node3: `192.168.10.3`
+This part will describe how to set up a Fluss cluster consisting of one CoordinatorServer and multiple TabletServers
+across four machines. Suppose you have four nodes in a `192.168.10/24` subnet with the following IP address assignment:
+- Node0: `192.168.10.100`
+- Node1: `192.168.10.101`
+- Node2: `192.168.10.102`
+- Node3: `192.168.10.103`
 
-Node1 will deploy the CoordinatorServer and one TabletServer, Node2 and Node3 will deploy one TabletServer.
+Node0 will deploy a CoordinatorServer instance. Node1, Node2 and Node3 will deploy one TabletServer instance, respectively.
 
 ### Preparation
 
-1. Make sure ZooKeeper has been deployed, and assuming ZooKeeper is also part of the subnet and listens on `192.168.10.99:2181`. See [Running zookeeper cluster](https://zookeeper.apache.org/doc/r3.6.0/zookeeperStarted.html#sc_RunningReplicatedZooKeeper) how to deploy a distributed ZooKeeper.
+1. Make sure ZooKeeper has been deployed. We assume that ZooKeeper listens on `192.168.10.199:2181`.
 
 2. Download Fluss
 
@@ -70,45 +74,43 @@ cd fluss-$FLUSS_VERSION$/
 
 ### Configuring Fluss
 
-After having extracted the archived files, you need to configure Fluss for the cluster.
+After having extracted the archived files, you need to configure Fluss for a distributed deployment.
+We will use the _default config file_ (`conf/server.yaml`) to configure Fluss.
+Adapt the `server.yaml` on each node as follows.
 
-On **each node**, we will use the _default config file_ (`conf/server.yaml`) to configure the _TabletServer_.
-Additionally, we will use a separate _custom config file_ (`conf/coordinator-server.yaml`) to configure the _CoordinatorServer_ on **Node1**.
-The custom config file on **Node1** is necessary to avoid a port collision for the `bind.listeners` config option with between the CoordianatorServer and the TabletServer instance running on the same node.
+**Node0**
 
-Adapt the files on each node as follows.
-
-**Node1**
 ```yaml title="server.yaml"
-# tablet server
-bind.listeners: FLUSS://192.168.10.1:9124 # alternatively, setting the port to 0 assigns a random port
-tablet-server.id: 1
+# coordinator server
+bind.listeners: FLUSS://192.168.10.100:9123
 
-zookeeper.address: 192.168.10.99:2181
+zookeeper.address: 192.168.10.199:2181
 zookeeper.path.root: /fluss
 
 remote.data.dir: /tmp/fluss-remote-data
 ```
 
-Additionally, create a file named `coordinator-server.yaml` in `conf` and add the following content.
+**Node1**
 
-```yaml title="coordinator-server.yaml"
-# coordinator server
-bind.listeners: FLUSS://192.168.10.1:9123
+```yaml title="server.yaml"
+# tablet server
+bind.listeners: FLUSS://192.168.10.101:9124 # alternatively, setting the port to 0 assigns a random port
+tablet-server.id: 1
 
-zookeeper.address: 192.168.10.99:2181
+zookeeper.address: 192.168.10.199:2181
 zookeeper.path.root: /fluss
 
 remote.data.dir: /tmp/fluss-remote-data
 ```
 
 **Node2**
+
 ```yaml title="server.yaml"
 # tablet server
-bind.listeners: FLUSS://192.168.10.2:9124 # alternatively, setting the port to 0 assigns a random port
+bind.listeners: FLUSS://192.168.10.102:9124 # alternatively, setting the port to 0 assigns a random port
 tablet-server.id: 2
 
-zookeeper.address: 192.168.10.99:2181
+zookeeper.address: 192.168.10.199:2181
 zookeeper.path.root: /fluss
 
 remote.data.dir: /tmp/fluss-remote-data
@@ -117,10 +119,13 @@ remote.data.dir: /tmp/fluss-remote-data
 **Node3**
 ```yaml title="server.yaml"
 # tablet server
-bind.listeners: FLUSS://192.168.10.3:9124 # alternatively, setting the port to 0 assigns a random port
+bind.listeners: FLUSS://192.168.10.103:9124 # alternatively, setting the port to 0 assigns a random port
 tablet-server.id: 3
-zookeeper.address: 192.168.10.99:2181
+
+zookeeper.address: 192.168.10.199:2181
 zookeeper.path.root: /fluss
+
+remote.data.dir: /tmp/fluss-remote-data
 ```
 
 :::note
@@ -130,25 +135,24 @@ zookeeper.path.root: /fluss
 
 ### Starting Fluss
 
-To start Fluss, you should first start a CoordinatorServer instance on **Node1**. 
+To deploy a distributed Fluss cluster, you should first start a CoordinatorServer instance on **Node0**. 
 Then, start a TabletServer instance on **Node1**, **Node2**, and **Node3**, respectively.
 
-#### Starting CoordinatorServer
+**CoordinatorServer**
 
-On **Node1**, start a CoordinatorServer instance with the custom config file as follows.
+On **Node0**, start a CoordinatorServer as follows.
 ```shell
-./bin/coordinator-server.sh start -D configFile=conf/coordinator-server.yaml
+./bin/coordinator-server.sh start
 ```
 
-#### Starting TabletServer
+**TabletServer**
 
 On **Node1**, **Node2** and **Node3**, start a TabletServer as follows.
 ```shell
-# uses conf/server.yaml
 ./bin/tablet-server.sh start
 ```
 
-After that, the Fluss distributed cluster is started.
+After that, you have successfully deployed a distributed Fluss cluster.
 
 ## Interacting with Fluss
 
@@ -171,7 +175,7 @@ In Flink SQL client, a catalog is created and named by executing the following q
 ```sql title="Flink SQL"
 CREATE CATALOG fluss_catalog WITH (
   'type' = 'fluss',
-  'bootstrap.servers' = '192.168.10.1:9123'
+  'bootstrap.servers' = '192.168.10.100:9123'
 );
 ```
 

--- a/website/docs/install-deploy/deploying-distributed-cluster.md
+++ b/website/docs/install-deploy/deploying-distributed-cluster.md
@@ -94,7 +94,7 @@ remote.data.dir: /tmp/fluss-remote-data
 
 ```yaml title="server.yaml"
 # tablet server
-bind.listeners: FLUSS://192.168.10.101:9124 # alternatively, setting the port to 0 assigns a random port
+bind.listeners: FLUSS://192.168.10.101:9123 # alternatively, setting the port to 0 assigns a random port
 tablet-server.id: 1
 
 zookeeper.address: 192.168.10.199:2181
@@ -107,7 +107,7 @@ remote.data.dir: /tmp/fluss-remote-data
 
 ```yaml title="server.yaml"
 # tablet server
-bind.listeners: FLUSS://192.168.10.102:9124 # alternatively, setting the port to 0 assigns a random port
+bind.listeners: FLUSS://192.168.10.102:9123 # alternatively, setting the port to 0 assigns a random port
 tablet-server.id: 2
 
 zookeeper.address: 192.168.10.199:2181
@@ -119,7 +119,7 @@ remote.data.dir: /tmp/fluss-remote-data
 **Node3**
 ```yaml title="server.yaml"
 # tablet server
-bind.listeners: FLUSS://192.168.10.103:9124 # alternatively, setting the port to 0 assigns a random port
+bind.listeners: FLUSS://192.168.10.103:9123 # alternatively, setting the port to 0 assigns a random port
 tablet-server.id: 3
 
 zookeeper.address: 192.168.10.199:2181

--- a/website/docs/install-deploy/deploying-with-docker.md
+++ b/website/docs/install-deploy/deploying-with-docker.md
@@ -81,7 +81,7 @@ docker run \
     --name coordinator-server \
     --network=fluss-demo \
     --env FLUSS_PROPERTIES="zookeeper.address: zookeeper:2181
-coordinator.host: coordinator-server" \
+bind.listeners: FLUSS://coordinator-server:9123" \
     -p 9123:9123 \
     -d fluss/fluss:$FLUSS_VERSION$ coordinatorServer
 ```
@@ -100,9 +100,8 @@ docker run \
     --name tablet-server \
     --network=fluss-demo \
     --env FLUSS_PROPERTIES="zookeeper.address: zookeeper:2181
-tablet-server.host: tablet-server
+bind.listeners: FLUSS://tablet-server:9124
 tablet-server.id: 0
-tablet-server.port: 9124
 data.dir: /tmp/fluss/data
 remote.data.dir: /tmp/fluss/remote-data" \
     -p 9124:9124 \
@@ -115,15 +114,14 @@ remote.data.dir: /tmp/fluss/remote-data" \
 In a production environment, you need to start multiple Fluss TabletServer nodes.
 Here we start 3 Fluss TabletServer nodes in daemon and connect to Zookeeper. The command is as follows:
 
-1. start tablet-server-0
+1. Start tablet-server-0
 ```bash
 docker run \
     --name tablet-server-0 \
     --network=fluss-demo \
     --env FLUSS_PROPERTIES="zookeeper.address: zookeeper:2181
-tablet-server.host: tablet-server-0
+bind.listeners: FLUSS://tablet-server-0:9124
 tablet-server.id: 0
-tablet-server.port: 9124
 data.dir: /tmp/fluss/data/tablet-server-0
 remote.data.dir: /tmp/fluss/remote-data" \
     -p 9124:9124 \
@@ -131,15 +129,14 @@ remote.data.dir: /tmp/fluss/remote-data" \
     -d fluss/fluss:$FLUSS_VERSION$ tabletServer
 ```
 
-2. start tablet-server-1
+2. Start tablet-server-1
 ```bash
 docker run \
     --name tablet-server-1 \
     --network=fluss-demo \
     --env FLUSS_PROPERTIES="zookeeper.address: zookeeper:2181
-tablet-server.host: tablet-server-1
+bind.listeners: FLUSS://tablet-server-1:9125
 tablet-server.id: 1
-tablet-server.port: 9125
 data.dir: /tmp/fluss/data/tablet-server-1
 remote.data.dir: /tmp/fluss/remote-data" \
     -p 9125:9125 \
@@ -147,15 +144,14 @@ remote.data.dir: /tmp/fluss/remote-data" \
     -d fluss/fluss:$FLUSS_VERSION$ tabletServer
 ```
 
-3. start tablet-server-2
+3. Start tablet-server-2
 ```bash
 docker run \
     --name tablet-server-2 \
     --network=fluss-demo \
     --env FLUSS_PROPERTIES="zookeeper.address: zookeeper:2181
-tablet-server.host: tablet-server-2
+bind.listeners: FLUSS://tablet-server-2:9126
 tablet-server.id: 2
-tablet-server.port: 9126
 data.dir: /tmp/fluss/data/tablet-server-2
 remote.data.dir: /tmp/fluss/remote-data" \
     -p 9126:9126 \
@@ -179,7 +175,7 @@ to interact with Fluss.
 
 #### Start Flink Cluster
 
-1. start jobManager
+1. Start jobManager
 
 ```bash
 docker run \
@@ -191,7 +187,7 @@ docker run \
     -d fluss/quickstart-flink:1.20-$FLUSS_VERSION_SHORT$ jobmanager
 ```
 
-2. start taskManager
+2. Start taskManager
 
 ```bash
 docker run \
@@ -253,7 +249,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        coordinator.host: coordinator-server
+        bind.listeners: FLUSS://coordinator-server:9123
         remote.data.dir: /tmp/fluss/remote-data
   tablet-server:
     image: fluss/fluss:$FLUSS_VERSION$
@@ -264,7 +260,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server
+        bind.listeners: FLUSS://tablet-server:9123
         tablet-server.id: 0
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data
@@ -298,7 +294,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        coordinator.host: coordinator-server
+        bind.listeners: FLUSS://coordinator-server:9123
         remote.data.dir: /tmp/fluss/remote-data
   tablet-server-0:
     image: fluss/fluss:$FLUSS_VERSION$
@@ -309,7 +305,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-0
+        bind.listeners: FLUSS://tablet-server-0:9123
         tablet-server.id: 0
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-0
@@ -325,7 +321,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-1
+        bind.listeners: FLUSS://tablet-server-1:9123
         tablet-server.id: 1
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-1
@@ -341,7 +337,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-2
+        bind.listeners: FLUSS://tablet-server-2:9123
         tablet-server.id: 2
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-2
@@ -387,7 +383,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        coordinator.host: coordinator-server
+        bind.listeners: FLUSS://coordinator-server:9123
         remote.data.dir: /tmp/fluss/remote-data
   tablet-server-0:
     image: fluss/fluss:$FLUSS_VERSION$
@@ -398,7 +394,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-0
+        bind.listeners: FLUSS://tablet-server-0:9123
         tablet-server.id: 0
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-0
@@ -414,7 +410,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-1
+        bind.listeners: FLUSS://tablet-server-1:9123
         tablet-server.id: 1
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-1
@@ -430,7 +426,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server-2
+        bind.listeners: FLUSS://tablet-server-2:9123
         tablet-server.id: 2
         kv.snapshot.interval: 0s
         data.dir: /tmp/fluss/data/tablet-server-2

--- a/website/docs/maintenance/observability/quickstart.md
+++ b/website/docs/maintenance/observability/quickstart.md
@@ -222,7 +222,7 @@ This recreates `shared-tmpfs` and all data is lost (created tables, running jobs
 Make sure that the modified and added containers are up and running using
 
 ```shell
-docker ps
+docker container ls -a
 ```
 
 4. Now you are all set! You can visit

--- a/website/docs/maintenance/observability/quickstart.md
+++ b/website/docs/maintenance/observability/quickstart.md
@@ -107,7 +107,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        coordinator.host: coordinator-server
+        bind.listeners: FLUSS://coordinator-server:9123
         remote.data.dir: /tmp/fluss/remote-data
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
@@ -129,7 +129,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server
+        bind.listeners: FLUSS://tablet-server:9123
         data.dir: /tmp/fluss/data
         remote.data.dir: /tmp/fluss/remote-data
         kv.snapshot.interval: 0s

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -63,7 +63,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        coordinator.host: coordinator-server
+        bind.listeners: FLUSS://coordinator-server:9123
         remote.data.dir: /tmp/fluss/remote-data
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
@@ -77,7 +77,7 @@ services:
       - |
         FLUSS_PROPERTIES=
         zookeeper.address: zookeeper:2181
-        tablet-server.host: tablet-server
+        bind.listeners: FLUSS://tablet-server:9123
         data.dir: /tmp/fluss/data
         remote.data.dir: /tmp/fluss/remote-data
         kv.snapshot.interval: 0s
@@ -363,7 +363,7 @@ SELECT * FROM fluss_customer WHERE `cust_key` = 1;
 To integrate with [Apache Paimon](https://paimon.apache.org/), you need to start the `Lakehouse Tiering Service`. 
 Open a new terminal, navigate to the `fluss-quickstart-flink` directory, and execute the following command within this directory to start the service:
 ```shell
-docker compose exec coordinator-server ./bin/lakehouse.sh -Dflink.rest.address=jobmanager -Dflink.rest.port=8081 -Dflink.execution.checkpointing.interval=30s
+docker compose exec coordinator-server ./bin/lakehouse.sh -Dflink.rest.address=jobmanager -Dflink.rest.port=8081 -Dflink.execution.checkpointing.interval=30s -Dbootstrap.servers=coordinator-server:9123
 ```
 You should see a Flink Job named `fluss-paimon-tiering-service` running in the [Flink Web UI](http://localhost:8083/).
 

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -140,7 +140,7 @@ This command automatically starts all the containers defined in the Docker Compo
 
 Run 
 ```shell
-docker ps
+docker container ls -a
 ```
 to check whether all containers are running properly.
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #619
<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Replaced `[coordinator|tablet-server].host` config option with `bind.listeners` in quickstart guides and "Deploying with Docker" guide
- Adapt "Deploying Distributed Cluster" to avoid port collision 

### Tests

<!-- List UT and IT cases to verify this change -->

n/a

### API and Format

<!-- Does this change affect API or storage format -->

n/a

### Documentation

<!-- Does this change introduce a new feature -->

n/a