### PR TITLE
[log] Introduce OffsetsForLeaderEpoch Request/Response

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/exception/UnknownLeaderEpochException.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/exception/UnknownLeaderEpochException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.exception;
+
+/**
+ * The request contained a leaderEpoch which is larger than that on the tabletServer that received
+ * the request. This can happen if the client/follower observes a metadata update before it has been
+ * propagated to all tabletServers. client/follower need not refresh metadata before retrying.
+ */
+public class UnknownLeaderEpochException extends RetriableException {
+    private static final long serialVersionUID = 1L;
+
+    public UnknownLeaderEpochException(String message) {
+        super(message);
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/EpochAndLogEndOffsetForBucket.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/entity/EpochAndLogEndOffsetForBucket.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.entity;
+
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+
+/** Result of {@link OffsetForLeaderEpochRequest} for each table bucket. */
+public class EpochAndLogEndOffsetForBucket extends ResultForBucket {
+
+    /** The leaderEpoch of this tableBucket. */
+    private final int leaderEpoch;
+
+    /** The logEndOffset of this leaderEpoch. */
+    private final long logEndOffset;
+
+    public EpochAndLogEndOffsetForBucket(
+            TableBucket tableBucket, int leaderEpoch, long logEndOffset) {
+        this(tableBucket, leaderEpoch, logEndOffset, ApiError.NONE);
+    }
+
+    public EpochAndLogEndOffsetForBucket(TableBucket tableBucket, ApiError error) {
+        this(tableBucket, -1, -1L, error);
+    }
+
+    public EpochAndLogEndOffsetForBucket(
+            TableBucket tableBucket, int leaderEpoch, long logEndOffset, ApiError error) {
+        super(tableBucket, error);
+        this.leaderEpoch = leaderEpoch;
+        this.logEndOffset = logEndOffset;
+    }
+
+    public int getLeaderEpoch() {
+        return leaderEpoch;
+    }
+
+    public long getLogEndOffset() {
+        return logEndOffset;
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/TabletServerGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/TabletServerGateway.java
@@ -35,6 +35,8 @@ import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
 import com.alibaba.fluss.rpc.messages.PrefixLookupRequest;
 import com.alibaba.fluss.rpc.messages.PrefixLookupResponse;
 import com.alibaba.fluss.rpc.messages.ProduceLogRequest;
@@ -160,4 +162,13 @@ public interface TabletServerGateway extends RpcGateway, AdminReadOnlyGateway {
     @RPC(api = ApiKeys.NOTIFY_LAKE_TABLE_OFFSET)
     CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request);
+
+    /**
+     * Get logEndOffset for leaderEpoch.
+     *
+     * @return logEndOffset for leaderEpoch response
+     */
+    @RPC(api = ApiKeys.OFFSET_FOR_LEADER_EPOCH)
+    CompletableFuture<OffsetForLeaderEpochResponse> offsetForLeaderEpoch(
+            OffsetForLeaderEpochRequest request);
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -65,7 +65,8 @@ public enum ApiKeys {
     GET_DATABASE_INFO(1035, 0, 0, PUBLIC),
     CREATE_PARTITION(1036, 0, 0, PUBLIC),
     DROP_PARTITION(1037, 0, 0, PUBLIC),
-    AUTHENTICATE(1038, 0, 0, PUBLIC);
+    AUTHENTICATE(1038, 0, 0, PUBLIC),
+    OFFSET_FOR_LEADER_EPOCH(1039, 0, 0, PUBLIC);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -60,6 +60,7 @@ import com.alibaba.fluss.exception.TableNotExistException;
 import com.alibaba.fluss.exception.TableNotPartitionedException;
 import com.alibaba.fluss.exception.TimeoutException;
 import com.alibaba.fluss.exception.TooManyPartitionsException;
+import com.alibaba.fluss.exception.UnknownLeaderEpochException;
 import com.alibaba.fluss.exception.UnknownServerException;
 import com.alibaba.fluss.exception.UnknownTableOrBucketException;
 import com.alibaba.fluss.exception.UnknownWriterIdException;
@@ -192,7 +193,11 @@ public enum Errors {
             LeaderNotAvailableException::new),
     PARTITION_MAX_NUM_EXCEPTION(
             45, "Exceed the maximum number of partitions.", TooManyPartitionsException::new),
-    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new);
+    AUTHENTICATE_EXCEPTION(46, "The authentication failed.", AuthenticationException::new),
+    UNKNOWN_LEADER_EPOCH_EXCEPTION(
+            47,
+            "The leaderEpoch in the request is newer than the leaderEpoch on the tabletServer.",
+            UnknownLeaderEpochException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -481,6 +481,16 @@ message AuthenticateResponse {
   optional bytes challenge = 1;
 }
 
+// OffsetForLeaderEpochRequest and response
+message OffsetForLeaderEpochRequest {
+  required int32 follower_server_id = 1;  // value -1 indicate the request from client.
+  repeated PbOffsetForLeaderEpochReqForTable tables_req = 2;
+}
+
+message OffsetForLeaderEpochResponse {
+  repeated PbOffsetForLeaderEpochRespForTable tables_resp = 1;
+}
+
 // --------------- Inner classes ----------------
 message PbApiVersion {
   required int32 api_key = 1;
@@ -751,6 +761,33 @@ message PbPartitionInfo {
 
 message PbPartitionSpec {
   repeated PbKeyValue partition_key_values = 1;
+}
+
+message PbOffsetForLeaderEpochReqForTable {
+  required int64 table_id = 1;
+  repeated PbOffsetForLeaderEpochReqForBucket buckets_req = 2;
+}
+
+
+message PbOffsetForLeaderEpochReqForBucket {
+  optional int64 partition_id = 1;
+  required int32 bucket_id = 2;
+  required int32 current_leader_epoch = 3;
+  required int32 leader_epoch = 4;
+}
+
+message PbOffsetForLeaderEpochRespForTable {
+  required int64 table_id = 1;
+  repeated PbOffsetForLeaderEpochRespForBucket buckets_resp = 2;
+}
+
+message PbOffsetForLeaderEpochRespForBucket {
+  optional int64 partition_id = 1;
+  required int32 bucket_id = 2;
+  optional int32 error_code = 3;
+  optional string error_message = 4;
+  optional int32 leader_epoch = 5;
+  optional int64 log_end_offset = 6;
 }
 
 

--- a/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
+++ b/fluss-rpc/src/test/java/com/alibaba/fluss/rpc/TestingTabletGatewayService.java
@@ -60,6 +60,8 @@ import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
 import com.alibaba.fluss.rpc.messages.PrefixLookupRequest;
 import com.alibaba.fluss.rpc.messages.PrefixLookupResponse;
 import com.alibaba.fluss.rpc.messages.ProduceLogRequest;
@@ -155,6 +157,12 @@ public class TestingTabletGatewayService extends TestingGatewayService
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
+        return null;
+    }
+
+    @Override
+    public CompletableFuture<OffsetForLeaderEpochResponse> offsetForLeaderEpoch(
+            OffsetForLeaderEpochRequest request) {
         return null;
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/entity/OffsetForLeaderEpochData.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/entity/OffsetForLeaderEpochData.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.entity;
+
+import com.alibaba.fluss.exception.FencedLeaderEpochException;
+import com.alibaba.fluss.exception.UnknownLeaderEpochException;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+
+import java.util.Objects;
+
+/** The data for request {@link OffsetForLeaderEpochRequest}. */
+public class OffsetForLeaderEpochData {
+
+    private final TableBucket tableBucket;
+
+    /**
+     * An epoch used to fence clients/followers with old metadata. If the leaderEpoch provided by
+     * the client or follower is larger than the current leaderEpoch known to the tabletServer, then
+     * the {@link UnknownLeaderEpochException} will be thrown. If the leaderEpoch provided by the
+     * client or follower is smaller than the current epoch known to the requested tabletServer,
+     * then the {@link FencedLeaderEpochException} will be thrown.
+     */
+    private final int currentLeaderEpoch;
+
+    /** The epoch to look up an offset for. */
+    private final int leaderEpoch;
+
+    public OffsetForLeaderEpochData(
+            TableBucket tableBucket, int currentLeaderEpoch, int leaderEpoch) {
+        this.tableBucket = tableBucket;
+        this.currentLeaderEpoch = currentLeaderEpoch;
+        this.leaderEpoch = leaderEpoch;
+    }
+
+    public TableBucket getTableBucket() {
+        return tableBucket;
+    }
+
+    public int getCurrentLeaderEpoch() {
+        return currentLeaderEpoch;
+    }
+
+    public int getLeaderEpoch() {
+        return leaderEpoch;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        OffsetForLeaderEpochData that = (OffsetForLeaderEpochData) o;
+        return currentLeaderEpoch == that.currentLeaderEpoch
+                && leaderEpoch == that.leaderEpoch
+                && tableBucket.equals(that.tableBucket);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(tableBucket, currentLeaderEpoch, leaderEpoch);
+    }
+
+    @Override
+    public String toString() {
+        return "OffsetForLeaderEpochData{"
+                + "tableBucket="
+                + tableBucket
+                + ", currentLeaderEpoch="
+                + currentLeaderEpoch
+                + ", leaderEpoch="
+                + leaderEpoch
+                + '}';
+    }
+}

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/Replica.java
@@ -44,6 +44,7 @@ import com.alibaba.fluss.record.DefaultValueRecordBatch;
 import com.alibaba.fluss.record.KvRecordBatch;
 import com.alibaba.fluss.record.LogRecords;
 import com.alibaba.fluss.record.MemoryLogRecords;
+import com.alibaba.fluss.rpc.entity.EpochAndLogEndOffsetForBucket;
 import com.alibaba.fluss.rpc.protocol.Errors;
 import com.alibaba.fluss.server.SequenceIDCounter;
 import com.alibaba.fluss.server.coordinator.CoordinatorContext;
@@ -91,6 +92,7 @@ import com.alibaba.fluss.utils.FlussPaths;
 import com.alibaba.fluss.utils.IOUtils;
 import com.alibaba.fluss.utils.MapUtils;
 import com.alibaba.fluss.utils.clock.Clock;
+import com.alibaba.fluss.utils.types.Either;
 import com.alibaba.fluss.utils.types.Tuple2;
 
 import org.slf4j.Logger;
@@ -1309,6 +1311,39 @@ public final class Replica {
                 () -> logManager.truncateFullyAndStartAt(tableBucket, newOffset));
     }
 
+    /**
+     * Find the (exclusive) last log offset of the largest leaderEpoch less than or equal to the
+     * requested epoch.
+     *
+     * @param currentLeaderEpoch The expected leaderEpoch of the current leader (if known)
+     * @param leaderEpoch Requested leaderEpoch
+     * @param requireLeader Whether to require servicing only from the leader
+     * @return The requested leaderEpoch and the endLogOffset of this leaderEpoch, or if the
+     *     requested leaderEpoch is unknown, the leaderEpoch less than the requested leaderEpoch and
+     *     the logEndOffset of this leaderEpoch. The logEndOffset of a leaderEpoch is defined as the
+     *     startLogOffset of the first leaderEpoch larger than the leaderEpoch, or else the
+     *     logEndOffset if the leaderEpoch is the latest leaderEpoch.
+     */
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public EpochAndLogEndOffsetForBucket lastLogOffsetForLeaderEpoch(
+            Optional<Integer> currentLeaderEpoch, int leaderEpoch, boolean requireLeader) {
+        return inReadLock(
+                leaderIsrUpdateLock,
+                () -> {
+                    Either<LogTablet, Errors> localLogOrError =
+                            localLogOrThrow(currentLeaderEpoch, requireLeader);
+                    if (localLogOrError.isLeft()) {
+                        // TODO add localLog.endOffsetForEpoch() in next pr.
+                        LogTablet localLog = localLogOrError.left();
+                        return new EpochAndLogEndOffsetForBucket(
+                                tableBucket, leaderEpoch, localLog.localLogEndOffset());
+                    } else {
+                        return new EpochAndLogEndOffsetForBucket(
+                                tableBucket, localLogOrError.right().toApiError());
+                    }
+                });
+    }
+
     private LogReadInfo readRecords(FetchParams fetchParams, LogTablet logTablet)
             throws IOException {
         // Note we use the log end offset prior to the read. This ensures that any appends following
@@ -1736,15 +1771,51 @@ public final class Replica {
     }
 
     private LogTablet localLogOrThrow(boolean requireLeader) {
-        // TODO check leader epoch.
-        if (requireLeader && !isLeader()) {
-            throw new NotLeaderOrFollowerException(
-                    String.format(
-                            "Leader not local for bucket %s on tabletServer %d",
-                            tableBucket, localTabletServerId));
+        Either<LogTablet, Errors> either = localLogOrThrow(Optional.empty(), requireLeader);
+        if (either.isLeft()) {
+            return either.left();
+        } else {
+            throw either.right()
+                    .exception(
+                            String.format(
+                                    "Failed to find %s logTablet for tableBucket %s which leaderEpoch %s. The "
+                                            + "current leader is %s and the current leaderEpoch is %s",
+                                    requireLeader ? "leader" : "",
+                                    tableBucket,
+                                    -1,
+                                    leaderReplicaIdOpt,
+                                    leaderEpoch));
         }
+    }
 
-        return logTablet;
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private Either<LogTablet, Errors> localLogOrThrow(
+            Optional<Integer> currentLeaderEpoch, boolean requireLeader) {
+        if (checkCurrentLeaderEpoch(currentLeaderEpoch) == Errors.NONE) {
+            if (requireLeader && !isLeader()) {
+                return Either.right(Errors.NOT_LEADER_OR_FOLLOWER);
+            } else {
+                return Either.left(logTablet);
+            }
+        }
+        return Either.right(Errors.FENCED_LEADER_EPOCH_EXCEPTION);
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private Errors checkCurrentLeaderEpoch(Optional<Integer> currentLeaderEpochOpt) {
+        if (!currentLeaderEpochOpt.isPresent()) {
+            return Errors.NONE;
+        } else {
+            int currentLeaderEpoch = currentLeaderEpochOpt.get();
+            int localLeaderEpoch = leaderEpoch;
+            if (currentLeaderEpoch < localLeaderEpoch) {
+                return Errors.FENCED_LEADER_EPOCH_EXCEPTION;
+            } else if (currentLeaderEpoch > localLeaderEpoch) {
+                return Errors.UNKNOWN_LEADER_EPOCH_EXCEPTION;
+            } else {
+                return Errors.NONE;
+            }
+        }
     }
 
     @VisibleForTesting

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/ReplicaManager.java
@@ -38,6 +38,7 @@ import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.remote.RemoteLogFetchInfo;
 import com.alibaba.fluss.remote.RemoteLogSegment;
 import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.rpc.entity.EpochAndLogEndOffsetForBucket;
 import com.alibaba.fluss.rpc.entity.FetchLogResultForBucket;
 import com.alibaba.fluss.rpc.entity.LimitScanResultForBucket;
 import com.alibaba.fluss.rpc.entity.ListOffsetsResultForBucket;
@@ -60,6 +61,7 @@ import com.alibaba.fluss.server.entity.NotifyLakeTableOffsetData;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrData;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrResultForBucket;
 import com.alibaba.fluss.server.entity.NotifyRemoteLogOffsetsData;
+import com.alibaba.fluss.server.entity.OffsetForLeaderEpochData;
 import com.alibaba.fluss.server.entity.StopReplicaData;
 import com.alibaba.fluss.server.entity.StopReplicaResultForBucket;
 import com.alibaba.fluss.server.kv.KvManager;
@@ -695,6 +697,35 @@ public class ReplicaManager {
                         responseCallback.accept(new NotifyLakeTableOffsetResponse());
                     }
                 });
+    }
+
+    public void lastLogOffsetForLeaderEpoch(
+            List<OffsetForLeaderEpochData> offsetForLeaderEpochDataList,
+            Consumer<List<EpochAndLogEndOffsetForBucket>> responseCallback) {
+        List<EpochAndLogEndOffsetForBucket> result = new ArrayList<>();
+        for (OffsetForLeaderEpochData epochData : offsetForLeaderEpochDataList) {
+            TableBucket tb = epochData.getTableBucket();
+            try {
+                Replica replica = getReplicaOrException(tb);
+                Optional<Integer> currentLeaderEpochOpt;
+                // TODO -1 change to NO_LEADER_EPOCH
+                if (epochData.getCurrentLeaderEpoch() == -1) {
+                    currentLeaderEpochOpt = Optional.empty();
+                } else {
+                    currentLeaderEpochOpt = Optional.of(epochData.getCurrentLeaderEpoch());
+                }
+                result.add(
+                        replica.lastLogOffsetForLeaderEpoch(
+                                currentLeaderEpochOpt, epochData.getLeaderEpoch(), true));
+            } catch (Exception e) {
+                LOG.error(
+                        "Error processing fetch last offset for leader epoch operation on replica {}",
+                        tb,
+                        e);
+                result.add(new EpochAndLogEndOffsetForBucket(tb, ApiError.fromThrowable(e)));
+            }
+        }
+        responseCallback.accept(result);
     }
 
     /**

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/LeaderEndpoint.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/replica/fetcher/LeaderEndpoint.java
@@ -17,7 +17,9 @@
 package com.alibaba.fluss.server.replica.fetcher;
 
 import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.rpc.entity.EpochAndLogEndOffsetForBucket;
 import com.alibaba.fluss.rpc.entity.FetchLogResultForBucket;
+import com.alibaba.fluss.server.entity.OffsetForLeaderEpochData;
 
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +38,10 @@ interface LeaderEndpoint {
     CompletableFuture<Long> fetchLocalLogStartOffset(TableBucket tableBucket);
 
     CompletableFuture<Long> fetchLeaderEndOffsetSnapshot(TableBucket tableBucket);
+
+    /** Fetches the logEndOffset for leader epoch of the given table bucket. */
+    CompletableFuture<Map<TableBucket, EpochAndLogEndOffsetForBucket>> fetchOffsetForLeaderEpoch(
+            Map<TableBucket, OffsetForLeaderEpochData> leaderEpochDataMap);
 
     /**
      * Given a fetchLogRequest, carries out the expected request and returns the results from

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletService.java
@@ -40,6 +40,8 @@ import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
 import com.alibaba.fluss.rpc.messages.PrefixLookupRequest;
 import com.alibaba.fluss.rpc.messages.PrefixLookupResponse;
 import com.alibaba.fluss.rpc.messages.ProduceLogRequest;
@@ -69,6 +71,7 @@ import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getNotifyLake
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getNotifyLeaderAndIsrRequestData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getNotifyRemoteLogOffsetsData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getNotifySnapshotOffsetData;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getOffsetForLeaderEpochData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getProduceLogData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getPutKvData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getStopReplicaData;
@@ -79,6 +82,7 @@ import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeLimitScan
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeListOffsetsResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeLookupResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeNotifyLeaderAndIsrResponse;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeOffsetForLeaderEpochResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makePrefixLookupResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeProduceLogResponse;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makePutKvResponse;
@@ -257,6 +261,17 @@ public final class TabletService extends RpcServiceBase implements TabletServerG
             NotifyLakeTableOffsetRequest request) {
         CompletableFuture<NotifyLakeTableOffsetResponse> response = new CompletableFuture<>();
         replicaManager.notifyLakeTableOffset(getNotifyLakeTableOffset(request), response::complete);
+        return response;
+    }
+
+    @Override
+    public CompletableFuture<OffsetForLeaderEpochResponse> offsetForLeaderEpoch(
+            OffsetForLeaderEpochRequest request) {
+        CompletableFuture<OffsetForLeaderEpochResponse> response = new CompletableFuture<>();
+        replicaManager.lastLogOffsetForLeaderEpoch(
+                getOffsetForLeaderEpochData(request),
+                (responseList) ->
+                        response.complete(makeOffsetForLeaderEpochResponse(responseList)));
         return response;
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -36,6 +36,7 @@ import com.alibaba.fluss.record.LogRecords;
 import com.alibaba.fluss.record.MemoryLogRecords;
 import com.alibaba.fluss.remote.RemoteLogFetchInfo;
 import com.alibaba.fluss.remote.RemoteLogSegment;
+import com.alibaba.fluss.rpc.entity.EpochAndLogEndOffsetForBucket;
 import com.alibaba.fluss.rpc.entity.FetchLogResultForBucket;
 import com.alibaba.fluss.rpc.entity.LimitScanResultForBucket;
 import com.alibaba.fluss.rpc.entity.ListOffsetsResultForBucket;
@@ -66,6 +67,8 @@ import com.alibaba.fluss.rpc.messages.NotifyLakeTableOffsetRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrReqForTable;
 import com.alibaba.fluss.rpc.messages.PbAdjustIsrRespForBucket;
@@ -85,6 +88,10 @@ import com.alibaba.fluss.rpc.messages.PbLookupRespForBucket;
 import com.alibaba.fluss.rpc.messages.PbNotifyLakeTableOffsetReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbNotifyLeaderAndIsrReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbNotifyLeaderAndIsrRespForBucket;
+import com.alibaba.fluss.rpc.messages.PbOffsetForLeaderEpochReqForBucket;
+import com.alibaba.fluss.rpc.messages.PbOffsetForLeaderEpochReqForTable;
+import com.alibaba.fluss.rpc.messages.PbOffsetForLeaderEpochRespForBucket;
+import com.alibaba.fluss.rpc.messages.PbOffsetForLeaderEpochRespForTable;
 import com.alibaba.fluss.rpc.messages.PbPartitionSpec;
 import com.alibaba.fluss.rpc.messages.PbPhysicalTablePath;
 import com.alibaba.fluss.rpc.messages.PbPrefixLookupReqForBucket;
@@ -122,6 +129,7 @@ import com.alibaba.fluss.server.entity.NotifyLakeTableOffsetData;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrData;
 import com.alibaba.fluss.server.entity.NotifyLeaderAndIsrResultForBucket;
 import com.alibaba.fluss.server.entity.NotifyRemoteLogOffsetsData;
+import com.alibaba.fluss.server.entity.OffsetForLeaderEpochData;
 import com.alibaba.fluss.server.entity.StopReplicaData;
 import com.alibaba.fluss.server.entity.StopReplicaResultForBucket;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshot;
@@ -1263,5 +1271,134 @@ public class ServerRpcMessageUtils {
             partitionKeyAndValues.put(pbKeyValue.getKey(), pbKeyValue.getValue());
         }
         return new PartitionSpec(partitionKeyAndValues);
+    }
+
+    public static OffsetForLeaderEpochRequest makeOffsetForLeaderEpochRequest(
+            int followerServerId, Map<TableBucket, OffsetForLeaderEpochData> leaderEpochDataMap) {
+        OffsetForLeaderEpochRequest request =
+                new OffsetForLeaderEpochRequest().setFollowerServerId(followerServerId);
+        Map<Long, List<PbOffsetForLeaderEpochReqForBucket>> reqForBuckets = new HashMap<>();
+        for (Map.Entry<TableBucket, OffsetForLeaderEpochData> entry :
+                leaderEpochDataMap.entrySet()) {
+            TableBucket tb = entry.getKey();
+            OffsetForLeaderEpochData epochData = entry.getValue();
+            PbOffsetForLeaderEpochReqForBucket reqForBucket =
+                    new PbOffsetForLeaderEpochReqForBucket()
+                            .setBucketId(tb.getBucket())
+                            .setCurrentLeaderEpoch(epochData.getCurrentLeaderEpoch())
+                            .setLeaderEpoch(epochData.getLeaderEpoch());
+            if (tb.getPartitionId() != null) {
+                reqForBucket.setPartitionId(tb.getPartitionId());
+            }
+            reqForBuckets
+                    .computeIfAbsent(tb.getTableId(), key -> new ArrayList<>())
+                    .add(reqForBucket);
+        }
+
+        reqForBuckets.forEach(
+                (tableId, buckets) ->
+                        request.addTablesReq().setTableId(tableId).addAllBucketsReqs(buckets));
+        return request;
+    }
+
+    public static Map<TableBucket, EpochAndLogEndOffsetForBucket> getOffsetForLeaderEpochData(
+            OffsetForLeaderEpochResponse response) {
+        Map<TableBucket, EpochAndLogEndOffsetForBucket> epochDataMap = new HashMap<>();
+        for (PbOffsetForLeaderEpochRespForTable pbEpochDataForTable :
+                response.getTablesRespsList()) {
+            long tableId = pbEpochDataForTable.getTableId();
+            for (PbOffsetForLeaderEpochRespForBucket pbEpochDataForBucket :
+                    pbEpochDataForTable.getBucketsRespsList()) {
+                TableBucket tb =
+                        new TableBucket(
+                                tableId,
+                                pbEpochDataForBucket.hasPartitionId()
+                                        ? pbEpochDataForBucket.getPartitionId()
+                                        : null,
+                                pbEpochDataForBucket.getBucketId());
+                if (pbEpochDataForBucket.hasErrorCode()) {
+                    epochDataMap.put(
+                            tb,
+                            new EpochAndLogEndOffsetForBucket(
+                                    tb, ApiError.fromErrorMessage(pbEpochDataForBucket)));
+                } else {
+                    epochDataMap.put(
+                            tb,
+                            new EpochAndLogEndOffsetForBucket(
+                                    tb,
+                                    pbEpochDataForBucket.getLeaderEpoch(),
+                                    pbEpochDataForBucket.getLogEndOffset()));
+                }
+            }
+        }
+        return epochDataMap;
+    }
+
+    public static List<OffsetForLeaderEpochData> getOffsetForLeaderEpochData(
+            OffsetForLeaderEpochRequest request) {
+        List<OffsetForLeaderEpochData> epochDataList = new ArrayList<>();
+        for (PbOffsetForLeaderEpochReqForTable pbEpochDataForTable : request.getTablesReqsList()) {
+            long tableId = pbEpochDataForTable.getTableId();
+            for (PbOffsetForLeaderEpochReqForBucket pbEpochDataForBucket :
+                    pbEpochDataForTable.getBucketsReqsList()) {
+                int bucketId = pbEpochDataForBucket.getBucketId();
+                TableBucket tb =
+                        new TableBucket(
+                                tableId,
+                                pbEpochDataForBucket.hasPartitionId()
+                                        ? pbEpochDataForBucket.getPartitionId()
+                                        : null,
+                                bucketId);
+                epochDataList.add(
+                        new OffsetForLeaderEpochData(
+                                tb,
+                                pbEpochDataForBucket.getCurrentLeaderEpoch(),
+                                pbEpochDataForBucket.getLeaderEpoch()));
+            }
+        }
+        return epochDataList;
+    }
+
+    public static OffsetForLeaderEpochResponse makeOffsetForLeaderEpochResponse(
+            List<EpochAndLogEndOffsetForBucket> epochAndLogEndOffsetForBuckets) {
+        OffsetForLeaderEpochResponse response = new OffsetForLeaderEpochResponse();
+        Map<Long, List<PbOffsetForLeaderEpochRespForBucket>> respForTableMap = new HashMap<>();
+        for (EpochAndLogEndOffsetForBucket epochDataForBucket : epochAndLogEndOffsetForBuckets) {
+            TableBucket tb = epochDataForBucket.getTableBucket();
+            PbOffsetForLeaderEpochRespForBucket respForBucket =
+                    new PbOffsetForLeaderEpochRespForBucket().setBucketId(tb.getBucket());
+            if (tb.getPartitionId() != null) {
+                respForBucket.setPartitionId(tb.getPartitionId());
+            }
+
+            if (epochDataForBucket.failed()) {
+                respForBucket.setError(
+                        epochDataForBucket.getErrorCode(), epochDataForBucket.getErrorMessage());
+            } else {
+                respForBucket
+                        .setLeaderEpoch(epochDataForBucket.getLeaderEpoch())
+                        .setLogEndOffset(epochDataForBucket.getLogEndOffset());
+            }
+
+            if (respForTableMap.containsKey(tb.getTableId())) {
+                respForTableMap.get(tb.getTableId()).add(respForBucket);
+            } else {
+                List<PbOffsetForLeaderEpochRespForBucket> respForBuckets = new ArrayList<>();
+                respForBuckets.add(respForBucket);
+                respForTableMap.put(tb.getTableId(), respForBuckets);
+            }
+        }
+
+        List<PbOffsetForLeaderEpochRespForTable> respForTables = new ArrayList<>();
+        for (Map.Entry<Long, List<PbOffsetForLeaderEpochRespForBucket>> entry :
+                respForTableMap.entrySet()) {
+            PbOffsetForLeaderEpochRespForTable respForTable =
+                    new PbOffsetForLeaderEpochRespForTable().setTableId(entry.getKey());
+            respForTable.addAllBucketsResps(entry.getValue());
+            respForTables.add(respForTable);
+        }
+
+        response.addAllTablesResps(respForTables);
+        return response;
     }
 }

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/RemoteLeaderEndpointTest.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/replica/fetcher/RemoteLeaderEndpointTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.replica.fetcher;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.rpc.TestingTabletGatewayService;
+import com.alibaba.fluss.rpc.entity.EpochAndLogEndOffsetForBucket;
+import com.alibaba.fluss.rpc.entity.ListOffsetsResultForBucket;
+import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
+import com.alibaba.fluss.rpc.messages.ListOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
+import com.alibaba.fluss.rpc.protocol.ApiError;
+import com.alibaba.fluss.server.entity.OffsetForLeaderEpochData;
+import com.alibaba.fluss.server.log.ListOffsetsParam;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getOffsetForLeaderEpochData;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeListOffsetsResponse;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.makeOffsetForLeaderEpochResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link RemoteLeaderEndpoint}. */
+public class RemoteLeaderEndpointTest {
+
+    private TestingTabletServerGateway remoteServerGateway;
+    private RemoteLeaderEndpoint remoteLeaderEndpoint;
+
+    @BeforeEach
+    public void setUp() {
+        Configuration conf = new Configuration();
+        int remoteServerId = 2;
+        int followerServerId = 1;
+        remoteServerGateway = new TestingTabletServerGateway();
+        remoteLeaderEndpoint =
+                new RemoteLeaderEndpoint(
+                        conf, followerServerId, remoteServerId, remoteServerGateway);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testFetchLogStartOffset(boolean isPartitionedTable) throws Exception {
+        TableBucket tb = new TableBucket(1, isPartitionedTable ? 1000L : null, 0);
+        // first add bucket leader status to mock gateway.
+        remoteServerGateway.setBucketLeaderStatus(
+                tb, new BucketLeaderStatus(tb, 0L, 100L, 0, Collections.singletonMap(0, 100L)));
+        assertThat(remoteLeaderEndpoint.fetchLocalLogStartOffset(tb).get()).isEqualTo(0L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testFetchLogEndOffset(boolean isPartitionedTable) throws Exception {
+        TableBucket tb = new TableBucket(1, isPartitionedTable ? 1000L : null, 0);
+
+        // first add bucket leader status to mock gateway.
+        remoteServerGateway.setBucketLeaderStatus(
+                tb, new BucketLeaderStatus(tb, 0L, 100L, 0, Collections.singletonMap(0, 100L)));
+
+        assertThat(remoteLeaderEndpoint.fetchLocalLogEndOffset(tb).get()).isEqualTo(100L);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void fetchOffsetForLeaderEpoch(boolean isPartitionedTable) throws Exception {
+        TableBucket tb0 = new TableBucket(1, isPartitionedTable ? 1000L : null, 0);
+        TableBucket tb1 = new TableBucket(2, isPartitionedTable ? 1100L : null, 1);
+
+        Map<Integer, Long> tb0LeaderEpochToEndOffset = new HashMap<>();
+        tb0LeaderEpochToEndOffset.put(0, 20L);
+        tb0LeaderEpochToEndOffset.put(1, 50L);
+        tb0LeaderEpochToEndOffset.put(2, 100L);
+        BucketLeaderStatus tb0Status =
+                new BucketLeaderStatus(tb0, 0L, 100L, 2, tb0LeaderEpochToEndOffset);
+
+        Map<Integer, Long> tb1LeaderEpochToEndOffset = new HashMap<>();
+        tb1LeaderEpochToEndOffset.put(1, 10L);
+        tb1LeaderEpochToEndOffset.put(2, 50L);
+        tb1LeaderEpochToEndOffset.put(3, 100L);
+        BucketLeaderStatus tb1Status =
+                new BucketLeaderStatus(tb1, 10L, 100L, 3, tb1LeaderEpochToEndOffset);
+
+        remoteServerGateway.setBucketLeaderStatus(tb0, tb0Status);
+        remoteServerGateway.setBucketLeaderStatus(tb1, tb1Status);
+
+        Map<TableBucket, OffsetForLeaderEpochData> leaderEpochDataMap = new HashMap<>();
+        leaderEpochDataMap.put(tb0, new OffsetForLeaderEpochData(tb0, 1, 2));
+        leaderEpochDataMap.put(tb1, new OffsetForLeaderEpochData(tb0, 1, 3));
+        Map<TableBucket, EpochAndLogEndOffsetForBucket> result =
+                remoteLeaderEndpoint.fetchOffsetForLeaderEpoch(leaderEpochDataMap).get();
+        assertThat(result.get(tb0).getLogEndOffset()).isEqualTo(100L);
+        assertThat(result.get(tb1).getLogEndOffset()).isEqualTo(100L);
+    }
+
+    private static class TestingTabletServerGateway extends TestingTabletGatewayService {
+        Map<TableBucket, BucketLeaderStatus> bucketLeaderStatusMap;
+
+        TestingTabletServerGateway() {
+            this.bucketLeaderStatusMap = new HashMap<>();
+        }
+
+        @Override
+        public CompletableFuture<ListOffsetsResponse> listOffsets(ListOffsetsRequest request) {
+            CompletableFuture<ListOffsetsResponse> response = new CompletableFuture<>();
+            TableBucket tb =
+                    new TableBucket(
+                            request.getTableId(),
+                            request.hasPartitionId() ? request.getPartitionId() : null,
+                            request.getBucketIdAt(0));
+            BucketLeaderStatus bucketLeaderStatus = bucketLeaderStatusMap.get(tb);
+            ListOffsetsResultForBucket result;
+            switch (request.getOffsetType()) {
+                case ListOffsetsParam.LATEST_OFFSET_TYPE:
+                    result = new ListOffsetsResultForBucket(tb, bucketLeaderStatus.logEndOffset);
+                    break;
+                case ListOffsetsParam.EARLIEST_OFFSET_TYPE:
+                    result = new ListOffsetsResultForBucket(tb, bucketLeaderStatus.logStartOffset);
+                    break;
+                default:
+                    result =
+                            new ListOffsetsResultForBucket(
+                                    tb,
+                                    ApiError.fromThrowable(new UnsupportedOperationException()));
+            }
+
+            response.complete(makeListOffsetsResponse(Collections.singletonList(result)));
+            return response;
+        }
+
+        @Override
+        public CompletableFuture<OffsetForLeaderEpochResponse> offsetForLeaderEpoch(
+                OffsetForLeaderEpochRequest request) {
+            CompletableFuture<OffsetForLeaderEpochResponse> response = new CompletableFuture<>();
+
+            List<OffsetForLeaderEpochData> requestData = getOffsetForLeaderEpochData(request);
+            List<EpochAndLogEndOffsetForBucket> resultList = new ArrayList<>();
+            requestData.forEach(
+                    data -> {
+                        TableBucket tb = data.getTableBucket();
+                        BucketLeaderStatus bucketLeaderStatus = bucketLeaderStatusMap.get(tb);
+                        Map<Integer, Long> cacheEpoch =
+                                bucketLeaderStatus.leaderEpochToLogEndOffset;
+                        int requestEpoch = data.getLeaderEpoch();
+                        if (cacheEpoch.containsKey(requestEpoch)) {
+                            resultList.add(
+                                    new EpochAndLogEndOffsetForBucket(
+                                            tb, requestEpoch, cacheEpoch.get(requestEpoch)));
+                        } else {
+                            resultList.add(
+                                    new EpochAndLogEndOffsetForBucket(
+                                            tb,
+                                            ApiError.fromThrowable(
+                                                    new UnsupportedOperationException())));
+                        }
+                    });
+
+            response.complete(makeOffsetForLeaderEpochResponse(resultList));
+            return response;
+        }
+
+        void setBucketLeaderStatus(TableBucket tableBucket, BucketLeaderStatus bucketLeaderStatus) {
+            bucketLeaderStatusMap.put(tableBucket, bucketLeaderStatus);
+        }
+    }
+
+    private static class BucketLeaderStatus {
+        final TableBucket tableBucket;
+        final long logStartOffset;
+        final long logEndOffset;
+        final int leaderEpoch;
+        final Map<Integer, Long> leaderEpochToLogEndOffset;
+
+        BucketLeaderStatus(
+                TableBucket tableBucket,
+                long logStartOffset,
+                long logEndOffset,
+                int leaderEpoch,
+                Map<Integer, Long> leaderEpochToLogEndOffset) {
+            this.tableBucket = tableBucket;
+            this.logStartOffset = logStartOffset;
+            this.logEndOffset = logEndOffset;
+            this.leaderEpoch = leaderEpoch;
+            this.leaderEpochToLogEndOffset = leaderEpochToLogEndOffset;
+        }
+    }
+}

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/tablet/TestTabletServerGateway.java
@@ -65,6 +65,8 @@ import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrRequest;
 import com.alibaba.fluss.rpc.messages.NotifyLeaderAndIsrResponse;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsRequest;
 import com.alibaba.fluss.rpc.messages.NotifyRemoteLogOffsetsResponse;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochRequest;
+import com.alibaba.fluss.rpc.messages.OffsetForLeaderEpochResponse;
 import com.alibaba.fluss.rpc.messages.PbNotifyLeaderAndIsrReqForBucket;
 import com.alibaba.fluss.rpc.messages.PbNotifyLeaderAndIsrRespForBucket;
 import com.alibaba.fluss.rpc.messages.PbStopReplicaReqForBucket;
@@ -307,6 +309,12 @@ public class TestTabletServerGateway implements TabletServerGateway {
     @Override
     public CompletableFuture<NotifyLakeTableOffsetResponse> notifyLakeTableOffset(
             NotifyLakeTableOffsetRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<OffsetForLeaderEpochResponse> offsetForLeaderEpoch(
+            OffsetForLeaderEpochRequest request) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue:  #750 

<!-- What is the purpose of the change -->

To use LeaderEpoch rather than HighWatermark for truncation, we need to introduce OffsetsForLeaderEpochRequest/Response to fetch the latest LeaderEpoch -> Offset info from leader to truncate log.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
