### PR TITLE
[server] fix: make ReplicaDeletionStarted ReplicaDeletionSuccessful a valid pr…

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaState.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/statemachine/ReplicaState.java
@@ -44,7 +44,12 @@ public enum ReplicaState implements BaseState<ReplicaState> {
     OfflineReplica {
         @Override
         public Set<ReplicaState> getValidPreviousStates() {
-            return EnumSet.of(NewReplica, OnlineReplica, OfflineReplica);
+            return EnumSet.of(
+                    NewReplica,
+                    OnlineReplica,
+                    OfflineReplica,
+                    ReplicaDeletionStarted,
+                    ReplicaDeletionSuccessful);
         }
     },
     ReplicaDeletionStarted {


### PR DESCRIPTION
…evious state of OfflineReplica

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #764 

<!-- What is the purpose of the change -->

### Brief change log

Add ReplicaDeletionStarted and ReplicaDeletionSuccessful as a valid previous state of OfflineReplica

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
