### PR TITLE
[kafka] Support connection max idle time configuration for KafkaProtocolPlugin

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -705,7 +705,7 @@ public class ConfigOptions {
                     .durationType()
                     .defaultValue(Duration.ofMinutes(10))
                     .withDescription(
-                            "Close idle connections after the number of milliseconds specified by this config.");
+                            "Close idle connections after the given time specified by this config.");
 
     public static final ConfigOption<Integer> NETTY_CLIENT_NUM_NETWORK_THREADS =
             key("netty.client.num-network-threads")
@@ -1541,7 +1541,7 @@ public class ConfigOptions {
                     .durationType()
                     .defaultValue(Duration.ofSeconds(60))
                     .withDescription(
-                            "Close kafka idle connections after the number of milliseconds specified by this config.");
+                            "Close kafka idle connections after the given time specified by this config.");
 
     /**
      * Compaction style for Fluss's kv, which is same to rocksdb's, but help use avoid including

--- a/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/config/ConfigOptions.java
@@ -1536,6 +1536,13 @@ public class ConfigOptions {
                     .withDescription(
                             "The database for fluss kafka. The default database is 'kafka'.");
 
+    public static final ConfigOption<Duration> KAFKA_CONNECTION_MAX_IDLE_TIME =
+            key("kafka.connection.max-idle-time")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(60))
+                    .withDescription(
+                            "Close kafka idle connections after the number of milliseconds specified by this config.");
+
     /**
      * Compaction style for Fluss's kv, which is same to rocksdb's, but help use avoid including
      * rocksdb dependency when only need include this common module.

--- a/fluss-kafka/src/main/java/com/alibaba/fluss/kafka/KafkaProtocolPlugin.java
+++ b/fluss-kafka/src/main/java/com/alibaba/fluss/kafka/KafkaProtocolPlugin.java
@@ -30,20 +30,29 @@ import java.util.List;
 /** The Kafka protocol plugin. */
 public class KafkaProtocolPlugin implements NetworkProtocolPlugin {
 
+    private Configuration conf;
+
     @Override
     public String name() {
         return KAFKA_PROTOCOL_NAME;
     }
 
     @Override
-    public List<String> listenerNames(Configuration conf) {
+    public void setup(Configuration conf) {
+        this.conf = conf;
+    }
+
+    @Override
+    public List<String> listenerNames() {
         return conf.get(ConfigOptions.KAFKA_LISTENER_NAMES);
     }
 
     @Override
     public ChannelHandler createChannelHandler(
             RequestChannel[] requestChannels, String listenerName) {
-        return new KafkaChannelInitializer(requestChannels);
+        return new KafkaChannelInitializer(
+                requestChannels,
+                conf.get(ConfigOptions.KAFKA_CONNECTION_MAX_IDLE_TIME).getSeconds());
     }
 
     @Override

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/NettyChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/NettyChannelInitializer.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.rpc.netty;
+
+import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelInitializer;
+import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.SocketChannel;
+import com.alibaba.fluss.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import com.alibaba.fluss.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
+
+import static com.alibaba.fluss.utils.Preconditions.checkArgument;
+
+/**
+ * A basic {@link ChannelInitializer} for initializing {@link SocketChannel} instances to support
+ * netty logging and add common handlers.
+ */
+public class NettyChannelInitializer extends ChannelInitializer<SocketChannel> {
+
+    private final int maxIdleTimeSeconds;
+
+    private static final NettyLogger nettyLogger = new NettyLogger();
+
+    public NettyChannelInitializer(long maxIdleTimeSeconds) {
+        checkArgument(maxIdleTimeSeconds <= Integer.MAX_VALUE, "maxIdleTimeSeconds too large");
+        this.maxIdleTimeSeconds = (int) maxIdleTimeSeconds;
+    }
+
+    @Override
+    protected void initChannel(SocketChannel ch) throws Exception {
+        if (nettyLogger.getLoggingHandler() != null) {
+            ch.pipeline().addLast("loggingHandler", nettyLogger.getLoggingHandler());
+        }
+    }
+
+    public void addFrameDecoder(SocketChannel ch, int maxFrameLength, int initialBytesToStrip) {
+        ch.pipeline()
+                .addLast(
+                        "frameDecoder",
+                        new LengthFieldBasedFrameDecoder(
+                                maxFrameLength, 0, 4, 0, initialBytesToStrip));
+    }
+
+    public void addIdleStateHandler(SocketChannel ch) {
+        ch.pipeline().addLast("idle", new IdleStateHandler(0, 0, maxIdleTimeSeconds));
+    }
+}

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -60,7 +60,8 @@ final class ServerChannelInitializer extends NettyChannelInitializer {
     }
 
     @Override
-    protected void initChannel(SocketChannel ch) {
+    protected void initChannel(SocketChannel ch) throws Exception {
+        super.initChannel(ch);
         // initialBytesToStrip=0 to include the frame size field after decoding
         addFrameDecoder(ch, Integer.MAX_VALUE, 0);
         addIdleStateHandler(ch);

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/netty/server/ServerChannelInitializer.java
@@ -16,13 +16,11 @@
 
 package com.alibaba.fluss.rpc.netty.server;
 
-import com.alibaba.fluss.rpc.netty.NettyLogger;
+import com.alibaba.fluss.rpc.netty.NettyChannelInitializer;
 import com.alibaba.fluss.rpc.protocol.ApiManager;
 import com.alibaba.fluss.security.auth.ServerAuthenticator;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.ChannelInitializer;
 import com.alibaba.fluss.shaded.netty4.io.netty.channel.socket.SocketChannel;
-import com.alibaba.fluss.shaded.netty4.io.netty.handler.codec.LengthFieldBasedFrameDecoder;
-import com.alibaba.fluss.shaded.netty4.io.netty.handler.timeout.IdleStateHandler;
 import com.alibaba.fluss.utils.MathUtils;
 
 import org.slf4j.Logger;
@@ -30,24 +28,19 @@ import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
 
-import static com.alibaba.fluss.utils.Preconditions.checkArgument;
-
 /**
  * A specialized {@link ChannelInitializer} for initializing {@link SocketChannel} instances that
  * will be used by the server to handle the init request for the client.
  */
-final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
+final class ServerChannelInitializer extends NettyChannelInitializer {
     private static final Logger LOG = LoggerFactory.getLogger(ServerChannelInitializer.class);
 
-    private final int maxIdleTimeSeconds;
     private final RequestChannel[] requestChannels;
     private final ApiManager apiManager;
     private final String endpointListenerName;
     private final boolean isInternal;
     private final RequestsMetrics requestsMetrics;
     private final Supplier<ServerAuthenticator> authenticatorSupplier;
-
-    private static final NettyLogger nettyLogger = new NettyLogger();
 
     public ServerChannelInitializer(
             RequestChannel[] requestChannels,
@@ -57,43 +50,33 @@ final class ServerChannelInitializer extends ChannelInitializer<SocketChannel> {
             RequestsMetrics requestsMetrics,
             long maxIdleTimeSeconds,
             Supplier<ServerAuthenticator> authenticatorSupplier) {
-        checkArgument(maxIdleTimeSeconds <= Integer.MAX_VALUE, "maxIdleTimeSeconds too large");
+        super(maxIdleTimeSeconds);
         this.requestChannels = requestChannels;
         this.apiManager = apiManager;
         this.endpointListenerName = endpointListenerName;
         this.isInternal = isInternal;
         this.requestsMetrics = requestsMetrics;
-        this.maxIdleTimeSeconds = (int) maxIdleTimeSeconds;
         this.authenticatorSupplier = authenticatorSupplier;
     }
 
     @Override
     protected void initChannel(SocketChannel ch) {
-        if (nettyLogger.getLoggingHandler() != null) {
-            ch.pipeline().addLast("loggingHandler", nettyLogger.getLoggingHandler());
-        }
-
-        // TODO: we can introduce a smarter and dynamic strategy to distribute requests to
-        //  channels
-        int channelIndex = MathUtils.murmurHash(ch.id().hashCode()) % requestChannels.length;
-
-        ch.pipeline()
-                .addLast(
-                        "frameDecoder",
-                        // initialBytesToStrip=0 to include the frame size field after decoding
-                        new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 0));
-        ch.pipeline().addLast("idle", new IdleStateHandler(0, 0, maxIdleTimeSeconds));
+        // initialBytesToStrip=0 to include the frame size field after decoding
+        addFrameDecoder(ch, Integer.MAX_VALUE, 0);
+        addIdleStateHandler(ch);
         ServerAuthenticator serverAuthenticator = authenticatorSupplier.get();
         LOG.debug(
                 "initial a channel for listener {} with protocol {}",
                 endpointListenerName,
                 serverAuthenticator.protocol());
-
+        // TODO: we can introduce a smarter and dynamic strategy to distribute requests to channels
         ch.pipeline()
                 .addLast(
                         "handler",
                         new NettyServerHandler(
-                                requestChannels[channelIndex],
+                                requestChannels[
+                                        MathUtils.murmurHash(ch.id().hashCode())
+                                                % requestChannels.length],
                                 apiManager,
                                 endpointListenerName,
                                 isInternal,

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/NetworkProtocolPlugin.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/NetworkProtocolPlugin.java
@@ -28,13 +28,17 @@ import java.util.List;
 /** A network protocol plugin that provides the server side implementation of a network protocol. */
 public interface NetworkProtocolPlugin extends Plugin {
 
+    String FLUSS_PROTOCOL_NAME = RequestType.FLUSS.name();
     String KAFKA_PROTOCOL_NAME = RequestType.KAFKA.name();
 
     /** Returns the name of the protocol. */
     String name();
 
+    /** Setup network protocol plugin with the given {@link Configuration}. */
+    void setup(Configuration conf);
+
     /** Returns the names of the listeners that the protocol binds to. */
-    List<String> listenerNames(Configuration conf);
+    List<String> listenerNames();
 
     /**
      * Creates a Netty {@link ChannelHandler} for handling server side I/O events and operations of

--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -175,8 +175,9 @@ during the Fluss cluster working.
 
 ## Kafka
 
-| Option         | Type    | Default | Description                                                                                                        |
-|----------------|---------|---------|--------------------------------------------------------------------------------------------------------------------|
-| kafka.enabled  | boolean | false   | Whether enable fluss kafka. Disabled by default. When this option is set to true, the fluss kafka will be enabled. |
-| kafka.port     | Integer | 9092    | The port for fluss kafka. The default port is 9092.                                                                |
-| kafka.database | String  | _kafka  | The database for fluss kafka. The default database is '_kafka'.                                                    |
+| Option                         | Type     | Default | Description                                                                                                        |
+|--------------------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------|
+| kafka.enabled                  | boolean  | false   | Whether enable fluss kafka. Disabled by default. When this option is set to true, the fluss kafka will be enabled. |
+| kafka.port                     | Integer  | 9092    | The port for fluss kafka. The default port is 9092.                                                                |
+| kafka.database                 | String   | _kafka  | The database for fluss kafka. The default database is '_kafka'.                                                    |
+| kafka.connection.max-idle-time | Duration | 60s     | Close kafka idle connections after the number of milliseconds specified by this config.                            |

--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -96,7 +96,7 @@ during the Fluss cluster working.
 | netty.server.num-network-threads | Integer  | 3       | The number of threads that the server uses for receiving requests from the network and sending responses to the network.                    |
 | netty.server.num-worker-threads  | Integer  | 8       | The number of threads that the server uses for processing requests, which may include disk and remote I/O.                                  |
 | netty.server.max-queued-requests | Integer  | 500     | The number of queued requests allowed for worker threads, before blocking the I/O threads.                                                  |
-| netty.connection.max-idle-time   | Duration | 10min   | Close idle connections after the number of milliseconds specified by this config.                                                           |
+| netty.connection.max-idle-time   | Duration | 10min   | Close idle connections after the given time specified by this config.                                                                       |
 | netty.client.num-network-threads | Integer  | 1       | The number of threads that the client uses for sending requests to the network and receiving responses from network. The default value is 1 |
 
 ## Log
@@ -180,4 +180,4 @@ during the Fluss cluster working.
 | kafka.enabled                  | boolean  | false   | Whether enable fluss kafka. Disabled by default. When this option is set to true, the fluss kafka will be enabled. |
 | kafka.port                     | Integer  | 9092    | The port for fluss kafka. The default port is 9092.                                                                |
 | kafka.database                 | String   | _kafka  | The database for fluss kafka. The default database is '_kafka'.                                                    |
-| kafka.connection.max-idle-time | Duration | 60s     | Close kafka idle connections after the number of milliseconds specified by this config.                            |
+| kafka.connection.max-idle-time | Duration | 60s     | Close kafka idle connections after the given time specified by this config.                                        |


### PR DESCRIPTION
### Purpose

Linked issue: close #820.

Support connection max idle time configuration for `KafkaProtocolPlugin`.

### Brief change log

Introduce `kafka.connection.max-idle-time` to support connection max idle time configuration for `KafkaProtocolPlugin`.

### Tests

No.

### API and Format

`NetworkProtocolPlugin` adds `setup(Configuration conf)` interface to setup network protoco plugin with the given configuration. 

### Documentation

Kafka section of `configuration.md` adds `kafka.connection.max-idle-time` config option.