### PR TITLE
[hotfix] Mark abstract itcase's variable as protected.

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/catalog/FlinkCatalogITCase.java
@@ -82,7 +82,7 @@ abstract class FlinkCatalogITCase {
     static final String DEFAULT_DB = FlinkCatalogOptions.DEFAULT_DATABASE.defaultValue();
     static Catalog catalog;
 
-    private TableEnvironment tEnv;
+    protected TableEnvironment tEnv;
 
     @BeforeAll
     static void beforeAll() {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -79,9 +79,9 @@ abstract class FlinkTableSinkITCase extends AbstractTestBase {
     static final String CATALOG_NAME = "testcatalog";
     static final String DEFAULT_DB = "defaultdb";
 
-    private StreamExecutionEnvironment env;
-    private StreamTableEnvironment tEnv;
-    private TableEnvironment tBatchEnv;
+    protected StreamExecutionEnvironment env;
+    protected StreamTableEnvironment tEnv;
+    protected TableEnvironment tBatchEnv;
 
     static Stream<Arguments> writePartitionedTableParams() {
         return Stream.of(

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceBatchITCase.java
@@ -54,7 +54,7 @@ abstract class FlinkTableSourceBatchITCase extends FlinkTestBase {
 
     static final String CATALOG_NAME = "testcatalog";
     static final String DEFAULT_DB = "defaultdb";
-    private StreamTableEnvironment tEnv;
+    protected StreamTableEnvironment tEnv;
 
     @BeforeEach
     void before() {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlinkTableSourceITCase.java
@@ -74,8 +74,8 @@ abstract class FlinkTableSourceITCase extends FlinkTestBase {
 
     static final String CATALOG_NAME = "testcatalog";
     static final String DEFAULT_DB = "defaultdb";
-    private StreamExecutionEnvironment execEnv;
-    private StreamTableEnvironment tEnv;
+    protected StreamExecutionEnvironment execEnv;
+    protected StreamTableEnvironment tEnv;
 
     @BeforeEach
     void before() {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/FlussSourceITCase.java
@@ -70,7 +70,7 @@ public class FlussSourceITCase extends FlinkTestBase {
     private final TableDescriptor pkTableDescriptor =
             TableDescriptor.builder().schema(PK_SCHEMA).distributedBy(1, "orderId").build();
 
-    private StreamExecutionEnvironment env;
+    protected StreamExecutionEnvironment env;
 
     @BeforeEach
     public void before() {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

The variable in abstract class (such as FlinkTableSinkITCase) in private now, its subclass can not use it.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
