### PR TITLE
[hotfix] Fix lead not in isr issue

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/LeaderAndIsr.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/LeaderAndIsr.java
@@ -31,6 +31,7 @@ public class LeaderAndIsr {
 
     public static final int INITIAL_LEADER_EPOCH = 0;
     public static final int INITIAL_BUCKET_EPOCH = 0;
+    public static final int NO_LEADER = -1;
 
     /** The leader replica id. */
     private final int leader;
@@ -68,8 +69,8 @@ public class LeaderAndIsr {
         this.bucketEpoch = bucketEpoch;
     }
 
-    public LeaderAndIsr newLeaderAndIsr(List<Integer> newIsr) {
-        return new LeaderAndIsr(leader, leaderEpoch, newIsr, coordinatorEpoch, bucketEpoch + 1);
+    public LeaderAndIsr newLeaderAndIsr(int newLeader, List<Integer> newIsr) {
+        return new LeaderAndIsr(newLeader, leaderEpoch, newIsr, coordinatorEpoch, bucketEpoch + 1);
     }
 
     public int leader() {

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
@@ -215,12 +215,14 @@ class ReplicaStateMachineTest {
         assertThat(leaderAndIsr)
                 .isEqualTo(new LeaderAndIsr(0, 0, Collections.singletonList(0), 0, 2));
 
-        // set replica 0 to offline, isr shouldn't be empty
+        // set replica 0 to offline, isr shouldn't be empty, leader should be NO_LEADER
         replicaStateMachine.handleStateChanges(
                 Collections.singleton(new TableBucketReplica(tableBucket, 0)), OfflineReplica);
         leaderAndIsr = coordinatorContext.getBucketLeaderAndIsr(tableBucket).get();
         assertThat(leaderAndIsr)
-                .isEqualTo(new LeaderAndIsr(0, 0, Collections.singletonList(0), 0, 2));
+                .isEqualTo(
+                        new LeaderAndIsr(
+                                LeaderAndIsr.NO_LEADER, 0, Collections.singletonList(0), 0, 3));
     }
 
     private void toReplicaDeletionStartedState(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
During complete #662, I mistake the mark leader as  `NO_LEADER` when the leader become offline in `ReplicaStatemachine` is only for unclean shutdown, so I keep the leader as same. But It may bring that the leader not in isr which will cause the leader change isr to empty array. 

This pr is to fix this.

<!-- What is the purpose of the change -->

### Brief change log
When the leader of the bucket is offline,  set the leader to `-1` marked as `NO_LEADER` just like Kafka

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

Have verified in my env, but Let's add IT in #644 by the way.

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
