### PR TITLE
[Dist] Fix bug when passing dynamic properties to CLI tooling

### DIFF
--- a/fluss-dist/src/main/resources/bin/coordinator-server.sh
+++ b/fluss-dist/src/main/resources/bin/coordinator-server.sh
@@ -22,8 +22,8 @@ USAGE="Usage: $0 ((start|start-foreground) [args])|stop|stop-all"
 
 STARTSTOP=$1
 
-if [ -z $2 ] || [[ $2 == "-D" ]]; then
-    # start [-D ...]
+if [ -z $2 ] || [[ $2 == -D* ]]; then
+    # start|start-foreground [-D...]
     args=("${@:2}")
 fi
 

--- a/fluss-dist/src/main/resources/bin/lakehouse.sh
+++ b/fluss-dist/src/main/resources/bin/lakehouse.sh
@@ -15,8 +15,8 @@
 # limitations under the License.
 #
 
-if [ -z $1 ] || [[ $1 == "-D" ]]; then
-    # [-D ...]
+if [ -z $1 ] || [[ $1 == -D* ]]; then
+    # [-D...]
     args=("${@:1}")
 fi
 

--- a/fluss-dist/src/main/resources/bin/local-cluster.sh
+++ b/fluss-dist/src/main/resources/bin/local-cluster.sh
@@ -20,8 +20,8 @@ USAGE="Usage: $0 (start [args])|stop"
 
 STARTSTOP=$1
 
-if [ -z $2 ] || [[ $2 == "-D" ]]; then
-    # start [-D ...]
+if [ -z $2 ] || [[ $2 == -D* ]]; then
+    # start [-D...]
     args=("${@:2}")
 fi
 

--- a/fluss-dist/src/main/resources/bin/tablet-server.sh
+++ b/fluss-dist/src/main/resources/bin/tablet-server.sh
@@ -22,8 +22,8 @@ USAGE="Usage: $0 ((start|start-foreground) [args])|stop|stop-all"
 
 STARTSTOP=$1
 
-if [ -z $2 ] || [[ $2 == "-D" ]]; then
-    # start [-D ...]
+if [ -z $2 ] || [[ $2 == -D* ]]; then
+    # start|start-foreground [-D...]
     args=("${@:2}")
 fi
 

--- a/website/docs/maintenance/tiered-storage/lakehouse-storage.md
+++ b/website/docs/maintenance/tiered-storage/lakehouse-storage.md
@@ -56,7 +56,7 @@ You can use the following commands to start the datalake tiering service:
 cd $FLUSS_HOME
 
 # start the tiering service, assuming rest endpoint is localhost:8081
-./bin/lakehouse.sh -D flink.rest.address=localhost -D flink.rest.port=8081 
+./bin/lakehouse.sh -Dflink.rest.address=localhost -Dflink.rest.port=8081 
 ```
 
 **Note:**
@@ -64,12 +64,12 @@ cd $FLUSS_HOME
 - The datalake tiering service is actual a flink job, you can set the Flink configuration in `-D` arguments while starting the datalake tiering service, There are some example commands for reference below.
 ```shell
 # If want to set the checkpoint interval to 10s, you can use the following command to start the datalake tiering service
-./bin/lakehouse.sh -D flink.rest.address=localhost -D flink.rest.port=8081 -D flink.execution.checkpointing.interval=10s
+./bin/lakehouse.sh -Dflink.rest.address=localhost -Dflink.rest.port=8081 -Dflink.execution.checkpointing.interval=10s
 
 # By default, datalake tiering service synchronizes all the tables with datalake enabled to Lakehouse Storage.
 # To distribute the workload of the datalake tiering service through multiple Flink jobs, 
 # you can specify the "database" parameter to synchronize only the datalake enabled tables in the specific database.
-./bin/lakehouse.sh -D flink.rest.address=localhost -D flink.rest.port=8081 -D database=fluss_\\w+
+./bin/lakehouse.sh -Dflink.rest.address=localhost -Dflink.rest.port=8081 -Ddatabase=fluss_\\w+
 ```
 
 ### Enable Lakehouse Storage Per Table

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -363,7 +363,7 @@ SELECT * FROM fluss_customer WHERE `cust_key` = 1;
 To integrate with [Apache Paimon](https://paimon.apache.org/), you need to start the `Lakehouse Tiering Service`. 
 Open a new terminal, navigate to the `fluss-quickstart-flink` directory, and execute the following command within this directory to start the service:
 ```shell
-docker compose exec coordinator-server ./bin/lakehouse.sh -D flink.rest.address=jobmanager -D flink.rest.port=8081 -D flink.execution.checkpointing.interval=30s
+docker compose exec coordinator-server ./bin/lakehouse.sh -Dflink.rest.address=jobmanager -Dflink.rest.port=8081 -Dflink.execution.checkpointing.interval=30s
 ```
 You should see a Flink Job named `fluss-paimon-tiering-service` running in the [Flink Web UI](http://localhost:8083/).
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #761

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Check for "starts with" instead of equality for dynamic properties argument, to support `-Dkey=value` (without space between `-D` option and its argument) in addition to `-D key=value` in CLI tooling.
- Adapt docs to use `-Dkey=value` instead of `-D key=value`

### Tests

<!-- List UT and IT cases to verify this change -->

n/a

### API and Format

<!-- Does this change affect API or storage format -->

n/a

### Documentation

<!-- Does this change introduce a new feature -->

n/a