### PR TITLE
[server] feat: authorize InitWriter RPC with table path parameters

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/IdempotenceManager.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/IdempotenceManager.java
@@ -277,11 +277,11 @@ public class IdempotenceManager {
         return false;
     }
 
-    void maybeWaitForWriterId() {
+    void maybeWaitForWriterId(InitWriterRequest initWriterRequest) {
         if (!isWriterIdValid()) {
             try {
                 tabletServerGateway
-                        .initWriter(new InitWriterRequest())
+                        .initWriter(initWriterRequest)
                         .thenAccept(response -> setWriterId(response.getWriterId()))
                         .exceptionally(
                                 e -> {

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/IdempotenceManager.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/IdempotenceManager.java
@@ -22,6 +22,7 @@ import com.alibaba.fluss.exception.OutOfOrderSequenceException;
 import com.alibaba.fluss.exception.UnknownWriterIdException;
 import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.record.LogRecordBatch;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
 import com.alibaba.fluss.rpc.messages.InitWriterRequest;
@@ -34,6 +35,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static com.alibaba.fluss.record.LogRecordBatch.NO_WRITER_ID;
 
@@ -299,9 +301,13 @@ public class IdempotenceManager {
         }
     }
 
-    InitWriterRequest prepareInitWriterRequest(Set<PhysicalTablePath> tablePaths) {
+    InitWriterRequest prepareInitWriterRequest(Set<PhysicalTablePath> physicalTables) {
         InitWriterRequest initWriterRequest = new InitWriterRequest();
-        for (PhysicalTablePath tablePath : tablePaths) {
+        Set<TablePath> tables =
+                physicalTables.stream()
+                        .map(PhysicalTablePath::getTablePath)
+                        .collect(Collectors.toSet());
+        for (TablePath tablePath : tables) {
             initWriterRequest
                     .addTablePath()
                     .setDatabaseName(tablePath.getDatabaseName())

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/RecordAccumulator.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/RecordAccumulator.java
@@ -360,6 +360,10 @@ public final class RecordAccumulator {
         return bucketAndWriteBatches.batches.get(tableBucket.getBucket());
     }
 
+    public Set<PhysicalTablePath> getPhysicalTablePathsInBatches() {
+        return writeBatches.keySet();
+    }
+
     private List<MemorySegment> allocateMemorySegments(WriteRecord writeRecord) throws IOException {
         if (writeRecord.getWriteFormat() == WriteFormat.ARROW_LOG) {
             // pre-allocate a batch memory size for Arrow, if it is not sufficient during batching,

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
@@ -30,7 +30,6 @@ import com.alibaba.fluss.metadata.PhysicalTablePath;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableInfo;
 import com.alibaba.fluss.rpc.gateway.TabletServerGateway;
-import com.alibaba.fluss.rpc.messages.InitWriterRequest;
 import com.alibaba.fluss.rpc.messages.PbProduceLogRespForBucket;
 import com.alibaba.fluss.rpc.messages.PbPutKvRespForBucket;
 import com.alibaba.fluss.rpc.messages.ProduceLogRequest;
@@ -173,23 +172,13 @@ public class Sender implements Runnable {
     public void runOnce() throws Exception {
         if (idempotenceManager.idempotenceEnabled()) {
             // may be wait for writer id.
-            idempotenceManager.maybeWaitForWriterId(prepareInitWriterRequest());
+            Set<PhysicalTablePath> physicalTablePaths =
+                    accumulator.getPhysicalTablePathsInBatches();
+            idempotenceManager.maybeWaitForWriterId(physicalTablePaths);
         }
 
         // do send.
         sendWriteData();
-    }
-
-    InitWriterRequest prepareInitWriterRequest() {
-        Set<PhysicalTablePath> physicalTablePaths = accumulator.getPhysicalTablePathsInBatches();
-        InitWriterRequest initWriterRequest = new InitWriterRequest();
-        for (PhysicalTablePath tablePath : physicalTablePaths) {
-            initWriterRequest
-                    .addTablePath()
-                    .setDatabaseName(tablePath.getDatabaseName())
-                    .setTableName(tablePath.getTableName());
-        }
-        return initWriterRequest;
     }
 
     public boolean isRunning() {

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
@@ -173,10 +173,8 @@ public class Sender implements Runnable {
         if (idempotenceManager.idempotenceEnabled()) {
             // may be wait for writer id.
             Set<PhysicalTablePath> targetTables = accumulator.getPhysicalTablePathsInBatches();
-            if (!targetTables.isEmpty()) {
-                // only request to init writer_id when we have valid target tables
-                idempotenceManager.maybeWaitForWriterId(targetTables);
-            }
+            // TODO: only request to init writer_id when we have valid target tables
+            idempotenceManager.maybeWaitForWriterId(targetTables);
         }
 
         // do send.

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/Sender.java
@@ -172,9 +172,11 @@ public class Sender implements Runnable {
     public void runOnce() throws Exception {
         if (idempotenceManager.idempotenceEnabled()) {
             // may be wait for writer id.
-            Set<PhysicalTablePath> physicalTablePaths =
-                    accumulator.getPhysicalTablePathsInBatches();
-            idempotenceManager.maybeWaitForWriterId(physicalTablePaths);
+            Set<PhysicalTablePath> targetTables = accumulator.getPhysicalTablePathsInBatches();
+            if (!targetTables.isEmpty()) {
+                // only request to init writer_id when we have valid target tables
+                idempotenceManager.maybeWaitForWriterId(targetTables);
+            }
         }
 
         // do send.

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -450,6 +450,9 @@ public class FlussAuthorizationITCase {
         TablePath writeAclTable = TablePath.of("test_db_1", "write_acl_table");
         TablePath noWriteAclTable = TablePath.of("test_db_1", "no_write_acl_table");
 
+        TableDescriptor descriptor =
+                TableDescriptor.builder().schema(DATA1_SCHEMA).distributedBy(1).build();
+        rootAdmin.createTable(writeAclTable, descriptor, false).get();
         // create acl to allow guest write.
         rootAdmin
                 .createAcls(
@@ -463,6 +466,9 @@ public class FlussAuthorizationITCase {
                                                 PermissionType.ALLOW))))
                 .all()
                 .get();
+
+        FLUSS_CLUSTER_EXTENSION.waitUtilTableReady(
+                rootAdmin.getTableInfo(writeAclTable).get().getTableId());
 
         FlussConnection flussConnection = (FlussConnection) guestConn;
         TabletServerGateway tabletServerGateway =

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -367,6 +367,7 @@ message GetFileSystemSecurityTokenResponse {
 
 // init writer request and response
 message InitWriterRequest {
+  repeated PbTablePath table_path = 1;
 }
 
 message InitWriterResponse {


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #756 

<!-- What is the purpose of the change -->

### Brief change log

1. put `tablePath` parameters in `InitWriterRequest` when init writer id.
2. authorize the table paths in tabletServer

### Tests

The `client.writer.enable-idempotence` is defaultly true. Thus the current test cases in `FlinkAuthorizationITCase` will cover this authorization. 

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
