### PR TITLE
[server] Support generating rack aware bucket assignment when creating table

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/utils/MetadataUtils.java
@@ -297,7 +297,8 @@ public class MetadataUtils {
                                             nodeId,
                                             serverNode.getHost(),
                                             serverNode.getPort(),
-                                            ServerType.TABLET_SERVER));
+                                            ServerType.TABLET_SERVER,
+                                            serverNode.getRack()));
                         });
         return aliveTabletServers;
     }

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/metadata/TestingMetadataUpdater.java
@@ -44,11 +44,11 @@ public class TestingMetadataUpdater extends MetadataUpdater {
     private static final ServerNode COORDINATOR =
             new ServerNode(0, "localhost", 90, ServerType.COORDINATOR);
     private static final ServerNode NODE1 =
-            new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER);
+            new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER, "rack1");
     private static final ServerNode NODE2 =
-            new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER);
+            new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER, "rack2");
     private static final ServerNode NODE3 =
-            new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER);
+            new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER, "rack3");
 
     private final TestCoordinatorGateway coordinatorGateway;
     private final Map<Integer, TestTabletServerGateway> tabletServerGatewayMap;

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/RecordAccumulatorTest.java
@@ -95,9 +95,9 @@ class RecordAccumulatorTest {
                     System.currentTimeMillis(),
                     System.currentTimeMillis());
 
-    ServerNode node1 = new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER);
-    ServerNode node2 = new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER);
-    ServerNode node3 = new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER);
+    ServerNode node1 = new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER, "rack1");
+    ServerNode node2 = new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER, "rack2");
+    ServerNode node3 = new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER, "rack3");
     private final ServerNode[] serverNodes = new ServerNode[] {node1, node2, node3};
     private final TableBucket tb1 = new TableBucket(DATA1_TABLE_ID, 0);
     private final TableBucket tb2 = new TableBucket(DATA1_TABLE_ID, 1);

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/StickyStaticBucketAssignerTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/StickyStaticBucketAssignerTest.java
@@ -46,9 +46,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link StickyBucketAssigner}. */
 class StickyStaticBucketAssignerTest {
-    ServerNode node1 = new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER);
-    ServerNode node2 = new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER);
-    ServerNode node3 = new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER);
+    ServerNode node1 = new ServerNode(1, "localhost", 90, ServerType.TABLET_SERVER, "rack1");
+    ServerNode node2 = new ServerNode(2, "localhost", 91, ServerType.TABLET_SERVER, "rack2");
+    ServerNode node3 = new ServerNode(3, "localhost", 92, ServerType.TABLET_SERVER, "rack3");
     private final ServerNode[] serverNodes = new ServerNode[] {node1, node2, node3};
     private final BucketLocation bucket1 =
             new BucketLocation(DATA1_PHYSICAL_TABLE_PATH, DATA1_TABLE_ID, 0, node1, serverNodes);

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/MetadataCache.java
@@ -64,17 +64,17 @@ public interface MetadataCache {
      */
     Map<Integer, ServerNode> getAllAliveTabletServers(String listenerName);
 
-    Set<Integer> getAliveTabletServerIds();
+    Set<TabletServerInfo> getAliveTabletServerInfos();
 
     @Nullable
     PhysicalTablePath getTablePath(long tableId);
 
     /** Get ids of all alive tablet server nodes. */
-    default int[] getLiveServerIds() {
-        Set<Integer> aliveTabletServerIds = getAliveTabletServerIds();
-        int[] server = new int[aliveTabletServerIds.size()];
-        Iterator<Integer> iterator = aliveTabletServerIds.iterator();
-        for (int i = 0; i < aliveTabletServerIds.size(); i++) {
+    default TabletServerInfo[] getLiveServers() {
+        Set<TabletServerInfo> aliveTabletServerInfos = getAliveTabletServerInfos();
+        TabletServerInfo[] server = new TabletServerInfo[aliveTabletServerInfos.size()];
+        Iterator<TabletServerInfo> iterator = aliveTabletServerInfos.iterator();
+        for (int i = 0; i < aliveTabletServerInfos.size(); i++) {
             server[i] = iterator.next();
         }
         return server;

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/ServerNode.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/ServerNode.java
@@ -18,6 +18,8 @@ package com.alibaba.fluss.cluster;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
 
+import javax.annotation.Nullable;
+
 import java.util.Objects;
 
 /**
@@ -33,15 +35,23 @@ public class ServerNode {
     private final int port;
     private final ServerType serverType;
 
+    /** rack info for ServerNode. Currently, only tabletServer has rack info. */
+    private final @Nullable String rack;
+
     // Cache hashCode as it is called in performance sensitive parts of the code (e.g.
     // RecordAccumulator.ready)
     private Integer hash;
 
     public ServerNode(int id, String host, int port, ServerType serverType) {
+        this(id, host, port, serverType, null);
+    }
+
+    public ServerNode(int id, String host, int port, ServerType serverType, @Nullable String rack) {
         this.id = id;
         this.host = host;
         this.port = port;
         this.serverType = serverType;
+        this.rack = rack;
         if (serverType == ServerType.COORDINATOR) {
             this.uid = "cs-" + id;
         } else {
@@ -80,6 +90,11 @@ public class ServerNode {
         return serverType;
     }
 
+    /** The rack for this node. */
+    public @Nullable String rack() {
+        return rack;
+    }
+
     /**
      * Check whether this node is empty, which may be the case if noNode() is used as a placeholder
      * in a response payload with an error.
@@ -98,6 +113,7 @@ public class ServerNode {
             result = 31 * result + id;
             result = 31 * result + port;
             result = 31 * result + serverType.hashCode();
+            result = 31 * result + ((rack == null) ? 0 : rack.hashCode());
             this.hash = result;
             return result;
         } else {
@@ -117,11 +133,12 @@ public class ServerNode {
         return id == other.id
                 && port == other.port
                 && Objects.equals(host, other.host)
-                && serverType == other.serverType;
+                && serverType == other.serverType
+                && Objects.equals(rack, other.rack);
     }
 
     @Override
     public String toString() {
-        return host + ":" + port + " (id: " + uid + ")";
+        return host + ":" + port + " (id: " + uid + ", rack: " + rack + ")";
     }
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/cluster/TabletServerInfo.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/cluster/TabletServerInfo.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.cluster;
+
+import javax.annotation.Nullable;
+
+import java.util.Objects;
+
+/** Tablet server info. */
+public class TabletServerInfo {
+    private final int id;
+
+    private @Nullable final String rack;
+
+    public TabletServerInfo(int id, @Nullable String rack) {
+        this.id = id;
+        this.rack = rack;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public @Nullable String getRack() {
+        return rack;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TabletServerInfo that = (TabletServerInfo) o;
+        return id == that.id && Objects.equals(rack, that.rack);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, rack);
+    }
+}

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -343,6 +343,14 @@ public class ConfigOptions {
                     .noDefaultValue()
                     .withDescription("The id for the tablet server.");
 
+    public static final ConfigOption<String> TABLET_SERVER_RACK =
+            key("tablet-server.rack")
+                    .stringType()
+                    .noDefaultValue()
+                    .withDescription(
+                            "The rack for the tabletServer. This will be used in rack aware bucket assignment "
+                                    + "for fault tolerance. Examples: `RACK1`, `cn-hangzhou-server10`");
+
     public static final ConfigOption<String> DATA_DIR =
             key("data.dir")
                     .stringType()

--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidServerRackInfoException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/InvalidServerRackInfoException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/**
+ * Exception for invalid server rack info. For example, not all tabletServer have assigned rack
+ * info.
+ */
+public class InvalidServerRackInfoException extends ApiException {
+    public InvalidServerRackInfoException(String message) {
+        super(message);
+    }
+}

--- a/fluss-common/src/test/java/com/alibaba/fluss/cluster/BucketLocationTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/cluster/BucketLocationTest.java
@@ -31,9 +31,11 @@ public class BucketLocationTest {
         TablePath tablePath = new TablePath("test_db", "test_table");
         int bucketId = 0;
         long tableId = 150001L;
-        ServerNode leader = new ServerNode(0, "localhost", 9092, ServerType.TABLET_SERVER);
-        ServerNode replica1 = new ServerNode(1, "localhost", 9093, ServerType.TABLET_SERVER);
-        ServerNode replica2 = new ServerNode(2, "localhost", 9094, ServerType.TABLET_SERVER);
+        ServerNode leader = new ServerNode(0, "localhost", 9092, ServerType.TABLET_SERVER, "rack0");
+        ServerNode replica1 =
+                new ServerNode(1, "localhost", 9093, ServerType.TABLET_SERVER, "rack1");
+        ServerNode replica2 =
+                new ServerNode(2, "localhost", 9094, ServerType.TABLET_SERVER, "rack2");
         ServerNode[] replicas = {leader, replica1, replica2};
         // TODO add isr and offline.
         BucketLocation bucketLocation =

--- a/fluss-common/src/test/java/com/alibaba/fluss/cluster/ClusterTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/cluster/ClusterTest.java
@@ -49,10 +49,10 @@ class ClusterTest {
             new ServerNode(0, "localhost", 98, ServerType.COORDINATOR);
     private static final ServerNode[] NODES =
             new ServerNode[] {
-                new ServerNode(0, "localhost", 99, ServerType.TABLET_SERVER),
-                new ServerNode(1, "localhost", 100, ServerType.TABLET_SERVER),
-                new ServerNode(2, "localhost", 101, ServerType.TABLET_SERVER),
-                new ServerNode(11, "localhost", 102, ServerType.TABLET_SERVER)
+                new ServerNode(0, "localhost", 99, ServerType.TABLET_SERVER, "rack0"),
+                new ServerNode(1, "localhost", 100, ServerType.TABLET_SERVER, "rack1"),
+                new ServerNode(2, "localhost", 101, ServerType.TABLET_SERVER, "rack2"),
+                new ServerNode(11, "localhost", 102, ServerType.TABLET_SERVER, "rack11")
             };
 
     private Configuration conf;

--- a/fluss-common/src/test/java/com/alibaba/fluss/cluster/ServerNodeTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/cluster/ServerNodeTest.java
@@ -44,7 +44,7 @@ public class ServerNodeTest {
         assertThat(serverNode.hashCode()).isNotEqualTo(serverNode2.hashCode());
         assertThat(serverNode).isEqualTo(new ServerNode(0, "HOST1", 9023, ServerType.COORDINATOR));
 
-        assertThat(serverNode.toString()).isEqualTo("HOST1:9023 (id: cs-0)");
-        assertThat(serverNode2.toString()).isEqualTo("HOST2:9123 (id: ts-1)");
+        assertThat(serverNode.toString()).isEqualTo("HOST1:9023 (id: cs-0, rack: null)");
+        assertThat(serverNode2.toString()).isEqualTo("HOST2:9123 (id: ts-1, rack: null)");
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -23,6 +23,7 @@ import com.alibaba.fluss.client.table.Table;
 import com.alibaba.fluss.client.table.writer.AppendWriter;
 import com.alibaba.fluss.client.table.writer.TableWriter;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.config.AutoPartitionTimeUnit;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
@@ -35,7 +36,6 @@ import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.server.coordinator.MetadataManager;
 import com.alibaba.fluss.server.testutils.FlussClusterExtension;
-import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.data.PartitionAssignment;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
@@ -57,6 +57,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
 import static com.alibaba.fluss.testutils.DataTestUtils.row;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -227,10 +228,14 @@ public class FlinkTestBase extends AbstractTestBase {
             long partitionId = zkClient.getPartitionIdAndIncrement();
             newPartitionIds.put(partitionId, partition);
             TableAssignment assignment =
-                    TableAssignmentUtils.generateAssignment(
+                    generateAssignment(
                             tableInfo.getNumBuckets(),
                             tableInfo.getTableConfig().getReplicationFactor(),
-                            new int[] {0, 1, 2});
+                            new TabletServerInfo[] {
+                                new TabletServerInfo(0, "rack0"),
+                                new TabletServerInfo(1, "rack1"),
+                                new TabletServerInfo(2, "rack2")
+                            });
 
             // register partition assignments
             zkClient.registerPartitionAssignment(

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -34,6 +34,7 @@ import com.alibaba.fluss.exception.InvalidDatabaseException;
 import com.alibaba.fluss.exception.InvalidPartitionException;
 import com.alibaba.fluss.exception.InvalidReplicationFactorException;
 import com.alibaba.fluss.exception.InvalidRequiredAcksException;
+import com.alibaba.fluss.exception.InvalidServerRackInfoException;
 import com.alibaba.fluss.exception.InvalidTableException;
 import com.alibaba.fluss.exception.InvalidTargetColumnException;
 import com.alibaba.fluss.exception.InvalidTimestampException;
@@ -207,7 +208,9 @@ public enum Errors {
     RETRIABLE_AUTHENTICATE_EXCEPTION(
             51,
             "Authentication failed with retriable exception. ",
-            RetriableAuthenticationException::new);
+            RetriableAuthenticationException::new),
+    INVALID_SERVER_RACK_INFO_EXCEPTION(
+            52, "The server rack info is invalid.", InvalidServerRackInfoException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -548,11 +548,13 @@ message PbPhysicalTablePath {
 // For UpdateMetadataRequest,
 //   * versions <= 0.6: host and port are used.
 //   * versions >= 0.7: listeners is used to replace host and port.
+// For MetadataResponse and UpdateMetadataRequest: Fluss versions >= 0.7: we add rack for each tabletServer
 message PbServerNode {
   required int32 node_id = 1;
   required string host = 2;
   required int32 port = 3;
   optional string listeners = 4;
+  optional string rack = 5;
 }
 
 message PbTableMetadata {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/RpcServiceBase.java
@@ -662,7 +662,8 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
                                 // and port as -1 just like kafka
                                 // TODO: client will not use this node to connect,
                                 //  should be removed in the future.
-                                new ServerNode(replicas.get(i), "", -1, ServerType.TABLET_SERVER));
+                                new ServerNode(
+                                        replicas.get(i), "", -1, ServerType.TABLET_SERVER, null));
             }
 
             // now get the leader

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -285,6 +285,7 @@ public class CoordinatorEventProcessor implements EventProcessor {
                                     // CoordinatorServer id to avoid node drift.
                                     new ServerInfo(
                                             0,
+                                            null, // For coordinatorServer, no rack info
                                             coordinatorAddress.getEndpoints(),
                                             ServerType.COORDINATOR))
                     .orElseGet(
@@ -310,7 +311,11 @@ public class CoordinatorEventProcessor implements EventProcessor {
         for (int server : currentServers) {
             TabletServerRegistration registration = zooKeeperClient.getTabletServer(server).get();
             ServerInfo serverInfo =
-                    new ServerInfo(server, registration.getEndpoints(), ServerType.TABLET_SERVER);
+                    new ServerInfo(
+                            server,
+                            registration.getRack(),
+                            registration.getEndpoints(),
+                            ServerType.TABLET_SERVER);
             // Get internal listener endpoint to send request to tablet server.
             Endpoint internalEndpoint = serverInfo.endpoint(internalListenerName);
             if (internalEndpoint == null) {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.coordinator;
 
 import com.alibaba.fluss.cluster.ServerType;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.InvalidCoordinatorException;
@@ -81,7 +82,6 @@ import com.alibaba.fluss.server.entity.LakeTieringTableInfo;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshot;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshotJsonSerde;
 import com.alibaba.fluss.server.metadata.ServerMetadataCache;
-import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.data.BucketAssignment;
 import com.alibaba.fluss.server.zk.data.PartitionAssignment;
@@ -109,6 +109,7 @@ import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getPartitionS
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeCreateAclsResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeDropAclsResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.toTablePath;
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
 import static com.alibaba.fluss.utils.PartitionUtils.validatePartitionSpec;
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 import static com.alibaba.fluss.utils.Preconditions.checkState;
@@ -245,9 +246,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
         if (!tableDescriptor.isPartitioned()) {
             // the replication factor must be set now
             int replicaFactor = tableDescriptor.getReplicationFactor();
-            int[] servers = metadataCache.getLiveServerIds();
-            tableAssignment =
-                    TableAssignmentUtils.generateAssignment(bucketCount, replicaFactor, servers);
+            TabletServerInfo[] servers = metadataCache.getLiveServers();
+            tableAssignment = generateAssignment(bucketCount, replicaFactor, servers);
         }
 
         // TODO: should tolerate if the lake exist but matches our schema. This ensures eventually
@@ -363,9 +363,9 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
         // second, generate the PartitionAssignment.
         int replicaFactor = table.getTableConfig().getReplicationFactor();
-        int[] servers = metadataCache.getLiveServerIds();
+        TabletServerInfo[] servers = metadataCache.getLiveServers();
         Map<Integer, BucketAssignment> bucketAssignments =
-                TableAssignmentUtils.generateAssignment(table.bucketCount, replicaFactor, servers)
+                generateAssignment(table.bucketCount, replicaFactor, servers)
                         .getBucketAssignments();
         PartitionAssignment partitionAssignment =
                 new PartitionAssignment(table.tableId, bucketAssignments);

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/event/watcher/TabletServerChangeWatcher.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/event/watcher/TabletServerChangeWatcher.java
@@ -87,6 +87,7 @@ public class TabletServerChangeWatcher {
                                     new NewTabletServerEvent(
                                             new ServerInfo(
                                                     serverId,
+                                                    registration.getRack(),
                                                     registration.getEndpoints(),
                                                     ServerType.TABLET_SERVER)));
                         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/AbstractServerMetadataCache.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/AbstractServerMetadataCache.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.metadata;
 
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.server.coordinator.CoordinatorServer;
 import com.alibaba.fluss.server.tablet.TabletServer;
@@ -53,8 +54,13 @@ public abstract class AbstractServerMetadataCache implements ServerMetadataCache
 
     @Override
     public boolean isAliveTabletServer(int serverId) {
-        Set<Integer> aliveTabletServersById = clusterMetadata.getAliveTabletServerIds();
-        return aliveTabletServersById.contains(serverId);
+        Set<TabletServerInfo> aliveTabletServersById = clusterMetadata.getAliveTabletServerInfos();
+        for (TabletServerInfo tabletServerInfo : aliveTabletServersById) {
+            if (tabletServerInfo.getId() == serverId) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override
@@ -73,8 +79,8 @@ public abstract class AbstractServerMetadataCache implements ServerMetadataCache
     }
 
     @Override
-    public Set<Integer> getAliveTabletServerIds() {
-        return clusterMetadata.getAliveTabletServerIds();
+    public Set<TabletServerInfo> getAliveTabletServerInfos() {
+        return clusterMetadata.getAliveTabletServerInfos();
     }
 
     @Override

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ClusterMetadataInfo.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ClusterMetadataInfo.java
@@ -98,11 +98,15 @@ public class ClusterMetadataInfo {
 
         List<PbServerNode> serverNodeList = new ArrayList<>();
         for (ServerNode serverNode : aliveTabletServers) {
-            serverNodeList.add(
+            PbServerNode tabletServerNode =
                     new PbServerNode()
                             .setNodeId(serverNode.id())
                             .setHost(serverNode.host())
-                            .setPort(serverNode.port()));
+                            .setPort(serverNode.port());
+            if (serverNode.rack() != null) {
+                tabletServerNode.setRack(serverNode.rack());
+            }
+            serverNodeList.add(tabletServerNode);
         }
 
         List<PbTableMetadata> tableMetadatas = new ArrayList<>();
@@ -181,6 +185,7 @@ public class ClusterMetadataInfo {
                     Optional.of(
                             new ServerInfo(
                                     pbCoordinatorServer.getNodeId(),
+                                    null,
                                     endpoints,
                                     ServerType.COORDINATOR));
         }
@@ -197,8 +202,13 @@ public class ClusterMetadataInfo {
                                             tabletServer.getPort(),
                                             // TODO: maybe use internal listener name from conf
                                             ConfigOptions.INTERNAL_LISTENER_NAME.defaultValue()));
+
             aliveTabletServers.add(
-                    new ServerInfo(tabletServer.getNodeId(), endpoints, ServerType.TABLET_SERVER));
+                    new ServerInfo(
+                            tabletServer.getNodeId(),
+                            tabletServer.hasRack() ? tabletServer.getRack() : null,
+                            endpoints,
+                            ServerType.TABLET_SERVER));
         }
         return new ClusterMetadataInfo(coordinatorServer, aliveTabletServers);
     }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerCluster.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/metadata/ServerCluster.java
@@ -17,11 +17,13 @@
 package com.alibaba.fluss.server.metadata;
 
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 
 import javax.annotation.Nullable;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -68,7 +70,14 @@ public class ServerCluster {
         return serverNodes;
     }
 
-    public Set<Integer> getAliveTabletServerIds() {
-        return Collections.unmodifiableSet(aliveTabletServers.keySet());
+    public Set<TabletServerInfo> getAliveTabletServerInfos() {
+        Set<TabletServerInfo> tabletServerInfos = new HashSet<>();
+        aliveTabletServers
+                .values()
+                .forEach(
+                        serverInfo ->
+                                tabletServerInfos.add(
+                                        new TabletServerInfo(serverInfo.id(), serverInfo.rack())));
+        return Collections.unmodifiableSet(tabletServerInfos);
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -208,7 +208,8 @@ public class ServerRpcMessageUtils {
                 pbServerNode.getNodeId(),
                 pbServerNode.getHost(),
                 pbServerNode.getPort(),
-                serverType);
+                serverType,
+                pbServerNode.hasRack() ? pbServerNode.getRack() : null);
     }
 
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
@@ -218,13 +219,17 @@ public class ServerRpcMessageUtils {
         Set<PbServerNode> aliveTableServerNodes = new HashSet<>();
         for (ServerInfo serverInfo : aliveTableServers) {
             List<Endpoint> endpoints = serverInfo.endpoints();
-            aliveTableServerNodes.add(
+            PbServerNode pbTabletServerNode =
                     new PbServerNode()
                             .setNodeId(serverInfo.id())
                             .setListeners(Endpoint.toListenersString(endpoints))
                             // for backward compatibility for versions <= 0.6
                             .setHost(endpoints.get(0).getHost())
-                            .setPort(endpoints.get(0).getPort()));
+                            .setPort(endpoints.get(0).getPort());
+            if (serverInfo.rack() != null) {
+                pbTabletServerNode.setRack(serverInfo.rack());
+            }
+            aliveTableServerNodes.add(pbTabletServerNode);
         }
         updateMetadataRequest.addAllTabletServers(aliveTableServerNodes);
         coordinatorServer.map(

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/TableAssignmentUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/TableAssignmentUtils.java
@@ -17,16 +17,22 @@
 package com.alibaba.fluss.server.utils;
 
 import com.alibaba.fluss.annotation.VisibleForTesting;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.exception.InvalidBucketsException;
 import com.alibaba.fluss.exception.InvalidReplicationFactorException;
+import com.alibaba.fluss.exception.InvalidServerRackInfoException;
 import com.alibaba.fluss.server.zk.data.BucketAssignment;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 /** Utils for the assignment of tables. */
 public class TableAssignmentUtils {
@@ -37,7 +43,7 @@ public class TableAssignmentUtils {
     protected static TableAssignment generateAssignment(
             int nBuckets,
             int replicationFactor,
-            int[] servers,
+            TabletServerInfo[] servers,
             int startIndex,
             int nextReplicaShift) {
         if (nBuckets < 0) {
@@ -55,33 +61,33 @@ public class TableAssignmentUtils {
                             replicationFactor, servers.length));
         }
 
-        Map<Integer, BucketAssignment> assignments = new HashMap<>();
-        int currentBucketId = 0;
-        for (int i = 0; i < nBuckets; i++) {
-            if (currentBucketId > 0 && (currentBucketId % servers.length == 0)) {
-                nextReplicaShift += 1;
+        if (Arrays.stream(servers).noneMatch(tsInfo -> tsInfo.getRack() != null)) {
+            return generateRackUnawareAssigment(
+                    nBuckets,
+                    replicationFactor,
+                    Arrays.stream(servers).mapToInt(TabletServerInfo::getId).toArray(),
+                    startIndex,
+                    nextReplicaShift);
+        } else {
+            if (Arrays.stream(servers).anyMatch(tsInfo -> tsInfo.getRack() == null)) {
+                throw new InvalidServerRackInfoException(
+                        "Not all tabletServers have rack information for replica rack aware assignment.");
+            } else {
+                return generateRackAwareAssigment(
+                        nBuckets, replicationFactor, servers, startIndex, nextReplicaShift);
             }
-            int firstReplicaIndex = (currentBucketId + startIndex) % servers.length;
-            List<Integer> replicas = new ArrayList<>();
-            replicas.add(servers[firstReplicaIndex]);
-            for (int j = 0; j < replicationFactor - 1; j++) {
-                int replicaIndex =
-                        replicaIndex(firstReplicaIndex, nextReplicaShift, j, servers.length);
-                replicas.add(servers[replicaIndex]);
-            }
-            assignments.put(currentBucketId, new BucketAssignment(replicas));
-            currentBucketId++;
         }
-        return new TableAssignment(assignments);
     }
 
     /**
      * There are two goals of the table assignment:
      *
      * <ol>
-     *   <li>Spread replicas evenly among the tablet servers
-     *   <li>For buckets assigned to a particular broker, their other replicas are spread over the
-     *       other tablet servers.
+     *   <li>Spread replicas evenly among the tabletServers
+     *   <li>For buckets assigned to a particular tabletServer, their other replicas are spread over
+     *       the other tabletServers.
+     *   <li>If all tabletServers have rack information, assign the replicas for each bucket to
+     *       different racks if possible
      * </ol>
      *
      * <p>To achieve this goal for replica assignment, we:
@@ -104,10 +110,58 @@ public class TableAssignmentUtils {
      * <tr><td>bucket7      </td><td>bucket8      </td><td>bucket9      </td><td>bucket5      </td><td>bucket6      </td><td>(3nd replica)</td></tr>
      * </table>
      *
-     * <p>Note: the assignment won't consider rack information currently,
+     * <p>To create rack aware assigment, this API will first create a rack alternated tabletServers
+     * list. For example, from this tabletServerId -> rack mapping:
+     *
+     * <pre>
+     *     0 -> "rack1"
+     *     1 -> "rack3"
+     *     2 -> "rack3"
+     *     3 -> "rack2"
+     *     4 -> "rack2"
+     *     5 -> "rack1"
+     * </pre>
+     *
+     * <p>The rack alternated list will be:
+     *
+     * <pre>
+     *     0, 3, 1, 5, 4, 2
+     * </pre>
+     *
+     * <p>Then an easy round-robin assignment can be applied. Assume 6 buckets with replica factor
+     * of 3, the assignment will be:
+     *
+     * <pre>
+     *     bucket0 -> 0,3,1
+     *     bucket1 -> 3,1,5
+     *     bucket2 -> 1,5,4
+     *     bucket3 -> 5,4,2
+     *     bucket4 -> 4,2,0
+     *     bucket5 -> 2,0,3
+     * </pre>
+     *
+     * <p>Once it has completed the first round-robin, if there are more buckets to assign, the
+     * algorithm will start shifting the followers. This is to ensure we will not always get the
+     * same set of sequences. In this case, if there is another bucket to assign (bucket6), the
+     * assignment will be:
+     *
+     * <pre>
+     *     bucket6 -> 0,4,2 (instead of repeating 0,3,1 as bucket0)
+     * </pre>
+     *
+     * <p>The rack aware assignment always chooses the 1st replica of the bucket using round-robin
+     * on the rack alternated tabletServer list. For rest of the replicas, it will be biased towards
+     * tabletServers on racks that do not have any replica assignment, until every rack has a
+     * replica. Then the assignment will go back to round-robin on the tabletServer list.
+     *
+     * <p>As the result, if the number of replicas is equal to or greater than the number of racks,
+     * it will ensure that each rack will get at least one replica. Otherwise, each rack will get at
+     * most one replica. In a perfect situation where the number of replicas is the same as the
+     * number of racks and each rack has the same number of tabletServers, it guarantees that the
+     * replica distribution is even across tabletServers and racks.
      */
     public static TableAssignment generateAssignment(
-            int nBuckets, int replicationFactor, int[] servers)
+            int nBuckets, int replicationFactor, TabletServerInfo[] servers)
             throws InvalidReplicationFactorException {
         return generateAssignment(
                 nBuckets,
@@ -115,6 +169,130 @@ public class TableAssignmentUtils {
                 servers,
                 randomInt(servers.length),
                 randomInt(servers.length));
+    }
+
+    private static TableAssignment generateRackUnawareAssigment(
+            int nBuckets,
+            int replicationFactor,
+            int[] serverIds,
+            int startIndex,
+            int nextReplicaShift) {
+        Map<Integer, BucketAssignment> assignments = new HashMap<>();
+        int currentBucketId = 0;
+        for (int i = 0; i < nBuckets; i++) {
+            if (currentBucketId > 0 && (currentBucketId % serverIds.length == 0)) {
+                nextReplicaShift += 1;
+            }
+            int firstReplicaIndex = (currentBucketId + startIndex) % serverIds.length;
+            List<Integer> replicas = new ArrayList<>();
+            replicas.add(serverIds[firstReplicaIndex]);
+            for (int j = 0; j < replicationFactor - 1; j++) {
+                int replicaIndex =
+                        replicaIndex(firstReplicaIndex, nextReplicaShift, j, serverIds.length);
+                replicas.add(serverIds[replicaIndex]);
+            }
+            assignments.put(currentBucketId, new BucketAssignment(replicas));
+            currentBucketId++;
+        }
+        return new TableAssignment(assignments);
+    }
+
+    private static TableAssignment generateRackAwareAssigment(
+            int nBuckets,
+            int replicationFactor,
+            TabletServerInfo[] servers,
+            int startIndex,
+            int nextReplicaShift) {
+        Map<Integer, String> serverRackMap = new HashMap<>();
+        for (TabletServerInfo server : servers) {
+            serverRackMap.put(server.getId(), server.getRack());
+        }
+        int numRacks = new HashSet<>(serverRackMap.values()).size();
+        List<Integer> arrangedServerList = getRackAlternatedTabletServerList(serverRackMap);
+        int numServers = arrangedServerList.size();
+        Map<Integer, BucketAssignment> assignments = new HashMap<>();
+        int currentBucketId = 0;
+        for (int i = 0; i < nBuckets; i++) {
+            if (currentBucketId > 0 && (currentBucketId % arrangedServerList.size() == 0)) {
+                nextReplicaShift += 1;
+            }
+
+            int firstReplicaIndex = (currentBucketId + startIndex) % arrangedServerList.size();
+            int leader = arrangedServerList.get(firstReplicaIndex);
+            List<Integer> replicas = new ArrayList<>();
+            replicas.add(leader);
+            Set<String> racksWithReplicas = new HashSet<>();
+            racksWithReplicas.add(serverRackMap.get(leader));
+            Set<Integer> brokersWithReplicas = new HashSet<>();
+            brokersWithReplicas.add(leader);
+            int k = 0;
+            for (int j = 0; j < replicationFactor - 1; j++) {
+                boolean done = false;
+                while (!done) {
+                    Integer broker =
+                            arrangedServerList.get(
+                                    replicaIndex(
+                                            firstReplicaIndex,
+                                            nextReplicaShift * numRacks,
+                                            k,
+                                            arrangedServerList.size()));
+                    String rack = serverRackMap.get(broker);
+                    // Skip this tabletServer if
+                    // 1. there is already a tabletServer in the same rack that has assigned a
+                    // replica AND there is one or more racks that do not have any replica, or
+                    // 2. the tabletServer has already assigned a replica AND there is one or more
+                    // tabletServers that do not have replica assigned
+                    if ((!racksWithReplicas.contains(rack) || racksWithReplicas.size() == numRacks)
+                            && (!brokersWithReplicas.contains(broker)
+                                    || brokersWithReplicas.size() == numServers)) {
+                        replicas.add(broker);
+                        racksWithReplicas.add(rack);
+                        brokersWithReplicas.add(broker);
+                        done = true;
+                    }
+                    k += 1;
+                }
+            }
+            assignments.put(currentBucketId, new BucketAssignment(replicas));
+            currentBucketId++;
+        }
+        return new TableAssignment(assignments);
+    }
+
+    /**
+     * Given tabletServer and rack information, returns a list of tabletServers alternated by the
+     * rack. Assume this is the rack and its tabletServer ids:
+     *
+     * <pre>
+     *     rack1: 0, 1, 2
+     *     rack2: 3, 4, 5
+     *     rack3: 6, 7, 8
+     * </pre>
+     *
+     * <p>This API would return the list of 0, 3, 6, 1, 4, 7, 2, 5, 8
+     *
+     * <p>This is essential to make sure that the generateAssignment API can use such list and
+     * assign replicas to tabletServers in a simple round-robin fashion, while ensuring an even
+     * distribution of leader and replica counts on each tabletServer and that replicas are
+     * distributed to all racks.
+     */
+    @VisibleForTesting
+    static List<Integer> getRackAlternatedTabletServerList(Map<Integer, String> serverRackMap) {
+        Map<String, Iterator<Integer>> serversIteratorByRack = new HashMap<>();
+        getInverseMap(serverRackMap)
+                .forEach((rack, servers) -> serversIteratorByRack.put(rack, servers.iterator()));
+        String[] racks = serversIteratorByRack.keySet().toArray(new String[0]);
+        Arrays.sort(racks);
+        List<Integer> result = new ArrayList<>();
+        int rackIndex = 0;
+        while (result.size() < serverRackMap.size()) {
+            Iterator<Integer> rackIterator = serversIteratorByRack.get(racks[rackIndex]);
+            if (rackIterator.hasNext()) {
+                result.add(rackIterator.next());
+            }
+            rackIndex = (rackIndex + 1) % racks.length;
+        }
+        return result;
     }
 
     private static int randomInt(int nServers) {
@@ -125,5 +303,13 @@ public class TableAssignmentUtils {
             int firstReplicaIndex, int secondReplicaShift, int replicaIndex, int nServers) {
         int shift = 1 + (secondReplicaShift + replicaIndex) % (nServers - 1);
         return (firstReplicaIndex + shift) % nServers;
+    }
+
+    private static Map<String, List<Integer>> getInverseMap(Map<Integer, String> serverRackMap) {
+        Map<String, List<Integer>> results = new HashMap<>();
+        serverRackMap.forEach(
+                (id, rack) -> results.computeIfAbsent(rack, key -> new ArrayList<>()).add(id));
+        results.forEach((rack, rackAndIdList) -> rackAndIdList.sort(Integer::compareTo));
+        return results;
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableAssignment.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TableAssignment.java
@@ -30,7 +30,7 @@ import java.util.Set;
  */
 public class TableAssignment {
     // a mapping from bucket id to assignment something like "{0: [0, 1, 3]}".
-    // the assignment is represented as a list of replica id (tabletserver id) where the first
+    // the assignment is represented as a list of replica id (tabletServer id) where the first
     // replica id will be considered as the replica leader.
     private final Map<Integer, BucketAssignment> assignments;
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TabletServerRegistration.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/data/TabletServerRegistration.java
@@ -18,6 +18,8 @@ package com.alibaba.fluss.server.zk.data;
 
 import com.alibaba.fluss.cluster.Endpoint;
 
+import javax.annotation.Nullable;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -27,10 +29,13 @@ import java.util.Objects;
  * @see TabletServerRegistrationJsonSerde for json serialization and deserialization.
  */
 public class TabletServerRegistration {
+    private final @Nullable String rack;
     private final List<Endpoint> endpoints;
     private final long registerTimestamp;
 
-    public TabletServerRegistration(List<Endpoint> endpoints, long registerTimestamp) {
+    public TabletServerRegistration(
+            @Nullable String rack, List<Endpoint> endpoints, long registerTimestamp) {
+        this.rack = rack;
         this.endpoints = endpoints;
         this.registerTimestamp = registerTimestamp;
     }
@@ -43,6 +48,10 @@ public class TabletServerRegistration {
         return registerTimestamp;
     }
 
+    public @Nullable String getRack() {
+        return rack;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -53,12 +62,13 @@ public class TabletServerRegistration {
         }
         TabletServerRegistration that = (TabletServerRegistration) o;
         return registerTimestamp == that.registerTimestamp
-                && Objects.equals(endpoints, that.endpoints);
+                && Objects.equals(endpoints, that.endpoints)
+                && Objects.equals(rack, that.rack);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(endpoints, registerTimestamp);
+        return Objects.hash(endpoints, registerTimestamp, rack);
     }
 
     @Override
@@ -68,6 +78,8 @@ public class TabletServerRegistration {
                 + endpoints
                 + ", registerTimestamp="
                 + registerTimestamp
+                + ", rack='"
+                + rack
                 + '}';
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/AutoPartitionManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/AutoPartitionManagerTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.server.coordinator;
 
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.config.AutoPartitionTimeUnit;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
@@ -24,7 +25,6 @@ import com.alibaba.fluss.metadata.TableDescriptor;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.server.testutils.TestingMetadataCache;
-import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.NOPErrorHandler;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperExtension;
@@ -54,6 +54,7 @@ import java.util.function.Function;
 import java.util.stream.Stream;
 
 import static com.alibaba.fluss.metadata.ResolvedPartitionSpec.fromPartitionName;
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Test for {@link AutoPartitionManager}. */
@@ -207,8 +208,14 @@ class AutoPartitionManagerTest {
         // manually create a partition.
         int replicaFactor = table.getTableConfig().getReplicationFactor();
         Map<Integer, BucketAssignment> bucketAssignments =
-                TableAssignmentUtils.generateAssignment(
-                                table.getNumBuckets(), replicaFactor, new int[] {0, 1, 2})
+                generateAssignment(
+                                table.getNumBuckets(),
+                                replicaFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
                         .getBucketAssignments();
         long tableId = table.getTableId();
         PartitionAssignment partitionAssignment =
@@ -286,8 +293,14 @@ class AutoPartitionManagerTest {
         // manually create 4 future partitions.
         int replicaFactor = table.getTableConfig().getReplicationFactor();
         Map<Integer, BucketAssignment> bucketAssignments =
-                TableAssignmentUtils.generateAssignment(
-                                table.getNumBuckets(), replicaFactor, new int[] {0, 1, 2})
+                generateAssignment(
+                                table.getNumBuckets(),
+                                replicaFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
                         .getBucketAssignments();
         long tableId = table.getTableId();
         PartitionAssignment partitionAssignment =

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessorTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.fluss.server.coordinator;
 
 import com.alibaba.fluss.cluster.Endpoint;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.exception.FencedLeaderEpochException;
@@ -48,7 +49,6 @@ import com.alibaba.fluss.server.metadata.ServerMetadataCache;
 import com.alibaba.fluss.server.metadata.ServerMetadataCacheImpl;
 import com.alibaba.fluss.server.metrics.group.TestingMetricGroups;
 import com.alibaba.fluss.server.tablet.TestTabletServerGateway;
-import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.NOPErrorHandler;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperExtension;
@@ -98,6 +98,7 @@ import static com.alibaba.fluss.server.coordinator.statemachine.BucketState.Onli
 import static com.alibaba.fluss.server.coordinator.statemachine.ReplicaState.OfflineReplica;
 import static com.alibaba.fluss.server.coordinator.statemachine.ReplicaState.OnlineReplica;
 import static com.alibaba.fluss.server.testutils.KvTestUtils.mockCompletedSnapshot;
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -147,6 +148,7 @@ class CoordinatorEventProcessorTest {
             zookeeperClient.registerTabletServer(
                     i,
                     new TabletServerRegistration(
+                            "rack" + i,
                             Collections.singletonList(
                                     new Endpoint("host" + i, 1000, DEFAULT_LISTENER_NAME)),
                             System.currentTimeMillis()));
@@ -189,8 +191,14 @@ class CoordinatorEventProcessorTest {
         int nBuckets = 3;
         int replicationFactor = 3;
         TableAssignment tableAssignment =
-                TableAssignmentUtils.generateAssignment(
-                        nBuckets, replicationFactor, new int[] {0, 1, 2});
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
         long t1Id = metadataManager.createTable(t1, tableDescriptor, tableAssignment, false);
 
         TablePath t2 = TablePath.of(defaultDatabase, "create_drop_t2");
@@ -250,7 +258,14 @@ class CoordinatorEventProcessorTest {
         initCoordinatorChannel(failedServer);
         // create a table,
         TablePath t1 = TablePath.of(defaultDatabase, "tdrop");
-        final long t1Id = createTable(t1, new int[] {0, 1, 2});
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
 
         // retry until the create table t1 has been handled by coordinator
         // otherwise, when receive create table event, it can't find the schema of the table
@@ -282,6 +297,7 @@ class CoordinatorEventProcessorTest {
         int newlyServerId = 3;
         TabletServerRegistration tabletServerRegistration =
                 new TabletServerRegistration(
+                        "rack3",
                         Endpoint.fromListenersString(DEFAULT_LISTENER_NAME + "://host3:1234"),
                         System.currentTimeMillis());
         client.registerTabletServer(newlyServerId, tabletServerRegistration);
@@ -458,7 +474,14 @@ class CoordinatorEventProcessorTest {
         ZooKeeperCompletedSnapshotHandleStore completedSnapshotHandleStore =
                 new ZooKeeperCompletedSnapshotHandleStore(zookeeperClient);
         TablePath t1 = TablePath.of(defaultDatabase, "t_completed_snapshot");
-        final long t1Id = createTable(t1, new int[] {0, 1, 2});
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
         CoordinatorEventManager coordinatorEventManager =
                 eventProcessor.getCoordinatorEventManager();
         int snapshotNum = 2;
@@ -540,8 +563,14 @@ class CoordinatorEventProcessorTest {
         int nBuckets = 3;
         int replicationFactor = 3;
         Map<Integer, BucketAssignment> assignments =
-                TableAssignmentUtils.generateAssignment(
-                                nBuckets, replicationFactor, new int[] {0, 1, 2})
+                generateAssignment(
+                                nBuckets,
+                                replicationFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
                         .getBucketAssignments();
         PartitionAssignment partitionAssignment = new PartitionAssignment(tableId, assignments);
         Tuple2<PartitionIdName, PartitionIdName> partitionIdAndNameTuple2 =
@@ -605,8 +634,14 @@ class CoordinatorEventProcessorTest {
         int nBuckets = 3;
         int replicationFactor = 3;
         Map<Integer, BucketAssignment> assignments =
-                TableAssignmentUtils.generateAssignment(
-                                nBuckets, replicationFactor, new int[] {0, 1, 2})
+                generateAssignment(
+                                nBuckets,
+                                replicationFactor,
+                                new TabletServerInfo[] {
+                                    new TabletServerInfo(0, "rack0"),
+                                    new TabletServerInfo(1, "rack1"),
+                                    new TabletServerInfo(2, "rack2")
+                                })
                         .getBucketAssignments();
         PartitionAssignment partitionAssignment = new PartitionAssignment(tableId, assignments);
         Tuple2<PartitionIdName, PartitionIdName> partitionIdAndNameTuple2 =
@@ -651,7 +686,14 @@ class CoordinatorEventProcessorTest {
     void testNotifyOffsetsWithShrinkISR(@TempDir Path tempDir) throws Exception {
         initCoordinatorChannel();
         TablePath t1 = TablePath.of(defaultDatabase, "test_notify_with_shrink_isr");
-        final long t1Id = createTable(t1, new int[] {0, 1, 2});
+        final long t1Id =
+                createTable(
+                        t1,
+                        new TabletServerInfo[] {
+                            new TabletServerInfo(0, "rack0"),
+                            new TabletServerInfo(1, "rack1"),
+                            new TabletServerInfo(2, "rack2")
+                        });
         TableBucket tableBucket = new TableBucket(t1Id, 0);
         LeaderAndIsr leaderAndIsr =
                 waitValue(
@@ -1004,9 +1046,9 @@ class CoordinatorEventProcessorTest {
         return event.getResultFuture().get(30, TimeUnit.SECONDS);
     }
 
-    private long createTable(TablePath tablePath, int[] servers) {
+    private long createTable(TablePath tablePath, TabletServerInfo[] servers) {
         TableAssignment tableAssignment =
-                TableAssignmentUtils.generateAssignment(N_BUCKETS, REPLICATION_FACTOR, servers);
+                generateAssignment(N_BUCKETS, REPLICATION_FACTOR, servers);
         return metadataManager.createTable(
                 tablePath, CoordinatorEventProcessorTest.TEST_TABLE, tableAssignment, false);
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorTestUtils.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/CoordinatorTestUtils.java
@@ -88,6 +88,7 @@ public class CoordinatorTestUtils {
             tabletServes.add(
                     new ServerInfo(
                             server,
+                            "RACK" + server,
                             Endpoint.fromListenersString("CLIENT://host:100"),
                             ServerType.TABLET_SERVER));
         }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TableManagerITCase.java
@@ -763,11 +763,15 @@ class TableManagerITCase {
         for (ServerInfo serverInfo : aliveTableServers) {
             // Legacy only support one endpoint
             Endpoint endpoint = serverInfo.endpoints().get(0);
-            aliveTableServerNodes.add(
+            PbServerNode pbServerNode =
                     new PbServerNode()
                             .setNodeId(serverInfo.id())
                             .setHost(endpoint.getHost())
-                            .setPort(endpoint.getPort()));
+                            .setPort(endpoint.getPort());
+            if (serverInfo.rack() != null) {
+                pbServerNode.setRack(serverInfo.rack());
+            }
+            aliveTableServerNodes.add(pbServerNode);
         }
         updateMetadataRequest.addAllTabletServers(aliveTableServerNodes);
         // Legacy only support one endpoint

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.server.coordinator.event.watcher;
 
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
 import com.alibaba.fluss.metadata.DatabaseDescriptor;
@@ -31,7 +32,6 @@ import com.alibaba.fluss.server.coordinator.event.CreateTableEvent;
 import com.alibaba.fluss.server.coordinator.event.DropPartitionEvent;
 import com.alibaba.fluss.server.coordinator.event.DropTableEvent;
 import com.alibaba.fluss.server.coordinator.event.TestingEventManager;
-import com.alibaba.fluss.server.utils.TableAssignmentUtils;
 import com.alibaba.fluss.server.zk.NOPErrorHandler;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperExtension;
@@ -50,6 +50,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.retry;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -105,7 +106,14 @@ class TableChangeWatcherTest {
         for (int i = 0; i < 10; i++) {
             TablePath tablePath = TablePath.of(DEFAULT_DB, "table_" + i);
             TableAssignment tableAssignment =
-                    TableAssignmentUtils.generateAssignment(3, 3, new int[] {0, 1, 2});
+                    generateAssignment(
+                            3,
+                            3,
+                            new TabletServerInfo[] {
+                                new TabletServerInfo(0, "rack0"),
+                                new TabletServerInfo(1, "rack1"),
+                                new TabletServerInfo(2, "rack2")
+                            });
             long tableId =
                     metadataManager.createTable(tablePath, TEST_TABLE, tableAssignment, false);
             SchemaInfo schemaInfo = metadataManager.getLatestSchema(tablePath);
@@ -183,7 +191,14 @@ class TableChangeWatcherTest {
         PartitionAssignment partitionAssignment =
                 new PartitionAssignment(
                         tableId,
-                        TableAssignmentUtils.generateAssignment(3, 3, new int[] {0, 1, 2})
+                        generateAssignment(
+                                        3,
+                                        3,
+                                        new TabletServerInfo[] {
+                                            new TabletServerInfo(0, "rack0"),
+                                            new TabletServerInfo(1, "rack1"),
+                                            new TabletServerInfo(2, "rack2")
+                                        })
                                 .getBucketAssignments());
         // register assignment
         zookeeperClient.registerPartitionAssignment(1L, partitionAssignment);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TabletServerChangeWatcherTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/event/watcher/TabletServerChangeWatcherTest.java
@@ -63,12 +63,14 @@ class TabletServerChangeWatcherTest {
         for (int i = 0; i < 10; i++) {
             TabletServerRegistration tabletServerRegistration =
                     new TabletServerRegistration(
+                            "rack" + i,
                             Collections.singletonList(new Endpoint("host" + i, 1234, "CLIENT")),
                             System.currentTimeMillis());
             expectedEvents.add(
                     new NewTabletServerEvent(
                             new ServerInfo(
                                     i,
+                                    tabletServerRegistration.getRack(),
                                     tabletServerRegistration.getEndpoints(),
                                     ServerType.TABLET_SERVER)));
             zookeeperClient.registerTabletServer(i, tabletServerRegistration);

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaStateMachineTest.java
@@ -282,6 +282,7 @@ class ReplicaStateMachineTest {
             servers.add(
                     new ServerInfo(
                             serverId,
+                            "RACK" + serverId,
                             Endpoint.fromListenersString("CLIENT://host:23"),
                             ServerType.TABLET_SERVER));
         }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImplTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/metadata/ServerMetadataCacheImplTest.java
@@ -41,6 +41,7 @@ public class ServerMetadataCacheImplTest {
         coordinatorServer =
                 new ServerInfo(
                         0,
+                        "rack0",
                         Endpoint.fromListenersString(
                                 "CLIENT://localhost:99,INTERNAL://localhost:100"),
                         ServerType.COORDINATOR);
@@ -49,15 +50,18 @@ public class ServerMetadataCacheImplTest {
                         Arrays.asList(
                                 new ServerInfo(
                                         0,
+                                        "rack0",
                                         Endpoint.fromListenersString(
                                                 "CLIENT://localhost:101, INTERNAL://localhost:102"),
                                         ServerType.TABLET_SERVER),
                                 new ServerInfo(
                                         1,
+                                        "rack1",
                                         Endpoint.fromListenersString("INTERNAL://localhost:103"),
                                         ServerType.TABLET_SERVER),
                                 new ServerInfo(
                                         2,
+                                        "rack2",
                                         Endpoint.fromListenersString("INTERNAL://localhost:104"),
                                         ServerType.TABLET_SERVER)));
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/ReplicaTestBase.java
@@ -122,6 +122,7 @@ public class ReplicaTestBase {
             new AllCallbackWrapper<>(new ZooKeeperExtension());
 
     protected static final int TABLET_SERVER_ID = 1;
+    private static final String TABLET_SERVER_RACK = "rack1";
     private static ZooKeeperClient zkClient;
 
     // to register all should be closed after each test
@@ -206,22 +207,26 @@ public class ReplicaTestBase {
                         Optional.of(
                                 new ServerInfo(
                                         0,
+                                        "rack0",
                                         Endpoint.fromListenersString("CLIENT://localhost:1234"),
                                         ServerType.COORDINATOR)),
                         new HashSet<>(
                                 Arrays.asList(
                                         new ServerInfo(
                                                 TABLET_SERVER_ID,
+                                                TABLET_SERVER_RACK,
                                                 Endpoint.fromListenersString(
                                                         "CLIENT://localhost:90"),
                                                 ServerType.TABLET_SERVER),
                                         new ServerInfo(
                                                 2,
+                                                "rack2",
                                                 Endpoint.fromListenersString(
                                                         "CLIENT://localhost:91"),
                                                 ServerType.TABLET_SERVER),
                                         new ServerInfo(
                                                 3,
+                                                "rack3",
                                                 Endpoint.fromListenersString(
                                                         "CLIENT://localhost:92"),
                                                 ServerType.TABLET_SERVER)))));

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/ReplicaFetcherThreadTest.java
@@ -111,9 +111,12 @@ public class ReplicaFetcherThreadTest {
         leaderRM = createReplicaManager(leaderServerId);
         followerRM = createReplicaManager(followerServerId);
         // with local test leader end point.
-        leader = new ServerNode(leaderServerId, "localhost", 9099, ServerType.TABLET_SERVER);
+        leader =
+                new ServerNode(
+                        leaderServerId, "localhost", 9099, ServerType.TABLET_SERVER, "rack1");
         ServerNode follower =
-                new ServerNode(followerServerId, "localhost", 10001, ServerType.TABLET_SERVER);
+                new ServerNode(
+                        followerServerId, "localhost", 10001, ServerType.TABLET_SERVER, "rack2");
         followerFetcher =
                 new ReplicaFetcherThread(
                         "test-fetcher-thread",

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerITCase.java
@@ -42,7 +42,7 @@ public class TabletServerITCase extends ServerITCaseBase {
 
     @Override
     protected ServerNode getServerNode() {
-        return new ServerNode(1, HOSTNAME, getPort(), ServerType.TABLET_SERVER);
+        return new ServerNode(1, HOSTNAME, getPort(), ServerType.TABLET_SERVER, "rack1");
     }
 
     @Override
@@ -62,6 +62,7 @@ public class TabletServerITCase extends ServerITCaseBase {
                 ConfigOptions.BIND_LISTENERS,
                 String.format("%s://%s:%d", DEFAULT_LISTENER_NAME, HOSTNAME, getPort()));
         conf.set(ConfigOptions.TABLET_SERVER_ID, 1);
+        conf.set(ConfigOptions.TABLET_SERVER_RACK, "rack1");
         conf.set(ConfigOptions.REMOTE_DATA_DIR, "/tmp/fluss/remote-data");
         return conf;
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TabletServerTest.java
@@ -35,6 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class TabletServerTest extends ServerTestBase {
 
     private static final int SERVER_ID = 0;
+    private static final String RACK = "cn-hangzhou-server10";
 
     private static @TempDir File tempDirForLog;
 
@@ -70,6 +71,7 @@ class TabletServerTest extends ServerTestBase {
     private static Configuration createTabletServerConfiguration() {
         Configuration configuration = createConfiguration();
         configuration.set(ConfigOptions.TABLET_SERVER_ID, SERVER_ID);
+        configuration.set(ConfigOptions.TABLET_SERVER_RACK, RACK);
         configuration.setString(ConfigOptions.DATA_DIR, tempDirForLog.getAbsolutePath());
         return configuration;
     }
@@ -82,6 +84,7 @@ class TabletServerTest extends ServerTestBase {
         assertThat(optionalTabletServerRegistration).isPresent();
 
         TabletServerRegistration tabletServerRegistration = optionalTabletServerRegistration.get();
+        assertThat(tabletServerRegistration.getRack()).isEqualTo(RACK);
         verifyEndpoint(
                 tabletServerRegistration.getEndpoints(), server.getRpcServer().getBindEndpoints());
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/FlussClusterExtension.java
@@ -238,6 +238,7 @@ public final class FlussClusterExtension
                     // TODO, Currently, we use 0 as coordinator server id.
                     new ServerInfo(
                             0,
+                            null,
                             coordinatorServer.getRpcServer().getBindEndpoints(),
                             ServerType.COORDINATOR);
         } else {
@@ -246,6 +247,7 @@ public final class FlussClusterExtension
             coordinatorServerInfo =
                     new ServerInfo(
                             0,
+                            null,
                             coordinatorServer.getRpcServer().getBindEndpoints(),
                             ServerType.COORDINATOR);
         }
@@ -282,6 +284,7 @@ public final class FlussClusterExtension
         String dataDir = getDataDir(serverId);
         Configuration tabletServerConf = new Configuration(clusterConf);
         tabletServerConf.set(ConfigOptions.TABLET_SERVER_ID, serverId);
+        tabletServerConf.set(ConfigOptions.TABLET_SERVER_RACK, "rack" + serverId);
         tabletServerConf.set(ConfigOptions.DATA_DIR, dataDir);
         tabletServerConf.setString(
                 ConfigOptions.ZOOKEEPER_ADDRESS, zooKeeperServer.getConnectString());
@@ -297,6 +300,7 @@ public final class FlussClusterExtension
         ServerInfo serverInfo =
                 new ServerInfo(
                         serverId,
+                        "rack" + serverId,
                         tabletServer.getRpcServer().getBindEndpoints(),
                         ServerType.TABLET_SERVER);
 
@@ -422,7 +426,8 @@ public final class FlussClusterExtension
                                     node.id(),
                                     endpoint.getHost(),
                                     endpoint.getPort(),
-                                    ServerType.TABLET_SERVER);
+                                    ServerType.TABLET_SERVER,
+                                    node.rack());
                         })
                 .collect(Collectors.toList());
     }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/TestingMetadataCache.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/testutils/TestingMetadataCache.java
@@ -18,21 +18,25 @@ package com.alibaba.fluss.server.testutils;
 
 import com.alibaba.fluss.cluster.MetadataCache;
 import com.alibaba.fluss.cluster.ServerNode;
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.IntStream;
 
 /** An implement of {@link MetadataCache} for testing purpose. */
 public class TestingMetadataCache implements MetadataCache {
 
-    private final int[] serverIds;
+    private final TabletServerInfo[] tabletServerInfos;
 
     public TestingMetadataCache(int serverNums) {
-        this.serverIds = IntStream.range(0, serverNums).toArray();
+        TabletServerInfo[] tabletServerInfos = new TabletServerInfo[serverNums];
+        for (int i = 0; i < serverNums; i++) {
+            tabletServerInfos[i] = new TabletServerInfo(i, "rack" + i);
+        }
+        this.tabletServerInfos = tabletServerInfos;
     }
 
     @Override
@@ -56,12 +60,12 @@ public class TestingMetadataCache implements MetadataCache {
     }
 
     @Override
-    public Set<Integer> getAliveTabletServerIds() {
+    public Set<TabletServerInfo> getAliveTabletServerInfos() {
         return Collections.emptySet();
     }
 
-    public int[] getLiveServerIds() {
-        return serverIds;
+    public TabletServerInfo[] getLiveServers() {
+        return tabletServerInfos;
     }
 
     @Override

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/utils/RpcGatewayManagerTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/utils/RpcGatewayManagerTest.java
@@ -38,7 +38,8 @@ class RpcGatewayManagerTest {
                                 new Configuration(), TestingClientMetricGroup.newInstance()),
                         TabletServerGateway.class);
 
-        ServerNode serverNode1 = new ServerNode(1, "localhost", 1234, ServerType.TABLET_SERVER);
+        ServerNode serverNode1 =
+                new ServerNode(1, "localhost", 1234, ServerType.TABLET_SERVER, "rack1");
         // should be empty at the beginning
         assertThat(gatewayRpcGatewayManager.getRpcGateway(serverNode1.id())).isEmpty();
         gatewayRpcGatewayManager.addServer(serverNode1);
@@ -50,7 +51,8 @@ class RpcGatewayManagerTest {
         assertThat(gatewayRpcGatewayManager.getRpcGateway(serverNode1.id())).isPresent();
 
         // add another server2
-        ServerNode serverNode2 = new ServerNode(2, "localhost", 1234, ServerType.TABLET_SERVER);
+        ServerNode serverNode2 =
+                new ServerNode(2, "localhost", 1234, ServerType.TABLET_SERVER, "rack2");
         gatewayRpcGatewayManager.addServer(serverNode2);
         assertThat(gatewayRpcGatewayManager.getRpcGateway(serverNode2.id())).isPresent();
 

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/utils/TableAssignmentUtilsTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/utils/TableAssignmentUtilsTest.java
@@ -16,40 +16,84 @@
 
 package com.alibaba.fluss.server.utils;
 
+import com.alibaba.fluss.cluster.TabletServerInfo;
 import com.alibaba.fluss.exception.InvalidBucketsException;
 import com.alibaba.fluss.exception.InvalidReplicationFactorException;
+import com.alibaba.fluss.exception.InvalidServerRackInfoException;
 import com.alibaba.fluss.server.zk.data.BucketAssignment;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.generateAssignment;
+import static com.alibaba.fluss.server.utils.TableAssignmentUtils.getRackAlternatedTabletServerList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test for {@link com.alibaba.fluss.server.utils.TableAssignmentUtils} . */
+/** Test for {@link TableAssignmentUtils} for rack unaware mode and rack aware mode. */
 class TableAssignmentUtilsTest {
 
     @Test
-    void testTableAssignment() {
+    void testTableAssignmentWithRackUnAware() {
         // should throw exception since servers is empty
-        assertThatThrownBy(() -> TableAssignmentUtils.generateAssignment(5, -1, new int[0]))
+        assertThatThrownBy(
+                        () ->
+                                generateAssignment(
+                                        5,
+                                        -1,
+                                        toTabletServerInfo(
+                                                Collections.emptyMap(), Collections.emptyList())))
                 .isInstanceOf(InvalidReplicationFactorException.class);
 
         // should throw exception since the buckets is less than 0
-        assertThatThrownBy(() -> TableAssignmentUtils.generateAssignment(-1, 3, new int[] {0, 1}))
+        assertThatThrownBy(
+                        () ->
+                                generateAssignment(
+                                        -1,
+                                        3,
+                                        toTabletServerInfo(
+                                                Collections.emptyMap(), Arrays.asList(0, 1))))
                 .isInstanceOf(InvalidBucketsException.class);
 
         // should throw exception since the server is less than replication factor
-        assertThatThrownBy(() -> TableAssignmentUtils.generateAssignment(5, 3, new int[] {0, 1}))
+        assertThatThrownBy(
+                        () ->
+                                generateAssignment(
+                                        5,
+                                        3,
+                                        toTabletServerInfo(
+                                                Collections.emptyMap(), Arrays.asList(0, 1))))
                 .isInstanceOf(InvalidReplicationFactorException.class);
 
         // should throw exception since replication factor is less than 0
-        assertThatThrownBy(() -> TableAssignmentUtils.generateAssignment(5, -1, new int[] {0, 1}))
+        assertThatThrownBy(
+                        () ->
+                                generateAssignment(
+                                        5,
+                                        -1,
+                                        toTabletServerInfo(
+                                                Collections.emptyMap(), Arrays.asList(0, 1))))
                 .isInstanceOf(InvalidReplicationFactorException.class);
 
         // test replica factor 1
         TableAssignment tableAssignment =
-                TableAssignmentUtils.generateAssignment(3, 1, new int[] {0, 1, 2, 3}, 0, 0);
+                generateAssignment(
+                        3,
+                        1,
+                        toTabletServerInfo(Collections.emptyMap(), Arrays.asList(0, 1, 2, 3)),
+                        0,
+                        0);
         TableAssignment expectedAssignment =
                 TableAssignment.builder()
                         .add(0, BucketAssignment.of(0))
@@ -60,7 +104,12 @@ class TableAssignmentUtilsTest {
 
         // test replica factor 3
         tableAssignment =
-                TableAssignmentUtils.generateAssignment(3, 3, new int[] {0, 1, 2, 3}, 1, 0);
+                generateAssignment(
+                        3,
+                        3,
+                        toTabletServerInfo(Collections.emptyMap(), Arrays.asList(0, 1, 2, 3)),
+                        1,
+                        0);
         expectedAssignment =
                 TableAssignment.builder()
                         .add(0, BucketAssignment.of(1, 2, 3))
@@ -71,7 +120,12 @@ class TableAssignmentUtilsTest {
 
         // test with 10 buckets and 3 replies
         tableAssignment =
-                TableAssignmentUtils.generateAssignment(10, 3, new int[] {0, 1, 2, 3, 4}, 0, 0);
+                generateAssignment(
+                        10,
+                        3,
+                        toTabletServerInfo(Collections.emptyMap(), Arrays.asList(0, 1, 2, 3, 4)),
+                        0,
+                        0);
         expectedAssignment =
                 TableAssignment.builder()
                         .add(0, BucketAssignment.of(0, 1, 2))
@@ -86,5 +140,489 @@ class TableAssignmentUtilsTest {
                         .add(9, BucketAssignment.of(4, 1, 2))
                         .build();
         assertThat(tableAssignment).isEqualTo(expectedAssignment);
+    }
+
+    @Test
+    void testGetRackAlternatedTabletServerListAndAssignReplicasToServers() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack3");
+        rackMap.put(2, "rack3");
+        rackMap.put(3, "rack2");
+        rackMap.put(4, "rack2");
+        rackMap.put(5, "rack1");
+
+        List<Integer> newList = getRackAlternatedTabletServerList(rackMap);
+        assertThat(newList).containsExactly(0, 3, 1, 5, 4, 2);
+
+        // Test with tabletServer 5 removed.
+        HashMap<Integer, String> copyMap = new HashMap<>(rackMap);
+        copyMap.remove(5);
+        newList = getRackAlternatedTabletServerList(copyMap);
+        assertThat(newList).containsExactly(0, 3, 1, 4, 2);
+
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        7, 3, toTabletServerInfo(rackMap, Collections.emptyList()), 0, 0);
+        TableAssignment expectedAssignment =
+                TableAssignment.builder()
+                        .add(0, BucketAssignment.of(0, 3, 1))
+                        .add(1, BucketAssignment.of(3, 1, 5))
+                        .add(2, BucketAssignment.of(1, 5, 4))
+                        .add(3, BucketAssignment.of(5, 4, 2))
+                        .add(4, BucketAssignment.of(4, 2, 0))
+                        .add(5, BucketAssignment.of(2, 0, 3))
+                        .add(6, BucketAssignment.of(0, 4, 2))
+                        .build();
+        assertThat(tableAssignment).isEqualTo(expectedAssignment);
+    }
+
+    @Test
+    void testTableAssignmentWithRackAware() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 6;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()),
+                        2,
+                        0);
+        checkTableAssignment(tableAssignment, rackMap, 6, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testAssignmentWithRackAwareWithRandomStartIndex() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 6;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(tableAssignment, rackMap, 6, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testAssignmentWithRackAwareWithUnevenReplicas() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 13;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()),
+                        0,
+                        0);
+        checkTableAssignment(
+                tableAssignment, rackMap, 6, nBuckets, replicationFactor, true, false, false);
+    }
+
+    @Test
+    void testAssignmentWithRackAwareWithUnevenRacks() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 12;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(
+                tableAssignment, rackMap, 6, nBuckets, replicationFactor, true, true, false);
+    }
+
+    @Test
+    void testAssignmentWith2ReplicasRackAware() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 12;
+        int replicationFactor = 2;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(tableAssignment, rackMap, 6, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testRackAwareExpansion() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(6, "rack1");
+        rackMap.put(7, "rack2");
+        rackMap.put(8, "rack2");
+        rackMap.put(9, "rack3");
+        rackMap.put(10, "rack3");
+        rackMap.put(11, "rack1");
+
+        int nBuckets = 12;
+        int replicationFactor = 2;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()),
+                        0,
+                        12);
+        checkTableAssignment(tableAssignment, rackMap, 6, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testAssignmentWith2ReplicasRackAwareWith6Buckets() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 6;
+        int replicationFactor = 2;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(tableAssignment, rackMap, 6, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testAssignmentWith2ReplicasRackAwareWith6BucketsAnd3Servers() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(4, "rack3");
+
+        int nBuckets = 6;
+        int replicationFactor = 2;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(tableAssignment, rackMap, 3, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testLargeNumberBucketsAssignment() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+        rackMap.put(6, "rack1");
+        rackMap.put(7, "rack2");
+        rackMap.put(8, "rack2");
+        rackMap.put(9, "rack3");
+        rackMap.put(10, "rack1");
+        rackMap.put(11, "rack3");
+
+        int nBuckets = 96;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        checkTableAssignment(tableAssignment, rackMap, 12, nBuckets, replicationFactor);
+    }
+
+    @Test
+    void testMoreReplicasThanRacks() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 6;
+        int replicationFactor = 5;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        ReplicaDistributions distribution = getReplicaDistribution(tableAssignment, rackMap);
+        for (int bucket = 0; bucket < nBuckets; bucket++) {
+            Set<String> racksForBucket = new HashSet<>(distribution.getBucketRacks().get(bucket));
+            assertThat(racksForBucket.size()).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void testLessReplicasThanRacks() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack2");
+        rackMap.put(2, "rack2");
+        rackMap.put(3, "rack3");
+        rackMap.put(4, "rack3");
+        rackMap.put(5, "rack2");
+
+        int nBuckets = 6;
+        int replicationFactor = 2;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        ReplicaDistributions distribution = getReplicaDistribution(tableAssignment, rackMap);
+        for (int bucket = 0; bucket <= 5; bucket++) {
+            Set<String> racksForBucket = new HashSet<>(distribution.getBucketRacks().get(bucket));
+            assertThat(racksForBucket.size()).isEqualTo(2);
+        }
+    }
+
+    @Test
+    void testSingleRack() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, "rack1");
+        rackMap.put(2, "rack1");
+        rackMap.put(3, "rack1");
+        rackMap.put(4, "rack1");
+        rackMap.put(5, "rack1");
+
+        int nBuckets = 6;
+        int replicationFactor = 3;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()));
+        ReplicaDistributions distribution = getReplicaDistribution(tableAssignment, rackMap);
+        for (int bucket = 0; bucket < nBuckets; bucket++) {
+            Set<String> racksForBucket = new HashSet<>(distribution.getBucketRacks().get(bucket));
+            assertThat(racksForBucket.size()).isEqualTo(1);
+        }
+
+        for (Integer serverId : rackMap.keySet()) {
+            assertThat(distribution.getServerLeaderCount().get(serverId)).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void testSkipTabletServerWithReplicaAlreadyAssigned() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "a");
+        rackMap.put(1, "b");
+        rackMap.put(2, "c");
+        rackMap.put(3, "a");
+        rackMap.put(4, "a");
+
+        int nBuckets = 6;
+        int replicationFactor = 4;
+        TableAssignment tableAssignment =
+                generateAssignment(
+                        nBuckets,
+                        replicationFactor,
+                        toTabletServerInfo(rackMap, Collections.emptyList()),
+                        2,
+                        0);
+        checkTableAssignment(
+                tableAssignment, rackMap, 12, nBuckets, replicationFactor, false, false, false);
+    }
+
+    @Test
+    void testPartialTabletServersHaveRackInfo() {
+        Map<Integer, String> rackMap = new HashMap<>();
+        rackMap.put(0, "rack1");
+        rackMap.put(1, null);
+        rackMap.put(2, "rack2");
+        rackMap.put(3, null);
+        rackMap.put(4, "rack3");
+
+        assertThatThrownBy(
+                        () ->
+                                generateAssignment(
+                                        6, 3, toTabletServerInfo(rackMap, Collections.emptyList())))
+                .isInstanceOf(InvalidServerRackInfoException.class)
+                .hasMessageContaining(
+                        "Not all tabletServers have rack information for replica rack aware assignment.");
+    }
+
+    private static void checkTableAssignment(
+            TableAssignment assignment,
+            Map<Integer, String> serverRackMapping,
+            int numTabletServers,
+            int nBuckets,
+            int replicationFactor) {
+        checkTableAssignment(
+                assignment,
+                serverRackMapping,
+                numTabletServers,
+                nBuckets,
+                replicationFactor,
+                true,
+                true,
+                true);
+    }
+
+    private static void checkTableAssignment(
+            TableAssignment assignment,
+            Map<Integer, String> serverRackMapping,
+            int numTabletServers,
+            int nBuckets,
+            int replicationFactor,
+            boolean verifyRackAware,
+            boolean verifyLeaderDistribution,
+            boolean verifyReplicaDistribution) {
+        for (Map.Entry<Integer, BucketAssignment> entry :
+                assignment.getBucketAssignments().entrySet()) {
+            List<Integer> serverList = entry.getValue().getReplicas();
+            Set<Integer> uniqueServers = new HashSet<>(serverList);
+            assertThat(uniqueServers.size()).isEqualTo(serverList.size());
+        }
+
+        ReplicaDistributions distribution = getReplicaDistribution(assignment, serverRackMapping);
+
+        // verify RackAware.
+        if (verifyRackAware) {
+            Map<Integer, List<String>> bucketRackMap = distribution.getBucketRacks();
+            List<Integer> expectedRackCounts = Collections.nCopies(nBuckets, replicationFactor);
+            List<Integer> actualRackCounts =
+                    bucketRackMap.values().stream()
+                            .map(racks -> new HashSet<>(racks).size())
+                            .collect(Collectors.toList());
+            assertThat(expectedRackCounts).isEqualTo(actualRackCounts);
+        }
+
+        // verify leader distribution
+        if (verifyLeaderDistribution) {
+            Map<Integer, Integer> leaderCount = distribution.getServerLeaderCount();
+            int leaderCountPerServer = nBuckets / numTabletServers;
+            List<Integer> expectedLeaderCounts =
+                    Collections.nCopies(numTabletServers, leaderCountPerServer);
+            List<Integer> actualLeaderCounts =
+                    leaderCount.values().stream().sorted().collect(Collectors.toList());
+            assertThat(expectedLeaderCounts).isEqualTo(actualLeaderCounts);
+        }
+
+        // verify replicas distribution
+        if (verifyReplicaDistribution) {
+            Map<Integer, Integer> replicasCount = distribution.getServerReplicasCount();
+            int numReplicasPerServer = (nBuckets * replicationFactor) / numTabletServers;
+            List<Integer> expectedReplicaCounts =
+                    Collections.nCopies(numTabletServers, numReplicasPerServer);
+            List<Integer> actualReplicaCounts =
+                    replicasCount.values().stream().sorted().collect(Collectors.toList());
+            assertThat(expectedReplicaCounts).isEqualTo(actualReplicaCounts);
+        }
+    }
+
+    private static ReplicaDistributions getReplicaDistribution(
+            TableAssignment assignment, Map<Integer, String> serverRackMapping) {
+        Map<Integer, Integer> leaderCount = new HashMap<>();
+        Map<Integer, Integer> bucketCount = new HashMap<>();
+        Map<Integer, List<String>> bucketRackMap = new HashMap<>();
+
+        for (Map.Entry<Integer, BucketAssignment> entry :
+                assignment.getBucketAssignments().entrySet()) {
+            int bucketId = entry.getKey();
+            List<Integer> replicaList = entry.getValue().getReplicas();
+            int leader = replicaList.get(0);
+            leaderCount.put(leader, leaderCount.getOrDefault(leader, 0) + 1);
+            for (int tabletServerId : replicaList) {
+                bucketCount.put(tabletServerId, bucketCount.getOrDefault(tabletServerId, 0) + 1);
+
+                String rack = serverRackMapping.get(tabletServerId);
+                if (rack == null) {
+                    throw new IllegalArgumentException(
+                            "No mapping found for " + tabletServerId + " in `serverRackMapping`");
+                }
+
+                bucketRackMap.computeIfAbsent(bucketId, k -> new ArrayList<>()).add(rack);
+            }
+        }
+
+        return new ReplicaDistributions(bucketRackMap, leaderCount, bucketCount);
+    }
+
+    private static TabletServerInfo[] toTabletServerInfo(
+            Map<Integer, String> rackMap, List<Integer> serversWithoutRack) {
+
+        List<TabletServerInfo> res = new ArrayList<>();
+        for (Map.Entry<Integer, String> entry : rackMap.entrySet()) {
+            int tabletServerId = entry.getKey();
+            String rack = entry.getValue();
+            res.add(new TabletServerInfo(tabletServerId, rack));
+        }
+
+        for (int tabletServerId : serversWithoutRack) {
+            res.add(new TabletServerInfo(tabletServerId, null));
+        }
+
+        res.sort(Comparator.comparingInt(TabletServerInfo::getId));
+        return res.toArray(new TabletServerInfo[0]);
+    }
+
+    private static class ReplicaDistributions {
+        private final Map<Integer, List<String>> bucketRacks;
+        private final Map<Integer, Integer> serverLeaderCount;
+        private final Map<Integer, Integer> serverReplicasCount;
+
+        public ReplicaDistributions(
+                Map<Integer, List<String>> bucketRacks,
+                Map<Integer, Integer> serverLeaderCount,
+                Map<Integer, Integer> serverReplicasCount) {
+            this.bucketRacks = bucketRacks;
+            this.serverLeaderCount = serverLeaderCount;
+            this.serverReplicasCount = serverReplicasCount;
+        }
+
+        public Map<Integer, List<String>> getBucketRacks() {
+            return bucketRacks;
+        }
+
+        public Map<Integer, Integer> getServerLeaderCount() {
+            return serverLeaderCount;
+        }
+
+        public Map<Integer, Integer> getServerReplicasCount() {
+            return serverReplicasCount;
+        }
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/utils/TableAssignmentUtilsTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/utils/TableAssignmentUtilsTest.java
@@ -246,7 +246,7 @@ class TableAssignmentUtilsTest {
     void testAssignmentWithRackAwareWithUnevenRacks() {
         Map<Integer, String> rackMap = new HashMap<>();
         rackMap.put(0, "rack1");
-        rackMap.put(1, "rack2");
+        rackMap.put(1, "rack1");
         rackMap.put(2, "rack2");
         rackMap.put(3, "rack3");
         rackMap.put(4, "rack3");

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/zk/ZooKeeperClientTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/zk/ZooKeeperClientTest.java
@@ -107,10 +107,12 @@ class ZooKeeperClientTest {
         // register two table servers
         TabletServerRegistration registration1 =
                 new TabletServerRegistration(
+                        "rack1",
                         Endpoint.fromListenersString("CLIENT://host1:3456"),
                         System.currentTimeMillis());
         TabletServerRegistration registration2 =
                 new TabletServerRegistration(
+                        "rack2",
                         Endpoint.fromListenersString("CLIENT://host2:3454"),
                         System.currentTimeMillis());
         zookeeperClient.registerTabletServer(2, registration2);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #785 

<!-- What is the purpose of the change -->

Currently, Fluss only support generate bucket assignment info using round-robin strategy. However, in some cases, like deploy on K8s, we need to avoid multi replicas of one bucket was deployed to same host. 
So, in this pr I will introduce one rack aware bucket assignment strategy. For example:

If we have a tabletServer set as follow:
ts-id  -> machine rack
0 -> "rack1"
1 -> "rack3"
2 -> "rack3"
3 -> "rack2"
4 -> "rack2"
5 -> "rack1"

First we will  create a rack alternated tabletServers list:

[0, 3, 1, 5, 4, 2]

the list is in order rack1 -> rack2 -> rack3 -> rack1 -> rack2 -> rack3, and the preview tabletServerId lower than the next tabletServerId for the same rack.

Then an easy round-robin assignment can be applied. Assume 6 buckets with replica factor of 3, the assignment will be:

bucket0 -> 0,3,1
bucket1 -> 3,1,5
bucket2 -> 1,5,4
bucket3 -> 5,4,2
bucket4 -> 4,2,0
bucket5 -> 2,0,3

Once it has completed the first round-robin, if there are more buckets to assign, the algorithm will start shifting the followers. This is to ensure we will not always get the same set of sequences. In this case, if there is another bucket to assign (bucket6, bucket7), the assignment will be: 

bucket6 -> 0,4,2 (instead of repeating 0,3,1 as bucket0)
bucket7 -> 3,2,0  (instead of repeating 3,1,5 as bucket1)


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
