### PR TITLE
[Connector] Resource cleanup via AfterEach Extending AbstractStreamBase

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -52,7 +52,7 @@ import static com.alibaba.fluss.config.ConfigOptions.DEFAULT_LISTENER_NAME;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BUCKET_KEY;
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BUCKET_NUMBER;
-import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.assertResultsIgnoreOrder;
+import static com.alibaba.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMetricsITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -98,6 +99,10 @@ abstract class FlinkMetricsITCase extends FlinkTestBase {
     void afterEach() {
         tEnv.useDatabase(BUILTIN_DATABASE);
         tEnv.executeSql(String.format("drop database %s cascade", DEFAULT_DB));
+    }
+
+    @AfterAll
+    public static void afterAll() {
         MINI_CLUSTER_EXTENSION.after();
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/metrics/FlinkMetricsITCase.java
@@ -39,7 +39,6 @@ import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.TableResult;
 import org.apache.flink.test.util.MiniClusterWithClientResource;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -99,10 +98,6 @@ abstract class FlinkMetricsITCase extends FlinkTestBase {
     void afterEach() {
         tEnv.useDatabase(BUILTIN_DATABASE);
         tEnv.executeSql(String.format("drop database %s cascade", DEFAULT_DB));
-    }
-
-    @AfterAll
-    public static void afterAll() {
         MINI_CLUSTER_EXTENSION.after();
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/security/acl/FlinkAuthorizationITCase.java
@@ -41,6 +41,7 @@ import org.apache.commons.lang3.RandomUtils;
 import org.apache.flink.table.api.EnvironmentSettings;
 import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.config.TableConfigOptions;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.util.CollectionUtil;
 import org.junit.jupiter.api.AfterAll;
@@ -69,7 +70,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** IT case for flink authorization. */
-abstract class FlinkAuthorizationITCase {
+abstract class FlinkAuthorizationITCase extends AbstractTestBase {
 
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -65,7 +65,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
-import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.assertResultsIgnoreOrder;
+import static com.alibaba.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
 import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.waitUntilPartitions;
 import static com.alibaba.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -72,7 +72,7 @@ import static com.alibaba.fluss.server.testutils.FlussClusterExtension.BUILTIN_D
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-/** Test for {@link FlinkTableSink}. */
+/** Test for {@link FlinkTableSink} inherit AbstractTestBase for resource cleanup. */
 abstract class FlinkTableSinkITCase extends AbstractTestBase {
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -39,6 +39,7 @@ import org.apache.flink.table.api.TableEnvironment;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.api.bridge.java.StreamTableEnvironment;
 import org.apache.flink.table.api.config.ExecutionConfigOptions;
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.util.CloseableIterator;
@@ -72,7 +73,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /** Test for {@link FlinkTableSink}. */
-abstract class FlinkTableSinkITCase {
+abstract class FlinkTableSinkITCase extends AbstractTestBase {
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =
             FlussClusterExtension.builder().setNumOfTabletServers(3).build();

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -45,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
+import static com.alibaba.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
 import static com.alibaba.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
 import static com.alibaba.fluss.testutils.DataTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceFailOverITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceFailOverITCase.java
@@ -54,7 +54,7 @@ import java.util.Collections;
 import java.util.List;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
-import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.assertResultsIgnoreOrder;
+import static com.alibaba.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
 import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.createPartitions;
 import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.dropPartitions;
 import static com.alibaba.fluss.flink.source.testutils.FlinkTestBase.waitUntilPartitions;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -80,10 +80,6 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
     @BeforeAll
     protected static void beforeAll() {
         FlinkTestBase.beforeAll();
-    }
-
-    @BeforeEach
-    void before() {
         // create database
         execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         // create table environment
@@ -97,6 +93,10 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
         tEnv.executeSql("use catalog " + CATALOG_NAME);
 
         tEnv.getConfig().set(ExecutionConfigOptions.TABLE_EXEC_RESOURCE_DEFAULT_PARALLELISM, 4);
+    }
+
+    @BeforeEach
+    void before() {
         tEnv.executeSql("create database " + DEFAULT_DB);
         tEnv.useDatabase(DEFAULT_DB);
     }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -63,6 +63,7 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
+import static com.alibaba.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertResultsIgnoreOrder;
 import static com.alibaba.fluss.server.testutils.FlussClusterExtension.BUILTIN_DATABASE;
 import static com.alibaba.fluss.testutils.DataTestUtils.row;
 import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitUtil;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -80,8 +80,8 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
     @BeforeAll
     protected static void beforeAll() {
+        // create fluss connection
         FlinkTestBase.beforeAll();
-        // create database
         execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
         // create table environment
         tEnv = StreamTableEnvironment.create(execEnv, EnvironmentSettings.inStreamingMode());
@@ -910,8 +910,6 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
                         "SELECT a, b, h.address FROM src JOIN %s FOR SYSTEM_TIME AS OF src.proc as h"
                                 + " ON src.b = h.name AND h.address = 'address5'",
                         dim);
-
-        waitUtilAllBucketFinishSnapshot(admin, TablePath.of(DEFAULT_DB, dim));
         CloseableIterator<Row> collected = tEnv.executeSql(dimJoinQuery).collect();
         List<String> expected = Collections.singletonList("+I[1, name1, address5]");
         assertResultsIgnoreOrder(collected, expected, true);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/metrics/FlinkSourceReaderMetricsTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/metrics/FlinkSourceReaderMetricsTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.flink.source.metrics;
 
+import com.alibaba.fluss.flink.source.testutils.FlinkTestBase;
 import com.alibaba.fluss.metadata.TableBucket;
 
 import org.apache.flink.metrics.Gauge;
@@ -32,7 +33,7 @@ import static com.alibaba.fluss.flink.source.metrics.FlinkSourceReaderMetrics.RE
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link com.alibaba.fluss.flink.source.metrics.FlinkSourceReaderMetrics}. */
-class FlinkSourceReaderMetricsTest {
+class FlinkSourceReaderMetricsTest extends FlinkTestBase {
 
     @Test
     void testCurrentOffsetTracking() {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/metrics/FlinkSourceReaderMetricsTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/metrics/FlinkSourceReaderMetricsTest.java
@@ -16,7 +16,6 @@
 
 package com.alibaba.fluss.flink.source.metrics;
 
-import com.alibaba.fluss.flink.source.testutils.FlinkTestBase;
 import com.alibaba.fluss.metadata.TableBucket;
 
 import org.apache.flink.metrics.Gauge;
@@ -33,7 +32,7 @@ import static com.alibaba.fluss.flink.source.metrics.FlinkSourceReaderMetrics.RE
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** Unit test for {@link com.alibaba.fluss.flink.source.metrics.FlinkSourceReaderMetrics}. */
-class FlinkSourceReaderMetricsTest extends FlinkTestBase {
+class FlinkSourceReaderMetricsTest {
 
     @Test
     void testCurrentOffsetTracking() {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.source.testutils;
+
+import org.apache.flink.types.Row;
+import org.apache.flink.util.CloseableIterator;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Utility class providing assertion methods for Flink test results. */
+public class FlinkRowAssertionsUtils {
+
+    private FlinkRowAssertionsUtils() {}
+
+    public static void assertResultsIgnoreOrder(
+            CloseableIterator<Row> iterator, List<String> expected, boolean closeIterator) {
+        try {
+            int expectRecords = expected.size();
+            List<String> actual = new ArrayList<>(expectRecords);
+            for (int i = 0; i < expectRecords; i++) {
+                actual.add(iterator.next().toString());
+            }
+            assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        } finally {
+            if (closeIterator) {
+                try {
+                    iterator.close();
+                } catch (Exception e) {
+                    System.err.println("Error closing iterator: " + e.getMessage());
+                }
+            }
+        }
+    }
+
+    // Add other shared utility methods here
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -41,6 +41,7 @@ import com.alibaba.fluss.server.zk.data.PartitionAssignment;
 import com.alibaba.fluss.server.zk.data.TableAssignment;
 import com.alibaba.fluss.types.DataTypes;
 
+import org.apache.flink.test.util.AbstractTestBase;
 import org.apache.flink.types.Row;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,7 +62,7 @@ import static com.alibaba.fluss.testutils.common.CommonTestUtils.waitValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /** A base class for testing with Fluss cluster prepared. */
-public class FlinkTestBase {
+public class FlinkTestBase extends AbstractTestBase {
 
     @RegisterExtension
     public static final FlussClusterExtension FLUSS_CLUSTER_EXTENSION =

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -170,14 +170,21 @@ public class FlinkTestBase {
             List<String> expected,
             boolean closeIterator)
             throws Exception {
-        int expectRecords = expected.size();
-        List<String> actual = new ArrayList<>(expectRecords);
-        for (int i = 0; i < expectRecords; i++) {
-            actual.add(iterator.next().toString());
-        }
-        assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
-        if (closeIterator) {
-            iterator.close();
+        try {
+            int expectRecords = expected.size();
+            List<String> actual = new ArrayList<>(expectRecords);
+            for (int i = 0; i < expectRecords; i++) {
+                actual.add(iterator.next().toString());
+            }
+            assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+        } finally {
+            if (closeIterator) {
+                try {
+                    iterator.close();
+                } catch (Exception e) {
+                    System.err.println("Error closing iterator: " + e.getMessage());
+                }
+            }
         }
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -166,29 +166,6 @@ public class FlinkTestBase extends AbstractTestBase {
         return admin.getTableInfo(tablePath).get().getTableId();
     }
 
-    public static void assertResultsIgnoreOrder(
-            org.apache.flink.util.CloseableIterator<Row> iterator,
-            List<String> expected,
-            boolean closeIterator)
-            throws Exception {
-        try {
-            int expectRecords = expected.size();
-            List<String> actual = new ArrayList<>(expectRecords);
-            for (int i = 0; i < expectRecords; i++) {
-                actual.add(iterator.next().toString());
-            }
-            assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
-        } finally {
-            if (closeIterator) {
-                try {
-                    iterator.close();
-                } catch (Exception e) {
-                    System.err.println("Error closing iterator: " + e.getMessage());
-                }
-            }
-        }
-    }
-
     public static List<String> assertAndCollectRecords(
             org.apache.flink.util.CloseableIterator<Row> iterator, int expectedNum)
             throws Exception {


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #868

<!-- What is the purpose of the change -->

To prevent Flink-core CI from failing randomly due to resource cleanup from one test iteration starting but not completing before another test iteration accesses the same resources, causing the test case to run indefinitely, eventually causing the CI pipeline to timeout.

### Brief change log

- Proper cleanup of resources after each test using `AbstractTestBase` MiniClusterExtension using cleanupRunningJobs
- Explicitly wait for bucket snapshots to complete before collecting results in `testPrefixLookupWithCondition`
- Created a separate utility class `FlinkRowAssertionsUtils` for assertion method, moved away from `FlinkTestBase` to avoid duplicate code, & Improved error handling and closure for the same.
- Removed extensibility of `FlinkTestBase` from `FlinkMetricsITCase`, manually configured Fluss & Flink cluster extension and changes related to it.

 

### Tests

Targeting PrefixLookup type tests

### API and Format

None

### Documentation

None
