### PR TITLE
[flink]Support partition pushdown(only equals) in Flink connector

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkSource.java
@@ -29,7 +29,7 @@ import com.alibaba.fluss.flink.source.split.SourceSplitBase;
 import com.alibaba.fluss.flink.source.split.SourceSplitSerializer;
 import com.alibaba.fluss.flink.source.state.FlussSourceEnumeratorStateSerializer;
 import com.alibaba.fluss.flink.source.state.SourceEnumeratorState;
-import com.alibaba.fluss.flink.utils.PushdownUtils;
+import com.alibaba.fluss.flink.utils.PushdownUtils.FieldEqual;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.RowType;
 
@@ -65,32 +65,7 @@ public class FlinkSource<OUT>
     private final boolean streaming;
     private final FlussDeserializationSchema<OUT> deserializationSchema;
 
-    @Nullable private final List<PushdownUtils.FieldEqual> partitionFilters;
-
-    public FlinkSource(
-            Configuration flussConf,
-            TablePath tablePath,
-            boolean hasPrimaryKey,
-            boolean isPartitioned,
-            RowType sourceOutputType,
-            @Nullable int[] projectedFields,
-            OffsetsInitializer offsetsInitializer,
-            long scanPartitionDiscoveryIntervalMs,
-            FlussDeserializationSchema<OUT> deserializationSchema,
-            boolean streaming) {
-        this(
-                flussConf,
-                tablePath,
-                hasPrimaryKey,
-                isPartitioned,
-                sourceOutputType,
-                projectedFields,
-                offsetsInitializer,
-                scanPartitionDiscoveryIntervalMs,
-                deserializationSchema,
-                streaming,
-                null);
-    }
+    @Nullable private final List<FieldEqual> partitionFilters;
 
     public FlinkSource(
             Configuration flussConf,
@@ -103,7 +78,7 @@ public class FlinkSource<OUT>
             long scanPartitionDiscoveryIntervalMs,
             FlussDeserializationSchema<OUT> deserializationSchema,
             boolean streaming,
-            @Nullable List<PushdownUtils.FieldEqual> partitionFilters) {
+            List<FieldEqual> partitionFilters) {
         this.flussConf = flussConf;
         this.tablePath = tablePath;
         this.hasPrimaryKey = hasPrimaryKey;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkSource.java
@@ -49,6 +49,8 @@ import javax.annotation.Nullable;
 
 import java.util.List;
 
+import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
+
 /** Flink source for Fluss. */
 public class FlinkSource<OUT>
         implements Source<OUT, SourceSplitBase, SourceEnumeratorState>, ResultTypeQueryable {
@@ -65,7 +67,7 @@ public class FlinkSource<OUT>
     private final boolean streaming;
     private final FlussDeserializationSchema<OUT> deserializationSchema;
 
-    @Nullable private final List<FieldEqual> partitionFilters;
+    private final List<FieldEqual> partitionFilters;
 
     public FlinkSource(
             Configuration flussConf,
@@ -89,7 +91,7 @@ public class FlinkSource<OUT>
         this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
         this.deserializationSchema = deserializationSchema;
         this.streaming = streaming;
-        this.partitionFilters = partitionFilters;
+        this.partitionFilters = checkNotNull(partitionFilters);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlinkTableSource.java
@@ -27,7 +27,6 @@ import com.alibaba.fluss.flink.utils.FlinkConnectorOptionsUtils;
 import com.alibaba.fluss.flink.utils.FlinkConversions;
 import com.alibaba.fluss.flink.utils.PushdownUtils;
 import com.alibaba.fluss.flink.utils.PushdownUtils.FieldEqual;
-import com.alibaba.fluss.flink.utils.PushdownUtils.ValueConversion;
 import com.alibaba.fluss.metadata.MergeEngineType;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.types.RowType;
@@ -76,6 +75,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+import static com.alibaba.fluss.flink.utils.PushdownUtils.ValueConversion.FLINK_INTERNAL_VALUE;
 import static com.alibaba.fluss.utils.Preconditions.checkNotNull;
 
 /** Flink table source to scan Fluss data. */
@@ -403,7 +403,7 @@ public class FlinkTableSource
                             primaryKeyTypes,
                             acceptedFilters,
                             remainingFilters,
-                            ValueConversion.FLINK_INTERNAL_VALUE);
+                            FLINK_INTERNAL_VALUE);
             int[] keyRowProjection = getKeyRowProjection();
             HashSet<Integer> visitedPkFields = new HashSet<>();
             GenericRowData lookupRow = new GenericRowData(primaryKeyIndexes.length);
@@ -425,7 +425,7 @@ public class FlinkTableSource
                             partitionKeyTypes,
                             acceptedFilters,
                             remainingFilters,
-                            ValueConversion.FLINK_INTERNAL_VALUE);
+                            FLINK_INTERNAL_VALUE);
             fieldEquals = serializeFieldEquals(fieldEquals);
 
             this.partitionFilters = fieldEquals;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/FlussSource.java
@@ -25,6 +25,8 @@ import com.alibaba.fluss.types.RowType;
 
 import javax.annotation.Nullable;
 
+import java.util.Collections;
+
 /**
  * A Flink DataStream source implementation for reading data from Fluss tables.
  *
@@ -67,6 +69,7 @@ public class FlussSource<OUT> extends FlinkSource<OUT> {
             long scanPartitionDiscoveryIntervalMs,
             FlussDeserializationSchema<OUT> deserializationSchema,
             boolean streaming) {
+        // TODO: Support partition pushDown in datastream
         super(
                 flussConf,
                 tablePath,
@@ -77,7 +80,8 @@ public class FlussSource<OUT> extends FlinkSource<OUT> {
                 offsetsInitializer,
                 scanPartitionDiscoveryIntervalMs,
                 deserializationSchema,
-                streaming);
+                streaming,
+                Collections.emptyList());
     }
 
     /**

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -34,6 +34,7 @@ import com.alibaba.fluss.flink.source.split.HybridSnapshotLogSplit;
 import com.alibaba.fluss.flink.source.split.LogSplit;
 import com.alibaba.fluss.flink.source.split.SourceSplitBase;
 import com.alibaba.fluss.flink.source.state.SourceEnumeratorState;
+import com.alibaba.fluss.flink.utils.PushdownUtils;
 import com.alibaba.fluss.metadata.PartitionInfo;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TableInfo;
@@ -125,6 +126,8 @@ public class FlinkSourceEnumerator
 
     private volatile boolean closed = false;
 
+    @Nullable private final List<PushdownUtils.FieldEqual> partitionFilters;
+
     public FlinkSourceEnumerator(
             TablePath tablePath,
             Configuration flussConf,
@@ -133,7 +136,8 @@ public class FlinkSourceEnumerator
             SplitEnumeratorContext<SourceSplitBase> context,
             OffsetsInitializer startingOffsetsInitializer,
             long scanPartitionDiscoveryIntervalMs,
-            boolean streaming) {
+            boolean streaming,
+            @Nullable List<PushdownUtils.FieldEqual> partitionFilters) {
         this(
                 tablePath,
                 flussConf,
@@ -144,7 +148,8 @@ public class FlinkSourceEnumerator
                 Collections.emptyMap(),
                 startingOffsetsInitializer,
                 scanPartitionDiscoveryIntervalMs,
-                streaming);
+                streaming,
+                partitionFilters);
     }
 
     public FlinkSourceEnumerator(
@@ -157,7 +162,8 @@ public class FlinkSourceEnumerator
             Map<Long, String> assignedPartitions,
             OffsetsInitializer startingOffsetsInitializer,
             long scanPartitionDiscoveryIntervalMs,
-            boolean streaming) {
+            boolean streaming,
+            @Nullable List<PushdownUtils.FieldEqual> partitionFilters) {
         this.tablePath = checkNotNull(tablePath);
         this.flussConf = checkNotNull(flussConf);
         this.hasPrimaryKey = hasPrimaryKey;
@@ -169,6 +175,7 @@ public class FlinkSourceEnumerator
         this.assignedPartitions = new HashMap<>(assignedPartitions);
         this.scanPartitionDiscoveryIntervalMs = scanPartitionDiscoveryIntervalMs;
         this.streaming = streaming;
+        this.partitionFilters = partitionFilters;
         this.stoppingOffsetsInitializer =
                 streaming ? new NoStoppingOffsetsInitializer() : OffsetsInitializer.latest();
     }
@@ -255,12 +262,42 @@ public class FlinkSourceEnumerator
     private Set<PartitionInfo> listPartitions() {
         try {
             List<PartitionInfo> partitionInfos = flussAdmin.listPartitionInfos(tablePath).get();
+            partitionInfos = applyPartitionFilter(partitionInfos);
             return new HashSet<>(partitionInfos);
         } catch (Exception e) {
             throw new FlinkRuntimeException(
                     String.format("Failed to list partitions for %s", tablePath),
                     ExceptionUtils.stripCompletionException(e));
         }
+    }
+
+    /** Apply partition filter. */
+    private List<PartitionInfo> applyPartitionFilter(List<PartitionInfo> partitionInfos) {
+        if (partitionFilters != null && !partitionFilters.isEmpty()) {
+            return partitionInfos.stream()
+                    .filter(
+                            partitionInfo -> {
+                                Map<String, String> specMap =
+                                        partitionInfo.getPartitionSpec().getSpecMap();
+                                for (PushdownUtils.FieldEqual filter : partitionFilters) {
+                                    String partitionValue =
+                                            specMap.get(
+                                                    tableInfo
+                                                            .getRowType()
+                                                            .getFieldNames()
+                                                            .get(filter.fieldIndex));
+                                    if (partitionValue == null
+                                            || !filter.equalValue
+                                                    .toString()
+                                                    .equals(partitionValue)) {
+                                        return false;
+                                    }
+                                }
+                                return true;
+                            })
+                    .collect(Collectors.toList());
+        }
+        return partitionInfos;
     }
 
     /** Init the splits for Fluss. */

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/utils/PushdownUtils.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/utils/PushdownUtils.java
@@ -61,6 +61,7 @@ import org.apache.flink.table.types.logical.RowType;
 
 import javax.annotation.Nullable;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -437,7 +438,8 @@ public class PushdownUtils {
     // ------------------------------------------------------------------------------------------
 
     /** A structure represents a source field equal literal expression. */
-    public static class FieldEqual {
+    public static class FieldEqual implements Serializable {
+        private static final long serialVersionUID = 1L;
         public final int fieldIndex;
         public final Object equalValue;
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -1034,18 +1034,18 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
     @Test
     void testNonPartitionPushDown() throws Exception {
         tEnv.executeSql(
-                "create table partitioned_table"
+                "create table partitioned_table_no_filter"
                         + " (a int not null, b varchar, c string, primary key (a, c) NOT ENFORCED) partitioned by (c) ");
-        TablePath tablePath = TablePath.of(DEFAULT_DB, "partitioned_table");
-        tEnv.executeSql("alter table partitioned_table add partition (c=2025)");
-        tEnv.executeSql("alter table partitioned_table add partition (c=2026)");
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "partitioned_table_no_filter");
+        tEnv.executeSql("alter table partitioned_table_no_filter add partition (c=2025)");
+        tEnv.executeSql("alter table partitioned_table_no_filter add partition (c=2026)");
 
         List<String> expectedRowValues =
                 writeRowsToPartition(tablePath, Arrays.asList("2025", "2026"));
         waitUtilAllBucketFinishSnapshot(admin, tablePath, Arrays.asList("2025", "2026"));
 
         org.apache.flink.util.CloseableIterator<Row> rowIter =
-                tEnv.executeSql("select * from partitioned_table").collect();
+                tEnv.executeSql("select * from partitioned_table_no_filter").collect();
         assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -996,6 +996,7 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
     @Test
     void testStreamingReadWithCombinedFilters() throws Exception {
+
         tEnv.executeSql(
                 "create table combined_filters_table"
                         + " (a int not null, b varchar, c string, d int, primary key (a, c) NOT ENFORCED) partitioned by (c) ");

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -1045,7 +1045,6 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
         org.apache.flink.util.CloseableIterator<Row> rowIter =
                 tEnv.executeSql("select * from partitioned_table").collect();
-
         assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
     }
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -935,7 +935,6 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
     @Test
     void testStreamingReadSinglePartitionPushDown() throws Exception {
-
         tEnv.executeSql(
                 "create table partitioned_table"
                         + " (a int not null, b varchar, c string, primary key (a, c) NOT ENFORCED) partitioned by (c) ");

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static com.alibaba.fluss.flink.FlinkConnectorOptions.BOOTSTRAP_SERVERS;
@@ -926,6 +927,78 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
                 .cause()
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Full lookup caching is not supported yet.");
+    }
+
+    // -------------------------------------------------------------------------------------
+    // Fluss partition push down tests
+    // -------------------------------------------------------------------------------------
+
+    @Test
+    void testStreamingReadSinglePartitionPushDown() throws Exception {
+
+        tEnv.executeSql(
+                "create table partitioned_table"
+                        + " (a int not null, b varchar, c string, primary key (a, c) NOT ENFORCED) partitioned by (c) "
+                        + "with ('table.auto-partition.enabled' = 'true', 'table.auto-partition.time-unit' = 'year')");
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "partitioned_table");
+
+        // write data into partitions and wait snapshot is done
+        Map<Long, String> partitionNameById =
+                waitUntilPartitions(FLUSS_CLUSTER_EXTENSION.getZooKeeperClient(), tablePath);
+        List<String> expectedRowValues =
+                writeRowsToPartition(tablePath, partitionNameById.values()).stream()
+                        .filter(s -> s.contains("2025"))
+                        .collect(Collectors.toList());
+        waitUtilAllBucketFinishSnapshot(admin, tablePath, partitionNameById.values());
+
+        org.apache.flink.util.CloseableIterator<Row> rowIter =
+                tEnv.executeSql("select * from partitioned_table where c ='2025'").collect();
+
+        assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
+    }
+
+    @Test
+    void testStreamingReadMultiPartitionPushDown() throws Exception {
+
+        tEnv.executeSql(
+                "create table multi_partitioned_table"
+                        + " (a int not null, b varchar, c string,d string, primary key (a, c, d) NOT ENFORCED) partitioned by (c,d) "
+                        + "with ('table.auto-partition.enabled' = 'true', 'table.auto-partition.time-unit' = 'year','table.auto-partition.key'= 'c','table.auto-partition.num-precreate' = '0')");
+        TablePath tablePath = TablePath.of(DEFAULT_DB, "multi_partitioned_table");
+        tEnv.executeSql("alter table multi_partitioned_table add partition (c=2025,d=1)");
+        tEnv.executeSql("alter table multi_partitioned_table add partition (c=2025,d=2)");
+        tEnv.executeSql("alter table multi_partitioned_table add partition (c=2026,d=1)");
+
+        List<String> expectedRowValues =
+                writeRowsToTwoPartition(
+                                tablePath, Arrays.asList("c=2025,d=1", "c=2025,d=2", "c=2026,d=1"))
+                        .stream()
+                        .filter(s -> s.contains("2025"))
+                        .collect(Collectors.toList());
+        waitUtilAllBucketFinishSnapshot(
+                admin, tablePath, Arrays.asList("2025$1", "2025$2", "2025$2"));
+
+        // test partition key prefix match
+        org.apache.flink.util.CloseableIterator<Row> rowIter =
+                tEnv.executeSql("select * from multi_partitioned_table where c ='2025'").collect();
+
+        assertResultsIgnoreOrder(rowIter, expectedRowValues, false);
+
+        tEnv.executeSql("alter table multi_partitioned_table add partition (c=2025,d=3)");
+        tEnv.executeSql("alter table multi_partitioned_table add partition (c=2026,d=2)");
+        expectedRowValues =
+                writeRowsToTwoPartition(tablePath, Arrays.asList("c=2025,d=3", "c=2026,d=2"))
+                        .stream()
+                        .filter(s -> s.contains("2025"))
+                        .collect(Collectors.toList());
+        waitUtilAllBucketFinishSnapshot(admin, tablePath, Arrays.asList("2025$3", "2026$2"));
+        assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
+
+        // test all partition key match
+        rowIter =
+                tEnv.executeSql("select * from multi_partitioned_table where c ='2025' and d ='3' ")
+                        .collect();
+        assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
     }
 
     private enum Caching {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -994,8 +994,8 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
         assertResultsIgnoreOrder(rowIter, expectedRowValues, true);
     }
 
-    private List<String> writeRowsToTwoPartition(
-            TablePath tablePath, Collection<String> partitions) throws Exception {
+    private List<String> writeRowsToTwoPartition(TablePath tablePath, Collection<String> partitions)
+            throws Exception {
         List<InternalRow> rows = new ArrayList<>();
         List<String> expectedRowValues = new ArrayList<>();
 

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -95,7 +95,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             context,
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
 
             enumerator.start();
 
@@ -141,7 +142,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             context,
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
             enumerator.start();
             // register all read
             for (int i = 0; i < numSubtasks; i++) {
@@ -211,7 +213,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             context,
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
 
             enumerator.start();
 
@@ -256,7 +259,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             context,
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
 
             enumerator.start();
 
@@ -291,7 +295,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             context,
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
 
             enumerator.start();
 
@@ -349,7 +354,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             Collections.emptyMap(),
                             OffsetsInitializer.earliest(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                            streaming);
+                            streaming,
+                            null);
 
             enumerator.start();
             assertThat(context.getSplitsAssignmentSequence()).isEmpty();
@@ -391,7 +397,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                 context,
                                 OffsetsInitializer.full(),
                                 DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                                streaming)) {
+                                streaming,
+                                null)) {
             Map<Long, String> partitionNameByIds =
                     waitUntilPartitions(zooKeeperClient, DEFAULT_TABLE_PATH);
             enumerator.start();
@@ -505,7 +512,8 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                 context,
                                 OffsetsInitializer.full(),
                                 DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
-                                streaming)) {
+                                streaming,
+                                null)) {
 
             // test splits for same non-partitioned bucket, should assign to same task
             TableBucket t1 = new TableBucket(tableId, 0);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -96,7 +96,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
 
             enumerator.start();
 
@@ -143,7 +143,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
             enumerator.start();
             // register all read
             for (int i = 0; i < numSubtasks; i++) {
@@ -214,7 +214,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
 
             enumerator.start();
 
@@ -260,7 +260,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
 
             enumerator.start();
 
@@ -296,7 +296,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.full(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
 
             enumerator.start();
 
@@ -355,7 +355,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                             OffsetsInitializer.earliest(),
                             DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                             streaming,
-                            null);
+                            Collections.emptyList());
 
             enumerator.start();
             assertThat(context.getSplitsAssignmentSequence()).isEmpty();
@@ -398,7 +398,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                 OffsetsInitializer.full(),
                                 DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                                 streaming,
-                                null)) {
+                                Collections.emptyList())) {
             Map<Long, String> partitionNameByIds =
                     waitUntilPartitions(zooKeeperClient, DEFAULT_TABLE_PATH);
             enumerator.start();
@@ -513,7 +513,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
                                 OffsetsInitializer.full(),
                                 DEFAULT_SCAN_PARTITION_DISCOVERY_INTERVAL_MS,
                                 streaming,
-                                null)) {
+                                Collections.emptyList())) {
 
             // test splits for same non-partitioned bucket, should assign to same task
             TableBucket t1 = new TableBucket(tableId, 0);

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -265,28 +265,6 @@ public class FlinkTestBase extends AbstractTestBase {
         return expectedRowValues;
     }
 
-    protected List<String> writeRowsToTwoPartition(
-            TablePath tablePath, Collection<String> partitions) throws Exception {
-        List<InternalRow> rows = new ArrayList<>();
-        List<String> expectedRowValues = new ArrayList<>();
-
-        for (String partition : partitions) {
-            String[] keyValuePairs = partition.split(",");
-            String[] values = new String[2];
-            values[0] = keyValuePairs[0].split("=")[1];
-            values[1] = keyValuePairs[1].split("=")[1];
-
-            for (int i = 0; i < 10; i++) {
-                rows.add(row(i, "v1", values[0], values[1]));
-                expectedRowValues.add(String.format("+I[%d, v1, %s, %s]", i, values[0], values[1]));
-            }
-        }
-
-        writeRows(tablePath, rows, false);
-
-        return expectedRowValues;
-    }
-
     protected void writeRows(TablePath tablePath, List<InternalRow> rows, boolean append)
             throws Exception {
         try (Table table = conn.getTable(tablePath)) {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -282,7 +282,6 @@ public class FlinkTestBase extends AbstractTestBase {
             }
         }
 
-        // 写入记录
         writeRows(tablePath, rows, false);
 
         return expectedRowValues;

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkTestBase.java
@@ -265,6 +265,29 @@ public class FlinkTestBase extends AbstractTestBase {
         return expectedRowValues;
     }
 
+    protected List<String> writeRowsToTwoPartition(
+            TablePath tablePath, Collection<String> partitions) throws Exception {
+        List<InternalRow> rows = new ArrayList<>();
+        List<String> expectedRowValues = new ArrayList<>();
+
+        for (String partition : partitions) {
+            String[] keyValuePairs = partition.split(",");
+            String[] values = new String[2];
+            values[0] = keyValuePairs[0].split("=")[1];
+            values[1] = keyValuePairs[1].split("=")[1];
+
+            for (int i = 0; i < 10; i++) {
+                rows.add(row(i, "v1", values[0], values[1]));
+                expectedRowValues.add(String.format("+I[%d, v1, %s, %s]", i, values[0], values[1]));
+            }
+        }
+
+        // 写入记录
+        writeRows(tablePath, rows, false);
+
+        return expectedRowValues;
+    }
+
     protected void writeRows(TablePath tablePath, List<InternalRow> rows, boolean append)
             throws Exception {
         try (Table table = conn.getTable(tablePath)) {

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/flink/LakeTableEnumeratorTest.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/flink/LakeTableEnumeratorTest.java
@@ -94,7 +94,8 @@ class LakeTableEnumeratorTest extends PaimonSyncTestBase {
                             OffsetsInitializer.full(),
                             1000,
                             // use batch mode
-                            false);
+                            false,
+                            null);
             enumerator.start();
             // register all read
             for (int i = 0; i < 3; i++) {
@@ -170,7 +171,8 @@ class LakeTableEnumeratorTest extends PaimonSyncTestBase {
                             OffsetsInitializer.full(),
                             1000,
                             // use batch mode
-                            false);
+                            false,
+                            null);
             enumerator.start();
             // register all read
             for (int i = 0; i < 3; i++) {

--- a/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/flink/LakeTableEnumeratorTest.java
+++ b/fluss-lakehouse/fluss-lakehouse-paimon/src/test/java/com/alibaba/fluss/lakehouse/paimon/flink/LakeTableEnumeratorTest.java
@@ -95,7 +95,7 @@ class LakeTableEnumeratorTest extends PaimonSyncTestBase {
                             1000,
                             // use batch mode
                             false,
-                            null);
+                            Collections.emptyList());
             enumerator.start();
             // register all read
             for (int i = 0; i < 3; i++) {
@@ -172,7 +172,7 @@ class LakeTableEnumeratorTest extends PaimonSyncTestBase {
                             1000,
                             // use batch mode
                             false,
-                            null);
+                            Collections.emptyList());
             enumerator.start();
             // register all read
             for (int i = 0; i < 3; i++) {


### PR DESCRIPTION
[flink]

Purpose
Support partition pushdown(only equals) in Flink connector
Linked issue: close https://github.com/alibaba/fluss/issues/196

Tests
com.alibaba.fluss.connector.flink.source.FlinkTableSourceITCase#testStreamingReadSinglePartitionPushDown
com.alibaba.fluss.connector.flink.source.FlinkTableSourceITCase#testStreamingReadMultiPartitionPushDown

API and Format
no

Documentation
no