### PR TITLE
[Document] Make slack and community call public

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
   <a href="https://alibaba.github.io/fluss-docs/docs/intro/">Documentation</a> | <a href="https://alibaba.github.io/fluss-docs/docs/quickstart/flink/">QuickStart</a> | <a href="https://alibaba.github.io/fluss-docs/community/dev/ide-setup/">Development</a>
 </p>
 
+<p align="center">
+  <a href="https://github.com/alibaba/fluss/actions/workflows/ci.yaml"><img src="https://github.com/alibaba/fluss/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/alibaba/fluss/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-4EB1BA.svg" alt="License"></a>
+  <a href="https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw"><img src="https://img.shields.io/badge/slack-join_chat-brightgreen.svg?logo=slack" alt="Slack"></a>
+</p>
+
 ## What is Fluss?
 
 Fluss is a streaming storage built for real-time analytics which can serve as the real-time data layer for Lakehouse architectures.

--- a/website/community/welcome.md
+++ b/website/community/welcome.md
@@ -30,5 +30,17 @@ If you are not sure on what to work on, look at issue tagged with [good first is
 
 The development discussions and user questions happen primarily on [GitHub Discussions](https://github.com/alibaba/fluss/discussions).
 
+## Slack 
+We use Slack for real-time communication and collaboration. To join our workspace, follow this [invite link](https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw).
 
+Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by creating an issue on GitHub.
+
+## Community Events
+Join our monthly community gatherings to get involved:
+
+* **Fluss Contributors Call**  
+  1:30 – 2:10pm UTC+8  
+  Inviattion link: [https://meet.google.com/nsu-rxvq-vuk](https://meet.google.com/nsu-rxvq-vuk)
+
+These community calls are a great opportunity to discuss the project roadmap, implementation details, and connect with other contributors.
 

--- a/website/community/welcome.md
+++ b/website/community/welcome.md
@@ -40,7 +40,7 @@ Join our monthly community gatherings to get involved:
 
 * **Fluss Contributors Call**  
   1:30 – 2:10pm UTC+8  
-  Inviattion link: [https://meet.google.com/nsu-rxvq-vuk](https://meet.google.com/nsu-rxvq-vuk)
+  Invitation link: [https://meet.google.com/nsu-rxvq-vuk](https://meet.google.com/nsu-rxvq-vuk)
 
 These community calls are a great opportunity to discuss the project roadmap, implementation details, and connect with other contributors.
 

--- a/website/community/welcome.md
+++ b/website/community/welcome.md
@@ -38,9 +38,9 @@ Please note that this link may occasionally break when Slack does an upgrade. If
 ## Community Events
 Join our monthly community gatherings to get involved:
 
-* **Fluss Contributors Call**  
-  1:30 – 2:10pm UTC+8  
-  Invitation link: [https://meet.google.com/nsu-rxvq-vuk](https://meet.google.com/nsu-rxvq-vuk)
+**Fluss Contributors Call**
+
+  Invitation link: [Event](https://calendar.app.google/HUHUns4tSiv9NFt26)
 
 These community calls are a great opportunity to discuss the project roadmap, implementation details, and connect with other contributors.
 

--- a/website/community/welcome.md
+++ b/website/community/welcome.md
@@ -40,7 +40,7 @@ Join our monthly community gatherings to get involved:
 
 **Fluss Contributors Call**
 
-  Invitation link: [Event](https://calendar.app.google/HUHUns4tSiv9NFt26)
+  Invitation link: [Community Events](https://calendar.app.google/1u58VvHpn71H9rz57)
 
 These community calls are a great opportunity to discuss the project roadmap, implementation details, and connect with other contributors.
 


### PR DESCRIPTION
### Purpose
<!-- What is the purpose of the change -->
Add community communication channels to improve contributor engagement and coordination.

### Brief change log
<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Added Slack channel section with invitation link to the community page and readme.md
- Added Community Events section with details about the Fluss Contributors Call

### Tests
<!-- List UT and IT cases to verify this change -->
N/A - Documentation change only

### API and Format
<!-- Does this change affect API or storage format -->
No impact on API or storage format.

### Documentation
<!-- Does this change introduce a new feature -->
Updates documentation to provide clear instructions for community participation channels.