### PR TITLE
[server] AutoPartitionManager shouldn't create partitions for dropped table

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/utils/PartitionUtils.java
@@ -21,7 +21,7 @@ import com.alibaba.fluss.config.AutoPartitionTimeUnit;
 import com.alibaba.fluss.exception.InvalidPartitionException;
 import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
-import com.alibaba.fluss.metadata.TableInfo;
+import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.DataTypeRoot;
 
 import java.time.ZonedDateTime;
@@ -46,14 +46,14 @@ public class PartitionUtils {
     private static final String DAY_FORMAT = "yyyyMMdd";
     private static final String HOUR_FORMAT = "yyyyMMddHH";
 
-    public static void validatePartitionSpec(TableInfo tableInfo, PartitionSpec partitionSpec) {
-        List<String> partitionKeys = tableInfo.getPartitionKeys();
+    public static void validatePartitionSpec(
+            TablePath tablePath, List<String> partitionKeys, PartitionSpec partitionSpec) {
         Map<String, String> partitionSpecMap = partitionSpec.getSpecMap();
         if (partitionKeys.size() != partitionSpecMap.size()) {
             throw new InvalidPartitionException(
                     String.format(
                             "PartitionSpec size is not equal to partition keys size for partitioned table %s.",
-                            tableInfo.getTablePath()));
+                            tablePath));
         }
 
         List<String> reOrderedPartitionValues = new ArrayList<>(partitionKeys.size());
@@ -62,7 +62,7 @@ public class PartitionUtils {
                 throw new InvalidPartitionException(
                         String.format(
                                 "PartitionSpec %s does not contain partition key '%s' for partitioned table %s.",
-                                partitionSpec, partitionKey, tableInfo.getTablePath()));
+                                partitionSpec, partitionKey, tablePath));
             } else {
                 reOrderedPartitionValues.add(partitionSpecMap.get(partitionKey));
             }

--- a/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/utils/PartitionUtilsTest.java
@@ -71,7 +71,9 @@ class PartitionUtilsTest {
         assertThatThrownBy(
                         () ->
                                 validatePartitionSpec(
-                                        tableInfo, new PartitionSpec(Collections.emptyMap())))
+                                        tableInfo.getTablePath(),
+                                        tableInfo.getPartitionKeys(),
+                                        new PartitionSpec(Collections.emptyMap())))
                 .isInstanceOf(InvalidPartitionException.class)
                 .hasMessageContaining(
                         "PartitionSpec size is not equal to partition keys size for "

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
@@ -30,6 +30,7 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.data.BucketAssignment;
 import com.alibaba.fluss.server.zk.data.PartitionAssignment;
+import com.alibaba.fluss.server.zk.data.TableRegistration;
 import com.alibaba.fluss.utils.AutoPartitionStrategy;
 import com.alibaba.fluss.utils.clock.Clock;
 import com.alibaba.fluss.utils.clock.SystemClock;
@@ -151,17 +152,27 @@ public class AutoPartitionManager implements AutoCloseable {
         // schedule auto partition for this table immediately
         periodicExecutor.schedule(
                 () -> doAutoPartition(tableId, forceDoAutoPartition), 0, TimeUnit.MILLISECONDS);
+        LOG.info(
+                "Added auto partition table [{}] (id={}) into scheduler",
+                tableInfo.getTablePath(),
+                tableInfo.getTableId());
     }
 
     public void removeAutoPartitionTable(long tableId) {
         checkNotClosed();
-        inLock(
-                lock,
-                () -> {
-                    autoPartitionTables.remove(tableId);
-                    partitionsByTable.remove(tableId);
-                    autoCreateDayPartitionDelayMinutes.remove(tableId);
-                });
+        TableInfo tableInfo =
+                inLock(
+                        lock,
+                        () -> {
+                            partitionsByTable.remove(tableId);
+                            return autoPartitionTables.remove(tableId);
+                        autoCreateDayPartitionDelayMinutes.remove(tableId);});
+        if (tableInfo != null) {
+            LOG.info(
+                    "Removed auto partition table [{}] (id={}) from scheduler",
+                    tableInfo.getTablePath(),
+                    tableInfo.getTableId());
+        }
     }
 
     /**
@@ -209,19 +220,18 @@ public class AutoPartitionManager implements AutoCloseable {
 
     private void doAutoPartition() {
         Instant now = clock.instant();
-        LOG.info("Start auto partitioning for all tables at {}.", now);
         inLock(lock, () -> doAutoPartition(now, autoPartitionTables.keySet(), false));
     }
 
     private void doAutoPartition(long tableId, boolean forceDoAutoPartition) {
         Instant now = clock.instant();
-        LOG.info("Start auto partitioning for table {} at {}.", tableId, now);
         inLock(
                 lock,
                 () -> doAutoPartition(now, Collections.singleton(tableId), forceDoAutoPartition));
     }
 
     private void doAutoPartition(Instant now, Set<Long> tableIds, boolean forceDoAutoPartition) {
+        LOG.info("Start auto partitioning for {} tables at {}.", tableIds.size(), now);
         for (Long tableId : tableIds) {
             Instant createPartitionInstant = now;
             TableInfo tableInfo = autoPartitionTables.get(tableId);
@@ -235,8 +245,28 @@ public class AutoPartitionManager implements AutoCloseable {
             }
             TreeSet<String> currentPartitions =
                     partitionsByTable.computeIfAbsent(tableId, k -> new TreeSet<>());
+            TableInfo tableInfo = autoPartitionTables.get(tableId);
+            TablePath tablePath = tableInfo.getTablePath();
+            TableRegistration table;
+            try {
+                table = metadataManager.getTableRegistration(tablePath);
+            } catch (Exception e) {
+                LOG.warn(
+                        "Skipping auto partitioning for table [{}] (id={}) as failed to get table information.",
+                        tablePath,
+                        tableId,
+                        e);
+                continue;
+            }
+            if (table.tableId != tableId) {
+                LOG.warn(
+                        "Skipping auto partitioning for table [{}] (id={}) as the table has been dropped.",
+                        tablePath,
+                        tableId);
+                continue;
+            }
             dropPartitions(
-                    tableInfo.getTablePath(),
+                    tablePath,
                     tableInfo.getPartitionKeys(),
                     createPartitionInstant,
                     tableInfo.getTableConfig().getAutoPartitionStrategy(),

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/AutoPartitionManager.java
@@ -165,8 +165,9 @@ public class AutoPartitionManager implements AutoCloseable {
                         lock,
                         () -> {
                             partitionsByTable.remove(tableId);
+                            autoCreateDayPartitionDelayMinutes.remove(tableId);
                             return autoPartitionTables.remove(tableId);
-                        autoCreateDayPartitionDelayMinutes.remove(tableId);});
+                        });
         if (tableInfo != null) {
             LOG.info(
                     "Removed auto partition table [{}] (id={}) from scheduler",
@@ -234,7 +235,6 @@ public class AutoPartitionManager implements AutoCloseable {
         LOG.info("Start auto partitioning for {} tables at {}.", tableIds.size(), now);
         for (Long tableId : tableIds) {
             Instant createPartitionInstant = now;
-            TableInfo tableInfo = autoPartitionTables.get(tableId);
             if (!forceDoAutoPartition) {
                 // not to force do auto partition and delay exist,
                 // we use now - delayMinutes as current instant to mock the delay

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -29,7 +29,6 @@ import com.alibaba.fluss.metadata.DatabaseDescriptor;
 import com.alibaba.fluss.metadata.PartitionSpec;
 import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TableDescriptor;
-import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
 import com.alibaba.fluss.rpc.messages.AdjustIsrRequest;
@@ -78,6 +77,7 @@ import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.data.BucketAssignment;
 import com.alibaba.fluss.server.zk.data.PartitionAssignment;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
+import com.alibaba.fluss.server.zk.data.TableRegistration;
 import com.alibaba.fluss.utils.concurrent.FutureUtils;
 
 import javax.annotation.Nullable;
@@ -292,30 +292,30 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         CreatePartitionResponse response = new CreatePartitionResponse();
         TableInfo tableInfo = metadataManager.getTable(tablePath);
         if (!tableInfo.isPartitioned()) {
+        TableRegistration table = metadataManager.getTableRegistration(tablePath);
+        if (!table.isPartitioned()) {
             throw new TableNotPartitionedException(
                     "Only partitioned table support create partition.");
         }
 
         // first, validate the partition spec, and get resolved partition spec.
         PartitionSpec partitionSpec = getPartitionSpec(request.getPartitionSpec());
-        validatePartitionSpec(tableInfo, partitionSpec);
+        validatePartitionSpec(tablePath, table.partitionKeys, partitionSpec);
         ResolvedPartitionSpec partitionToCreate =
-                ResolvedPartitionSpec.fromPartitionSpec(
-                        tableInfo.getPartitionKeys(), partitionSpec);
+                ResolvedPartitionSpec.fromPartitionSpec(table.partitionKeys, partitionSpec);
 
         // second, generate the PartitionAssignment.
-        int replicaFactor = tableInfo.getTableConfig().getReplicationFactor();
+        int replicaFactor = table.getTableConfig().getReplicationFactor();
         int[] servers = metadataCache.getLiveServerIds();
         Map<Integer, BucketAssignment> bucketAssignments =
-                TableAssignmentUtils.generateAssignment(
-                                tableInfo.getNumBuckets(), replicaFactor, servers)
+                TableAssignmentUtils.generateAssignment(table.bucketCount, replicaFactor, servers)
                         .getBucketAssignments();
         PartitionAssignment partitionAssignment =
-                new PartitionAssignment(tableInfo.getTableId(), bucketAssignments);
+                new PartitionAssignment(table.tableId, bucketAssignments);
 
         metadataManager.createPartition(
-                tableInfo.getTablePath(),
-                tableInfo.getTableId(),
+                tablePath,
+                table.tableId,
                 partitionAssignment,
                 partitionToCreate,
                 request.isIgnoreIfNotExists());
@@ -333,18 +333,18 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         }
 
         DropPartitionResponse response = new DropPartitionResponse();
-        TableInfo tableInfo = metadataManager.getTable(tablePath);
-        if (!tableInfo.isPartitioned()) {
+        TablePath tablePath = toTablePath(request.getTablePath());
+        TableRegistration table = metadataManager.getTableRegistration(tablePath);
+        if (!table.isPartitioned()) {
             throw new TableNotPartitionedException(
                     "Only partitioned table support drop partition.");
         }
 
         // first, validate the partition spec.
         PartitionSpec partitionSpec = getPartitionSpec(request.getPartitionSpec());
-        validatePartitionSpec(tableInfo, partitionSpec);
+        validatePartitionSpec(tablePath, table.partitionKeys, partitionSpec);
         ResolvedPartitionSpec partitionToDrop =
-                ResolvedPartitionSpec.fromPartitionSpec(
-                        tableInfo.getPartitionKeys(), partitionSpec);
+                ResolvedPartitionSpec.fromPartitionSpec(table.partitionKeys, partitionSpec);
 
         metadataManager.dropPartition(tablePath, partitionToDrop, request.isIgnoreIfNotExists());
         return CompletableFuture.completedFuture(response);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -290,8 +290,6 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         }
 
         CreatePartitionResponse response = new CreatePartitionResponse();
-        TableInfo tableInfo = metadataManager.getTable(tablePath);
-        if (!tableInfo.isPartitioned()) {
         TableRegistration table = metadataManager.getTableRegistration(tablePath);
         if (!table.isPartitioned()) {
             throw new TableNotPartitionedException(
@@ -333,7 +331,6 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         }
 
         DropPartitionResponse response = new DropPartitionResponse();
-        TablePath tablePath = toTablePath(request.getTablePath());
         TableRegistration table = metadataManager.getTableRegistration(tablePath);
         if (!table.isPartitioned()) {
             throw new TableNotPartitionedException(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/MetadataManager.java
@@ -267,8 +267,6 @@ public class MetadataManager {
                     // register the table
                     zookeeperClient.registerTable(
                             tablePath, TableRegistration.newTable(tableId, tableToCreate), false);
-                    // create partitions parent path
-                    zookeeperClient.createPartitionsPath(tablePath);
                     return tableId;
                 },
                 "Fail to create table " + tablePath);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
@@ -426,11 +426,6 @@ public class ZooKeeperClient implements AutoCloseable {
         return stat.getNumChildren();
     }
 
-    public void createPartitionsPath(TablePath tablePath) throws Exception {
-        String path = PartitionsZNode.path(tablePath);
-        zkClient.create().withMode(CreateMode.PERSISTENT).forPath(path);
-    }
-
     /** Create a partition for a table in ZK. */
     public void registerPartition(
             TablePath tablePath, long tableId, String partitionName, long partitionId)

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
@@ -426,13 +426,17 @@ public class ZooKeeperClient implements AutoCloseable {
         return stat.getNumChildren();
     }
 
+    public void createPartitionsPath(TablePath tablePath) throws Exception {
+        String path = PartitionsZNode.path(tablePath);
+        zkClient.create().withMode(CreateMode.PERSISTENT).forPath(path);
+    }
+
     /** Create a partition for a table in ZK. */
     public void registerPartition(
             TablePath tablePath, long tableId, String partitionName, long partitionId)
             throws Exception {
         String path = PartitionZNode.path(tablePath, partitionName);
         zkClient.create()
-                .creatingParentsIfNeeded()
                 .withMode(CreateMode.PERSISTENT)
                 .forPath(path, PartitionZNode.encode(new TablePartition(tableId, partitionId)));
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
@@ -437,6 +437,7 @@ public class ZooKeeperClient implements AutoCloseable {
             throws Exception {
         String path = PartitionZNode.path(tablePath, partitionName);
         zkClient.create()
+                .creatingParentsIfNeeded()
                 .withMode(CreateMode.PERSISTENT)
                 .forPath(path, PartitionZNode.encode(new TablePartition(tableId, partitionId)));
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableRegistration.java
@@ -18,6 +18,7 @@ package com.alibaba.fluss.server.zk.data;
 
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.config.TableConfig;
 import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.SchemaInfo;
 import com.alibaba.fluss.metadata.TableDescriptor;
@@ -74,6 +75,14 @@ public class TableRegistration {
         this.customProperties = customProperties;
         this.createdTime = createdTime;
         this.modifiedTime = modifiedTime;
+    }
+
+    public boolean isPartitioned() {
+        return !partitionKeys.isEmpty();
+    }
+
+    public TableConfig getTableConfig() {
+        return new TableConfig(Configuration.fromMap(properties));
     }
 
     public TableInfo toTableInfo(TablePath tablePath, SchemaInfo schemaInfo) {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
@@ -394,6 +394,16 @@ class TableManagerITCase {
 
         // let's drop the table
         adminGateway.dropTable(newDropTableRequest(db1, tb1, false)).get();
+        assertThat(zkClient.getPartitions(tablePath)).isEmpty();
+
+        // create a non-auto-partitioned table
+        adminGateway
+                .createTable(
+                        newCreateTableRequest(
+                                tablePath,
+                                newPartitionedTable().withProperties(new HashMap<>()),
+                                false))
+                .get();
 
         // verify the partition assignment is deleted
         for (Long partitionId : partitions.values()) {
@@ -401,6 +411,9 @@ class TableManagerITCase {
                     Duration.ofMinutes(1),
                     () -> assertThat(zkClient.getPartitionAssignment(partitionId)).isEmpty());
         }
+
+        // make sure the auto partition manager won't create partitions for the new table
+        assertThat(zkClient.getPartitions(tablePath)).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #712

<!-- What is the purpose of the change -->

This is a simple fix for #712 that during auto-partition creating it should first check if the table is dropped or re-created before creating partitions. This still don't guarantes the table id consist between the table node and partition node, because the table maybe re-created after the checking... But this should happen very rarely and is tracked in https://github.com/alibaba/fluss/issues/767.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
