### PR TITLE
[Website] Check only main branch for ci-badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/alibaba/fluss/actions/workflows/ci.yaml"><img src="https://github.com/alibaba/fluss/actions/workflows/ci.yaml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/alibaba/fluss/actions/workflows/ci.yaml"><img src="https://github.com/alibaba/fluss/actions/workflows/ci.yaml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/alibaba/fluss/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202-4EB1BA.svg" alt="License"></a>
   <a href="https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw"><img src="https://img.shields.io/badge/slack-join_chat-brightgreen.svg?logo=slack" alt="Slack"></a>
 </p>


### PR DESCRIPTION
### Purpose

Currently, the ci-badge is looking for CI status for all branches combined, causing any feature/experimental branch to fail, marking the entire CI badge as Fail

<!-- What is the purpose of the change -->

### Brief change log

Add & Set the branch parameter to the main branch for the CI badge.


### Tests

None

### API and Format

None

### Documentation

None
