### PR TITLE
Add HeartBeat RPC in Servers for Tiering Services

### DIFF
--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/CoordinatorGateway.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/gateway/CoordinatorGateway.java
@@ -25,6 +25,8 @@ import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestRequest;
 import com.alibaba.fluss.rpc.messages.CommitRemoteLogManifestResponse;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatRequest;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatResponse;
 import com.alibaba.fluss.rpc.protocol.ApiKeys;
 import com.alibaba.fluss.rpc.protocol.RPC;
 
@@ -70,4 +72,9 @@ public interface CoordinatorGateway extends RpcGateway, AdminGateway {
     @RPC(api = ApiKeys.COMMIT_LAKE_TABLE_SNAPSHOT)
     CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request);
+
+    /** Report lake tiering heartbeats to Fluss for lake tiering service. */
+    @RPC(api = ApiKeys.LAKE_TIERING_HEARTBEAT)
+    CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
+            LakeTieringHeartbeatRequest request);
 }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/ApiKeys.java
@@ -68,7 +68,8 @@ public enum ApiKeys {
     AUTHENTICATE(1038, 0, 0, PUBLIC),
     CREATE_ACLS(1039, 0, 0, PUBLIC),
     LIST_ACLS(1040, 0, 0, PUBLIC),
-    DROP_ACLS(1041, 0, 0, PUBLIC);
+    DROP_ACLS(1041, 0, 0, PUBLIC),
+    LAKE_TIERING_HEARTBEAT(1042, 0, 0, PRIVATE);
 
     private static final Map<Integer, ApiKeys> ID_TO_TYPE =
             Arrays.stream(ApiKeys.values())

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -506,6 +506,25 @@ message DropAclsResponse{
   repeated PbDropAclsFilterResult filter_results = 1;
 }
 
+message LakeTieringHeartbeatRequest {
+  repeated PbHeartbeatReqForTable tiering_tables = 2;
+  repeated PbHeartbeatReqForTable finished_tables = 3;
+  repeated PbHeartbeatReqForTable failed_tables = 4;
+  // whether to request a table
+  optional bool request_table = 5;
+}
+
+message LakeTieringHeartbeatResponse {
+  // coordinator epoch
+  required int32 coordinator_epoch = 1;
+  // the returned table to tier, empty when no table is needed by the lake tiering service
+  optional PbLakeTieringTableInfo tiering_table = 2;
+  repeated PbHeartbeatRespForTable tiering_table_resp = 3;
+  repeated PbHeartbeatRespForTable finished_table_resp = 4;
+  repeated PbHeartbeatRespForTable failed_table_resp = 5;
+}
+
+
 // --------------- Inner classes ----------------
 message PbApiVersion {
   required int32 api_key = 1;
@@ -815,4 +834,23 @@ message PbDropAclsMatchingAcl {
   required PbAclInfo acl = 1;
   optional int32 error_code = 2;
   optional string error_message = 3;
+}
+
+message PbLakeTieringTableInfo {
+  required int64 table_id = 1;
+  required PbTablePath table_path = 2;
+  required int64 tiering_epoch = 3;
+}
+
+message PbHeartbeatReqForTable {
+  required int64 table_id = 1;
+  // the coordinator epoch when the table is assigned to be tiering service
+  required int32 coordinator_epoch = 2;
+  // the tiering epoch when the table is assigned to be tiering service
+  required int32 tiering_epoch = 3;
+}
+
+message PbHeartbeatRespForTable {
+  required int64 table_id = 1;
+  optional ErrorResponse error = 2;
 }

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -507,11 +507,11 @@ message DropAclsResponse{
 }
 
 message LakeTieringHeartbeatRequest {
-  repeated PbHeartbeatReqForTable tiering_tables = 2;
-  repeated PbHeartbeatReqForTable finished_tables = 3;
-  repeated PbHeartbeatReqForTable failed_tables = 4;
+  repeated PbHeartbeatReqForTable tiering_tables = 1;
+  repeated PbHeartbeatReqForTable finished_tables = 2;
+  repeated PbHeartbeatReqForTable failed_tables = 3;
   // whether to request a table
-  optional bool request_table = 5;
+  optional bool request_table = 4;
 }
 
 message LakeTieringHeartbeatResponse {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -297,6 +297,10 @@ public class CoordinatorEventProcessor implements EventProcessor {
         }
     }
 
+    public int getCoordinatorEpoch() {
+        return coordinatorContext.getCoordinatorEpoch();
+    }
+
     private void initCoordinatorContext() throws Exception {
         long start = System.currentTimeMillis();
         // get all tablet server's

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -35,7 +35,6 @@ import com.alibaba.fluss.rpc.netty.server.RequestsMetrics;
 import com.alibaba.fluss.server.ServerBase;
 import com.alibaba.fluss.server.authorizer.Authorizer;
 import com.alibaba.fluss.server.authorizer.AuthorizerLoader;
-import com.alibaba.fluss.server.coordinator.event.CoordinatorEventManager;
 import com.alibaba.fluss.server.metadata.ServerMetadataCache;
 import com.alibaba.fluss.server.metadata.ServerMetadataCacheImpl;
 import com.alibaba.fluss.server.metrics.ServerMetricUtils;
@@ -183,11 +182,12 @@ public class CoordinatorServer extends ServerBase {
                             conf,
                             remoteFileSystem,
                             zkClient,
-                            this::getCoordinatorEventManager,
+                            this::getCoordinatorEventProcessor,
                             metadataCache,
                             metadataManager,
                             authorizer,
-                            createLakeCatalog());
+                            createLakeCatalog(),
+                            lakeTableTieringManager);
 
             this.rpcServer =
                     RpcServer.create(
@@ -294,9 +294,9 @@ public class CoordinatorServer extends ServerBase {
         }
     }
 
-    private CoordinatorEventManager getCoordinatorEventManager() {
+    private CoordinatorEventProcessor getCoordinatorEventProcessor() {
         if (coordinatorEventProcessor != null) {
-            return coordinatorEventProcessor.getCoordinatorEventManager();
+            return coordinatorEventProcessor;
         } else {
             throw new IllegalStateException("CoordinatorEventProcessor is not initialized yet.");
         }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorService.java
@@ -19,6 +19,7 @@ package com.alibaba.fluss.server.coordinator;
 import com.alibaba.fluss.cluster.ServerType;
 import com.alibaba.fluss.config.ConfigOptions;
 import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.exception.InvalidCoordinatorException;
 import com.alibaba.fluss.exception.InvalidDatabaseException;
 import com.alibaba.fluss.exception.InvalidTableException;
 import com.alibaba.fluss.exception.SecurityDisabledException;
@@ -57,6 +58,11 @@ import com.alibaba.fluss.rpc.messages.DropPartitionRequest;
 import com.alibaba.fluss.rpc.messages.DropPartitionResponse;
 import com.alibaba.fluss.rpc.messages.DropTableRequest;
 import com.alibaba.fluss.rpc.messages.DropTableResponse;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatRequest;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatResponse;
+import com.alibaba.fluss.rpc.messages.PbHeartbeatReqForTable;
+import com.alibaba.fluss.rpc.messages.PbHeartbeatRespForTable;
+import com.alibaba.fluss.rpc.protocol.ApiError;
 import com.alibaba.fluss.security.acl.AclBinding;
 import com.alibaba.fluss.security.acl.AclBindingFilter;
 import com.alibaba.fluss.security.acl.OperationType;
@@ -71,6 +77,7 @@ import com.alibaba.fluss.server.coordinator.event.CommitLakeTableSnapshotEvent;
 import com.alibaba.fluss.server.coordinator.event.CommitRemoteLogManifestEvent;
 import com.alibaba.fluss.server.coordinator.event.EventManager;
 import com.alibaba.fluss.server.entity.CommitKvSnapshotData;
+import com.alibaba.fluss.server.entity.LakeTieringTableInfo;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshot;
 import com.alibaba.fluss.server.kv.snapshot.CompletedSnapshotJsonSerde;
 import com.alibaba.fluss.server.metadata.ServerMetadataCache;
@@ -93,6 +100,7 @@ import java.util.function.Supplier;
 
 import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBindingFilters;
 import static com.alibaba.fluss.rpc.util.CommonRpcMessageUtils.toAclBindings;
+import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.fromTablePath;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getAdjustIsrData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getCommitLakeTableSnapshotData;
 import static com.alibaba.fluss.server.utils.ServerRpcMessageUtils.getCommitRemoteLogManifestData;
@@ -110,20 +118,23 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     private final int defaultBucketNumber;
     private final int defaultReplicationFactor;
     private final Supplier<EventManager> eventManagerSupplier;
+    private final Supplier<Integer> coordinatorEpochSupplier;
 
     // null if the cluster hasn't configured datalake format
     private final @Nullable DataLakeFormat dataLakeFormat;
     private final @Nullable LakeCatalog lakeCatalog;
+    private final LakeTableTieringManager lakeTableTieringManager;
 
     public CoordinatorService(
             Configuration conf,
             FileSystem remoteFileSystem,
             ZooKeeperClient zkClient,
-            Supplier<EventManager> eventManagerSupplier,
+            Supplier<CoordinatorEventProcessor> coordinatorEventProcessorSupplier,
             ServerMetadataCache metadataCache,
             MetadataManager metadataManager,
             @Nullable Authorizer authorizer,
-            @Nullable LakeCatalog lakeCatalog) {
+            @Nullable LakeCatalog lakeCatalog,
+            LakeTableTieringManager lakeTableTieringManager) {
         super(
                 remoteFileSystem,
                 ServerType.COORDINATOR,
@@ -133,9 +144,13 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
                 authorizer);
         this.defaultBucketNumber = conf.getInt(ConfigOptions.DEFAULT_BUCKET_NUMBER);
         this.defaultReplicationFactor = conf.getInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR);
-        this.eventManagerSupplier = eventManagerSupplier;
+        this.eventManagerSupplier =
+                () -> coordinatorEventProcessorSupplier.get().getCoordinatorEventManager();
+        this.coordinatorEpochSupplier =
+                () -> coordinatorEventProcessorSupplier.get().getCoordinatorEpoch();
         this.dataLakeFormat = conf.getOptional(ConfigOptions.DATALAKE_FORMAT).orElse(null);
         this.lakeCatalog = lakeCatalog;
+        this.lakeTableTieringManager = lakeTableTieringManager;
         checkState(
                 (dataLakeFormat == null) == (lakeCatalog == null),
                 "dataLakeFormat and lakeCatalog must both be null or both non-null, but dataLakeFormat is %s, lakeCatalog is %s.",
@@ -446,5 +461,75 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
                         new CommitLakeTableSnapshotEvent(
                                 getCommitLakeTableSnapshotData(request), response));
         return response;
+    }
+
+    @Override
+    public CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
+            LakeTieringHeartbeatRequest request) {
+        LakeTieringHeartbeatResponse heartbeatResponse = new LakeTieringHeartbeatResponse();
+        int currentCoordinatorEpoch = coordinatorEpochSupplier.get();
+        heartbeatResponse.setCoordinatorEpoch(currentCoordinatorEpoch);
+        // process tiering tables
+        for (PbHeartbeatReqForTable tieringTable : request.getTieringTablesList()) {
+            PbHeartbeatRespForTable pbHeartbeatRespForTable =
+                    heartbeatResponse.addTieringTableResp().setTableId(tieringTable.getTableId());
+            try {
+                validateHeartbeatRequest(tieringTable, currentCoordinatorEpoch);
+                lakeTableTieringManager.renewTieringHeartbeat(
+                        tieringTable.getTableId(), tieringTable.getTieringEpoch());
+            } catch (Throwable t) {
+                pbHeartbeatRespForTable.setError(ApiError.fromThrowable(t).toErrorResponse());
+            }
+        }
+
+        // process finished tables
+        for (PbHeartbeatReqForTable finishTable : request.getFinishedTablesList()) {
+            PbHeartbeatRespForTable pbHeartbeatRespForTable =
+                    heartbeatResponse.addFinishedTableResp().setTableId(finishTable.getTableId());
+            try {
+                validateHeartbeatRequest(finishTable, currentCoordinatorEpoch);
+                lakeTableTieringManager.finishTableTiering(
+                        finishTable.getTableId(), finishTable.getTieringEpoch());
+            } catch (Throwable e) {
+                pbHeartbeatRespForTable.setError(ApiError.fromThrowable(e).toErrorResponse());
+            }
+        }
+
+        // process failed tables
+        for (PbHeartbeatReqForTable failedTable : request.getFailedTablesList()) {
+            PbHeartbeatRespForTable pbHeartbeatRespForTable =
+                    heartbeatResponse.addFailedTableResp().setTableId(failedTable.getTableId());
+            try {
+                validateHeartbeatRequest(failedTable, currentCoordinatorEpoch);
+                lakeTableTieringManager.reportTieringFail(
+                        failedTable.getTableId(), failedTable.getTieringEpoch());
+            } catch (Throwable e) {
+                pbHeartbeatRespForTable.setError(ApiError.fromThrowable(e).toErrorResponse());
+            }
+        }
+
+        if (request.hasRequestTable() && request.isRequestTable()) {
+            LakeTieringTableInfo lakeTieringTableInfo = lakeTableTieringManager.requestTable();
+            if (lakeTieringTableInfo != null) {
+                heartbeatResponse
+                        .setTieringTable()
+                        .setTableId(lakeTieringTableInfo.tableId())
+                        .setTablePath(fromTablePath(lakeTieringTableInfo.tablePath()))
+                        .setTieringEpoch(lakeTieringTableInfo.tieringEpoch());
+            }
+        }
+        return CompletableFuture.completedFuture(heartbeatResponse);
+    }
+
+    private void validateHeartbeatRequest(
+            PbHeartbeatReqForTable heartbeatReqForTable, int currentEpoch) {
+        if (heartbeatReqForTable.getCoordinatorEpoch() != currentEpoch) {
+            throw new InvalidCoordinatorException(
+                    String.format(
+                            "The coordinator epoch %s in request is not match current coordinator epoch %d for table %d.",
+                            heartbeatReqForTable.getCoordinatorEpoch(),
+                            currentEpoch,
+                            heartbeatReqForTable.getTableId()));
+        }
     }
 }

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/utils/ServerRpcMessageUtils.java
@@ -57,6 +57,7 @@ import com.alibaba.fluss.rpc.messages.GetKvSnapshotMetadataResponse;
 import com.alibaba.fluss.rpc.messages.GetLatestKvSnapshotsResponse;
 import com.alibaba.fluss.rpc.messages.GetLatestLakeSnapshotResponse;
 import com.alibaba.fluss.rpc.messages.InitWriterResponse;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatResponse;
 import com.alibaba.fluss.rpc.messages.LimitScanResponse;
 import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListOffsetsRequest;
@@ -187,6 +188,12 @@ public class ServerRpcMessageUtils {
             pbPath.setPartitionName(physicalPath.getPartitionName());
         }
         return pbPath;
+    }
+
+    public static PbTablePath fromTablePath(TablePath tablePath) {
+        return new PbTablePath()
+                .setDatabaseName(tablePath.getDatabaseName())
+                .setTableName(tablePath.getTableName());
     }
 
     public static TableBucket toTableBucket(PbTableBucket protoTableBucket) {
@@ -1362,6 +1369,11 @@ public class ServerRpcMessageUtils {
                     new PbDropAclsFilterResult().addAllMatchingAcls(dropAclsMatchingAcls));
         }
         return new DropAclsResponse().addAllFilterResults(dropAclsFilterResults);
+    }
+
+    public static LakeTieringHeartbeatResponse makeLakeTieringHeartbeatResponse(
+            int coordinatorEpoch) {
+        return new LakeTieringHeartbeatResponse().setCoordinatorEpoch(coordinatorEpoch);
     }
 
     private static <T> Map<TableBucket, T> mergeResponse(

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/LakeTieringHeartbeatITCase.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/LakeTieringHeartbeatITCase.java
@@ -1,0 +1,331 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.server.coordinator;
+
+import com.alibaba.fluss.config.ConfigOptions;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.DataLakeFormat;
+import com.alibaba.fluss.metadata.Schema;
+import com.alibaba.fluss.metadata.TableDescriptor;
+import com.alibaba.fluss.metadata.TablePath;
+import com.alibaba.fluss.rpc.gateway.AdminGateway;
+import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
+import com.alibaba.fluss.rpc.messages.ErrorResponse;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatRequest;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatResponse;
+import com.alibaba.fluss.rpc.messages.PbHeartbeatRespForTable;
+import com.alibaba.fluss.rpc.messages.PbLakeTieringTableInfo;
+import com.alibaba.fluss.rpc.messages.PbTablePath;
+import com.alibaba.fluss.rpc.protocol.Errors;
+import com.alibaba.fluss.server.testutils.FlussClusterExtension;
+import com.alibaba.fluss.types.DataTypes;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.alibaba.fluss.server.coordinator.CoordinatorContext.INITIAL_COORDINATOR_EPOCH;
+import static com.alibaba.fluss.server.testutils.RpcMessageTestUtils.newCreateTableRequest;
+import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ITCase for {@link CoordinatorService#lakeTieringHeartbeat}. */
+class LakeTieringHeartbeatITCase {
+
+    @RegisterExtension
+    public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
+            FlussClusterExtension.builder()
+                    .setNumOfTabletServers(3)
+                    .setClusterConf(Configuration.fromMap(getDataLakeFormat()))
+                    .build();
+
+    private static CoordinatorGateway coordinatorGateway;
+
+    private static Map<String, String> getDataLakeFormat() {
+        Map<String, String> datalakeFormat = new HashMap<>();
+        datalakeFormat.put(ConfigOptions.DATALAKE_FORMAT.key(), DataLakeFormat.PAIMON.toString());
+        return datalakeFormat;
+    }
+
+    @BeforeAll
+    static void beforeAll() {
+        coordinatorGateway = FLUSS_CLUSTER_EXTENSION.newCoordinatorClient();
+    }
+
+    @Test
+    void testLakeTieringHeartBeat() throws Exception {
+        int tableCounts = 4;
+        // firstly, create 4 tables;
+        createLakeTables(tableCounts);
+
+        // verify coordinator epoch in response
+        LakeTieringHeartbeatResponse heartbeatResponse =
+                coordinatorGateway.lakeTieringHeartbeat(new LakeTieringHeartbeatRequest()).get();
+        assertThat(heartbeatResponse.getCoordinatorEpoch()).isEqualTo(INITIAL_COORDINATOR_EPOCH);
+
+        for (int i = 0; i < tableCounts; i++) {
+            verifyGetTableToTier(i);
+        }
+        // now, no table to tier
+        verifyNoAnyTableToTier();
+
+        // send heartbeat to mark some table has been finished, and some has been failed
+        LakeTieringHeartbeatRequest request =
+                makeTieringHeartbeatRequest(new long[] {0}, new long[] {1, 3}, new long[] {2});
+        coordinatorGateway.lakeTieringHeartbeat(request).get();
+
+        // then, request table via heartbeat, should get the tables has been finished and failed
+        Set<Long> expectedTieredTableIds = new HashSet<>(Arrays.asList(1L, 3L, 2L));
+        for (int i = 0; i < 3; i++) {
+            PbLakeTieringTableInfo pbLakeTieringTableInfo = waitGetLakeTieringTableInfo();
+            long tieredTableId = pbLakeTieringTableInfo.getTableId();
+            assertThat(expectedTieredTableIds.remove(tieredTableId)).isTrue();
+            // tiering epoch should be 2 then
+            verifyLakeTieringTableInfo(pbLakeTieringTableInfo, tieredTableId, 2);
+        }
+        // no table to tier
+        verifyNoAnyTableToTier();
+
+        // verify error response for the tables carried in heartbeat request,
+        // the tiering epoch for table 0,2,3 in request is 1, but actual is 2, should throw
+        // exception
+        request = makeTieringHeartbeatRequest(new long[] {0}, new long[] {1, 2}, new long[] {3});
+        LakeTieringHeartbeatResponse lakeTieringHeartbeatResponse =
+                coordinatorGateway.lakeTieringHeartbeat(request).get();
+        // error will only be in finish & failed response
+        List<PbHeartbeatRespForTable> tieringTableResps =
+                lakeTieringHeartbeatResponse.getTieringTableRespsList();
+        assertThat(tieringTableResps).hasSize(1);
+        assertThat(tieringTableResps.get(0).getTableId()).isEqualTo(0);
+        assertThat(tieringTableResps.get(0).hasError()).isFalse();
+
+        List<PbHeartbeatRespForTable> finishedTableResps =
+                lakeTieringHeartbeatResponse.getFinishedTableRespsList();
+        assertThat(finishedTableResps).hasSize(2);
+        for (PbHeartbeatRespForTable heartbeatRespForTable : finishedTableResps) {
+            verifyFencedTieringEpochException(
+                    heartbeatRespForTable, 1, 2, heartbeatRespForTable.getTableId());
+        }
+
+        List<PbHeartbeatRespForTable> failedTableResps =
+                lakeTieringHeartbeatResponse.getFailedTableRespsList();
+        verifyFencedTieringEpochException(failedTableResps.get(0), 1, 2, 3);
+
+        // now, let's finish some table and get the table again
+        request =
+                makeTieringHeartbeatRequest(
+                        new long[0],
+                        new long[] {1, 2, 3},
+                        new long[0],
+                        INITIAL_COORDINATOR_EPOCH,
+                        2);
+        coordinatorGateway.lakeTieringHeartbeat(request).get();
+
+        expectedTieredTableIds = new HashSet<>(Arrays.asList(1L, 2L, 3L));
+        // request table
+        for (int i = 0; i < 3; i++) {
+            PbLakeTieringTableInfo pbLakeTieringTableInfo = waitGetLakeTieringTableInfo();
+            long tieredTableId = pbLakeTieringTableInfo.getTableId();
+            assertThat(expectedTieredTableIds.remove(tieredTableId)).isTrue();
+            // tiering epoch should be 3 then
+            verifyLakeTieringTableInfo(pbLakeTieringTableInfo, tieredTableId, 3);
+        }
+
+        // verify error response for the tiering tables carried in heartbeat request
+        // when tiering epoch is not match current tiering epoch
+        request =
+                makeTieringHeartbeatRequest(
+                        new long[] {1, 2, 3},
+                        new long[0],
+                        new long[0],
+                        INITIAL_COORDINATOR_EPOCH,
+                        2);
+        lakeTieringHeartbeatResponse = coordinatorGateway.lakeTieringHeartbeat(request).get();
+        tieringTableResps = lakeTieringHeartbeatResponse.getTieringTableRespsList();
+        assertThat(tieringTableResps).hasSize(3);
+        for (PbHeartbeatRespForTable pbHeartbeatRespForTable : tieringTableResps) {
+            verifyFencedTieringEpochException(
+                    pbHeartbeatRespForTable, 2, 3, pbHeartbeatRespForTable.getTableId());
+        }
+
+        // verify error response for the tables carried in heartbeat request
+        // when coordinator epoch is not match current coordinator epoch
+        int invalidEpoch = INITIAL_COORDINATOR_EPOCH + 1;
+        request =
+                makeTieringHeartbeatRequest(
+                        new long[] {1}, new long[] {2}, new long[] {3}, invalidEpoch, 2);
+        lakeTieringHeartbeatResponse = coordinatorGateway.lakeTieringHeartbeat(request).get();
+        // collect all resp
+        List<PbHeartbeatRespForTable> pbHeartbeatRespForTables =
+                new ArrayList<>(lakeTieringHeartbeatResponse.getTieringTableRespsList());
+        pbHeartbeatRespForTables.addAll(lakeTieringHeartbeatResponse.getFinishedTableRespsList());
+        pbHeartbeatRespForTables.addAll(lakeTieringHeartbeatResponse.getFailedTableRespsList());
+        for (PbHeartbeatRespForTable pbHeartbeatRespForTable : pbHeartbeatRespForTables) {
+            verifyError(
+                    pbHeartbeatRespForTable.getError(),
+                    Errors.INVALID_COORDINATOR_EXCEPTION.code(),
+                    String.format(
+                            "The coordinator epoch %s in request is not match current coordinator epoch %d for table %d.",
+                            invalidEpoch,
+                            INITIAL_COORDINATOR_EPOCH,
+                            pbHeartbeatRespForTable.getTableId()));
+        }
+    }
+
+    private void verifyNoAnyTableToTier() throws Exception {
+        assertThat(
+                        coordinatorGateway
+                                .lakeTieringHeartbeat(makeRequestTableTieringHeartbeat())
+                                .get()
+                                .hasTieringTable())
+                .isFalse();
+    }
+
+    private LakeTieringHeartbeatRequest makeRequestTableTieringHeartbeat() {
+        LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
+        heartbeatRequest.setRequestTable(true);
+        return heartbeatRequest;
+    }
+
+    private void verifyGetTableToTier(long expectTableId) {
+        PbLakeTieringTableInfo pbLakeTieringTableInfo = waitGetLakeTieringTableInfo();
+        verifyLakeTieringTableInfo(pbLakeTieringTableInfo, expectTableId);
+    }
+
+    private void verifyFencedTieringEpochException(
+            PbHeartbeatRespForTable pbHeartbeatRespForTable,
+            int tieringEpochInRequest,
+            int tieringEpochInCoordinator,
+            long tableId) {
+        verifyError(
+                pbHeartbeatRespForTable.getError(),
+                Errors.FENCED_TIERING_EPOCH_EXCEPTION.code(),
+                String.format(
+                        "The tiering epoch %d is not match current epoch %d in coordinator for table %d.",
+                        tieringEpochInRequest, tieringEpochInCoordinator, tableId));
+    }
+
+    private PbLakeTieringTableInfo waitGetLakeTieringTableInfo() {
+        return waitValue(
+                () -> {
+                    LakeTieringHeartbeatResponse response =
+                            coordinatorGateway
+                                    .lakeTieringHeartbeat(makeRequestTableTieringHeartbeat())
+                                    .get();
+                    if (response.hasTieringTable()) {
+                        return Optional.of(response.getTieringTable());
+                    } else {
+                        return Optional.empty();
+                    }
+                },
+                Duration.ofMinutes(1),
+                "Fail to wait to get table info to be tiered.");
+    }
+
+    private void verifyError(
+            ErrorResponse errorResponse, int errorCode, String expectedErrorMessage) {
+        assertThat(errorResponse.getErrorCode()).isEqualTo(errorCode);
+        assertThat(errorResponse.getErrorMessage()).isEqualTo(expectedErrorMessage);
+    }
+
+    private LakeTieringHeartbeatRequest makeTieringHeartbeatRequest(
+            long[] tieringTables, long[] finishTieringTables, long[] failedTieringTables) {
+        return makeTieringHeartbeatRequest(
+                tieringTables,
+                finishTieringTables,
+                failedTieringTables,
+                INITIAL_COORDINATOR_EPOCH,
+                1);
+    }
+
+    private LakeTieringHeartbeatRequest makeTieringHeartbeatRequest(
+            long[] tieringTables,
+            long[] finishTieringTables,
+            long[] failedTieringTables,
+            int coordinatorEpoch,
+            int tieringEpoch) {
+        LakeTieringHeartbeatRequest heartbeatRequest = new LakeTieringHeartbeatRequest();
+        for (long tableId : tieringTables) {
+            heartbeatRequest
+                    .addTieringTable()
+                    .setCoordinatorEpoch(coordinatorEpoch)
+                    .setTieringEpoch(tieringEpoch)
+                    .setTableId(tableId);
+        }
+
+        for (long tableId : finishTieringTables) {
+            heartbeatRequest
+                    .addFinishedTable()
+                    .setTieringEpoch(tieringEpoch)
+                    .setCoordinatorEpoch(coordinatorEpoch)
+                    .setTableId(tableId);
+        }
+
+        for (long tableId : failedTieringTables) {
+            heartbeatRequest
+                    .addFailedTable()
+                    .setCoordinatorEpoch(coordinatorEpoch)
+                    .setTieringEpoch(tieringEpoch)
+                    .setTableId(tableId);
+        }
+        return heartbeatRequest;
+    }
+
+    private void verifyLakeTieringTableInfo(
+            PbLakeTieringTableInfo pbLakeTieringTableInfo, long expectTableId) {
+        verifyLakeTieringTableInfo(pbLakeTieringTableInfo, expectTableId, 1);
+    }
+
+    private void verifyLakeTieringTableInfo(
+            PbLakeTieringTableInfo pbLakeTieringTableInfo,
+            long expectTableId,
+            long expectTieringEpoch) {
+        assertThat(pbLakeTieringTableInfo.getTableId()).isEqualTo(expectTableId);
+        assertThat(pbLakeTieringTableInfo.getTieringEpoch()).isEqualTo(expectTieringEpoch);
+        PbTablePath pbTablePath = pbLakeTieringTableInfo.getTablePath();
+        assertThat(pbTablePath.getDatabaseName()).isEqualTo("fluss");
+        assertThat(pbTablePath.getTableName()).isEqualTo("test_lake_table_" + expectTableId);
+    }
+
+    private void createLakeTables(int tableCount) throws Exception {
+        AdminGateway adminGateway = FLUSS_CLUSTER_EXTENSION.newCoordinatorClient();
+        for (int i = 0; i < tableCount; i++) {
+            TableDescriptor tableDescriptor =
+                    TableDescriptor.builder()
+                            .schema(Schema.newBuilder().column("f1", DataTypes.INT()).build())
+                            .property("table.datalake.enabled", "true")
+                            .property(
+                                    ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(100))
+                            .build();
+            TablePath tablePath = TablePath.of("fluss", "test_lake_table_" + i);
+            // create the table
+            adminGateway
+                    .createTable(newCreateTableRequest(tablePath, tableDescriptor, false))
+                    .get();
+        }
+    }
+}

--- a/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
+++ b/fluss-server/src/test/java/com/alibaba/fluss/server/coordinator/TestCoordinatorGateway.java
@@ -61,6 +61,8 @@ import com.alibaba.fluss.rpc.messages.GetTableInfoRequest;
 import com.alibaba.fluss.rpc.messages.GetTableInfoResponse;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaRequest;
 import com.alibaba.fluss.rpc.messages.GetTableSchemaResponse;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatRequest;
+import com.alibaba.fluss.rpc.messages.LakeTieringHeartbeatResponse;
 import com.alibaba.fluss.rpc.messages.ListAclsRequest;
 import com.alibaba.fluss.rpc.messages.ListAclsResponse;
 import com.alibaba.fluss.rpc.messages.ListDatabasesRequest;
@@ -291,6 +293,12 @@ public class TestCoordinatorGateway implements CoordinatorGateway {
     @Override
     public CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
+            LakeTieringHeartbeatRequest request) {
         throw new UnsupportedOperationException();
     }
 


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #432 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Introduce RPC request for laketiering heartbeat request:
LakeTieringHeartbeatRequest:
```
message LakeTieringHeartbeatRequest {
  repeated PbHeartbeatReqForTable tiering_tables = 2;
  repeated PbHeartbeatReqForTable finished_tables = 3;
  repeated PbHeartbeatReqForTable failed_tables = 4;
  // whether to request a table
  optional bool request_table = 5;
}
message PbHeartbeatReqForTable {
  // the coordinator epoch when the table has been assigned to be tiering service
  required int64 table_id = 1;
  required int32 coordinator_epoch = 2;
  required int32 tiering_epoch = 3;
}
```

LakeTieringHeartbeatResponse:
```
message PbHeartbeatReqForTable {
  required int64 table_id = 1;
  // the coordinator epoch when the table is assigned to be tiering service
  required int32 coordinator_epoch = 2;
  // the tiering epoch when the table is assigned to be tiering service
  required int32 tiering_epoch = 3;
}

message PbHeartbeatRespForTable {
  required int64 table_id = 1;
  optional ErrorResponse error = 2;
}
```

The `LakeTieringHeartbeatRequest` contain a field `request_table` to tell coordinator server to assign a table to tier. It's designed to only request a table in one round of heartbeat. I'm not sure whether it's needed to request many tables in one round of heartbeat. So, keep it simiple currently. 


Then, the  lake tiering service can carry the tables are tiering, finished table,  failed_tables in the `request` to let coordinator server know the status of tiering.  
The `PbHeartbeatReqForTable` for each table(tiering, finished, failed) in request contains three fields:

- table_id: the table id for the table
- coordinator_epoch: the coordinator epoch when the table is assigned to be tiering service
When the `coordinator_epoch` in the request  is less than the `coordinator_epoch` of the coordinator, it means coordinator move happens but table is assigned by the stale coordinator. It'll throw `InvalidCoordinatorException` to refuse such request to avoid inconsistent.

When the `coordinator_epoch` in the request  is greater than the `coordinator_epoch` of the coordinator, it means it sends to a stale coordinator server, also throw `InvalidCoordinatorException` to refuse such request to avoid inconsistent. 

Note it may still happen that the tiering service send to the stale coordinator, like mark the table as finished and request the table again, but other tiering serevice are still tiering the table which is assgined by the active coordinator , which causes the inconsistent. But it should happen rarely.


- tiering_epoch: the tiering epoch when the table is assigned to be tiering service

When the `tiering_epoch` in request is not match the `tiering_epoch` in coordinator, it means the table has been assigned to other tiering service, throw `FencedTieringEpochException`


For each  `PbHeartbeatReqForTable` of each table in the request, there's one  `PbHeartbeatRespForTable`    for that.

If there is any exception(like `FencedTieringEpochException`) happen when mark tables as `tiering`, `finished`, `failed`, the cooresponding `PbHeartbeatRespForTable` will contains errors. 
The lake tiering service should check and act to the errors:
- If mark table as `tiering`:  if `FencedTieringEpochException`, `InvalidCoordinatorException`, abort the tiering directly since it means other tiering service may be tiering this table. Otherwise, retry to make as `tiering` in next heartbeats.
- if mark table as `finished`: if `FencedTieringEpochException`, `InvalidCoordinatorException`, remove from the finished table from lake tiering service, don't retry to mark  as `finished` in next heartbeats. Otherwise, retry to make as `tiering` in next heartbeats. 
- if mark table as `failed`: it should same as `finished`.

### Tests

<!-- List UT and IT cases to verify this change -->
`LakeTieringHeartBeatITCase`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
