### PR TITLE
[connector] Support projection pushdown via field names for fluss source

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSource.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
  *     .setBootstrapServers("localhost:9092")
  *     .setDatabase("mydb")
  *     .setTable("orders")
+ *     .setProjectedFields("orderId", "amount")
  *     .setStartingOffsets(OffsetsInitializer.earliest())
  *     .setScanPartitionDiscoveryIntervalMs(1000L)
  *     .setDeserializationSchema(new OrderDeserializationSchema())

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSourceBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSourceBuilder.java
@@ -27,6 +27,7 @@ import com.alibaba.fluss.flink.source.enumerator.initializer.OffsetsInitializer;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.RowType;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSourceBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSourceBuilder.java
@@ -27,10 +27,10 @@ import com.alibaba.fluss.flink.source.enumerator.initializer.OffsetsInitializer;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.RowType;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.util.Preconditions.checkNotNull;
@@ -48,6 +48,7 @@ import static org.apache.flink.util.Preconditions.checkNotNull;
  *     .setBootstrapServers("localhost:9092")
  *     .setDatabase("mydb")
  *     .setTable("orders")
+ *     .setProjectedFields("orderId", "amount")
  *     .setScanPartitionDiscoveryIntervalMs(1000L)
  *     .setStartingOffsets(OffsetsInitializer.earliest())
  *     .setDeserializationSchema(new OrderDeserializationSchema())
@@ -62,6 +63,7 @@ public class FlussSourceBuilder<OUT> {
     private Configuration flussConf;
 
     private int[] projectedFields;
+    private String[] projectedFieldNames;
     private Long scanPartitionDiscoveryIntervalMs;
     private OffsetsInitializer offsetsInitializer;
     private FlussDeserializationSchema<OUT> deserializationSchema;
@@ -103,10 +105,8 @@ public class FlussSourceBuilder<OUT> {
         return this;
     }
 
-    // TODO: refactor this method to use field names instead of indexes
-    //  see: https://github.com/alibaba/fluss/issues/804
-    public FlussSourceBuilder<OUT> setProjectedFields(int[] projectedFields) {
-        this.projectedFields = projectedFields;
+    public FlussSourceBuilder<OUT> setProjectedFields(String[] projectedFieldNames) {
+        this.projectedFieldNames = projectedFieldNames;
         return this;
     }
 
@@ -146,7 +146,6 @@ public class FlussSourceBuilder<OUT> {
 
         TablePath tablePath = new TablePath(this.database, this.tableName);
         this.flussConf.setString(ConfigOptions.BOOTSTRAP_SERVERS.key(), bootstrapServers);
-
         TableInfo tableInfo;
         try (Connection connection = ConnectionFactory.createConnection(flussConf);
                 Admin admin = connection.getAdmin()) {
@@ -161,6 +160,24 @@ public class FlussSourceBuilder<OUT> {
         } catch (Exception e) {
             throw new RuntimeException(
                     "Failed to initialize FlussSource admin connection: " + e.getMessage(), e);
+        }
+
+        if (this.projectedFieldNames != null && projectedFieldNames.length > 0) {
+            RowType rowType = tableInfo.getRowType();
+            List<String> allFieldNames = rowType.getFieldNames();
+            int[] indices = new int[projectedFieldNames.length];
+            for (int i = 0; i < projectedFieldNames.length; i++) {
+                int index = allFieldNames.indexOf(projectedFieldNames[i]);
+                if (index == -1) {
+                    throw new IllegalArgumentException(
+                            "Field name '"
+                                    + projectedFieldNames[i]
+                                    + "' not found in table schema.");
+                }
+                indices[i] = index;
+            }
+
+            this.projectedFields = indices;
         }
 
         flussConf.addAll(tableInfo.getCustomProperties());

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceBuilderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceBuilderTest.java
@@ -232,7 +232,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
     @Test
     public void testSetProjectedFields() {
         // Given
-        int[] projectedFields = new int[] {0, 1};
+        String[] projectedFieldNames = new String[] {"id", "name"};
         FlussSource<TestRecord> source =
                 FlussSource.<TestRecord>builder()
                         .setBootstrapServers(bootstrapServers)
@@ -241,7 +241,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new TestDeserializationSchema())
-                        .setProjectedFields(projectedFields)
+                        .setProjectedFields(projectedFieldNames)
                         .build();
 
         // Then
@@ -251,7 +251,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
     @Test
     public void testProjectedFields() {
         // Given
-        int[] projectedFields = new int[] {0, 1}; // Only include orderId and amount fields
+        String[] projectedFieldsNames = new String[] {"id", "name"};
 
         // When
         FlussSource<TestRecord> source =
@@ -262,7 +262,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new TestDeserializationSchema())
-                        .setProjectedFields(projectedFields)
+                        .setProjectedFields(projectedFieldsNames)
                         .build();
 
         // Then

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceBuilderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceBuilderTest.java
@@ -232,7 +232,6 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
     @Test
     public void testSetProjectedFields() {
         // Given
-        String[] projectedFieldNames = new String[] {"id", "name"};
         FlussSource<TestRecord> source =
                 FlussSource.<TestRecord>builder()
                         .setBootstrapServers(bootstrapServers)
@@ -241,7 +240,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new TestDeserializationSchema())
-                        .setProjectedFields(projectedFieldNames)
+                        .setProjectedFields("id", "name")
                         .build();
 
         // Then
@@ -250,9 +249,6 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
 
     @Test
     public void testProjectedFields() {
-        // Given
-        String[] projectedFieldsNames = new String[] {"id", "name"};
-
         // When
         FlussSource<TestRecord> source =
                 FlussSource.<TestRecord>builder()
@@ -262,7 +258,7 @@ public class FlussSourceBuilderTest extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new TestDeserializationSchema())
-                        .setProjectedFields(projectedFieldsNames)
+                        .setProjectedFields("id", "name")
                         .build();
 
         // Then

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
@@ -132,7 +132,7 @@ public class FlussSourceITCase extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new OrderPartialDeserializationSchema())
-                        .setProjectedFields(new String[] {"orderId", "amount"})
+                        .setProjectedFields("orderId", "amount")
                         .build();
 
         DataStreamSource<OrderPartial> stream =
@@ -262,7 +262,7 @@ public class FlussSourceITCase extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new OrderPartialDeserializationSchema())
-                        .setProjectedFields(new String[] {"orderId", "amount"})
+                        .setProjectedFields("orderId", "amount")
                         .build();
 
         DataStreamSource<OrderPartial> stream =

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
@@ -132,7 +132,7 @@ public class FlussSourceITCase extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new OrderPartialDeserializationSchema())
-                        .setProjectedFields(new int[] {0, 2})
+                        .setProjectedFields(new String[] {"orderId", "amount"})
                         .build();
 
         DataStreamSource<OrderPartial> stream =
@@ -262,7 +262,7 @@ public class FlussSourceITCase extends FlinkTestBase {
                         .setStartingOffsets(OffsetsInitializer.earliest())
                         .setScanPartitionDiscoveryIntervalMs(1000L)
                         .setDeserializationSchema(new OrderPartialDeserializationSchema())
-                        .setProjectedFields(new int[] {0, 2})
+                        .setProjectedFields(new String[] {"orderId", "amount"})
                         .build();
 
         DataStreamSource<OrderPartial> stream =


### PR DESCRIPTION
### Purpose
<!-- Linking this pull request to the issue -->
Linked issue: close #804

<!-- What is the purpose of the change -->
Add a user-friendly field name-based projection API to FlussSourceBuilder while maintaining backward compatibility with the existing index-based approach.

### Brief change log
<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Added new `setProjectedFields(String[] fieldNames)` method to FlussSourceBuilder
- Added field name to index mapping in the build() method
- Added the projectedFieldNames List to store the requested field names
- Maintained backward compatibility with existing index-based API
- Modified comprehensive validation for field name existence
- Modified unit tests for the new field name-based API

### Tests
<!-- List UT and IT cases to verify this change -->
- Fixed existing unit tests in FlussSourceBuilderTest for field name projection
- Fixed existing integration tests to use appropriate field names

### API and Format
<!-- Does this change affect API or storage format -->
This change extends the FlussSourceBuilder API by adding a more user-friendly method for projection specification, but it doesn't change any storage format or break backward compatibility.

### Documentation
<!-- Does this change introduce a new feature -->
Updated JavaDoc to document the new field name-based projection API and added usage examples in class-level documentation.