### PR TITLE
[Flink] Change logfetchercollector warning and timeout closableiterator

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
@@ -249,7 +249,6 @@ public class LogFetchCollector {
             CompletedFetch completedFetch, Errors error, String errorMessage) {
         TableBucket tb = completedFetch.tableBucket;
         long fetchOffset = completedFetch.nextFetchOffset();
-
         if (error == Errors.NOT_LEADER_OR_FOLLOWER
                 || error == Errors.LOG_STORAGE_EXCEPTION
                 || error == Errors.KV_STORAGE_EXCEPTION
@@ -259,21 +258,7 @@ public class LogFetchCollector {
                     "Error in fetch for bucket {}: {}:{}", tb, error.exceptionName(), errorMessage);
             metadataUpdater.checkAndUpdateMetadata(tablePath, tb);
         } else if (error == Errors.UNKNOWN_TABLE_OR_BUCKET_EXCEPTION) {
-            // Check if bucket should be removed from scanner status to stop repeated fetch
-            // attempts.
-            Long currentOffset = logScannerStatus.getBucketOffset(tb);
-            if (currentOffset != null) {
-                LOG.warn(
-                        "Received unknown table or bucket error in fetch for bucket {}, removing from scanner status",
-                        tb);
-                // Remove the bucket from scanner status to prevent repeated fetch attempts
-                logScannerStatus.unassignScanBuckets(Collections.singletonList(tb));
-            } else {
-                // Bucket already unassigned, just log at debug level to reduce noise
-                LOG.debug(
-                        "Received unknown table or bucket error for already unassigned bucket {}",
-                        tb);
-            }
+            LOG.warn("Received unknown table or bucket error in fetch for bucket {}", tb);
             metadataUpdater.checkAndUpdateMetadata(tablePath, tb);
         } else if (error == Errors.LOG_OFFSET_OUT_OF_RANGE_EXCEPTION) {
             throw new FetchException(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
@@ -127,8 +127,8 @@ public class LogFetchCollector {
                             // because the old one may be immutable
                             List<ScanRecord> newScanRecords =
                                     new ArrayList<>(records.size() + currentRecords.size());
-                            newScanRecords.All(currentRecords);
-                            newScanRecords.All(records);
+                            newScanRecords.addAll(currentRecords);
+                            newScanRecords.addAll(records);
                             fetched.put(tableBucket, newScanRecords);
                         }
 

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
@@ -260,7 +260,7 @@ public class LogFetchCollector {
             metadataUpdater.checkAndUpdateMetadata(tablePath, tb);
         } else if (error == Errors.UNKNOWN_TABLE_OR_BUCKET_EXCEPTION) {
             // Check if bucket should be removed from scanner status to stop repeated fetch
-            // attempts
+            // attempts.
             Long currentOffset = logScannerStatus.getBucketOffset(tb);
             if (currentOffset != null) {
                 LOG.warn(

--- a/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/table/scanner/log/LogFetchCollector.java
@@ -127,8 +127,8 @@ public class LogFetchCollector {
                             // because the old one may be immutable
                             List<ScanRecord> newScanRecords =
                                     new ArrayList<>(records.size() + currentRecords.size());
-                            newScanRecords.addAll(currentRecords);
-                            newScanRecords.addAll(records);
+                            newScanRecords.All(currentRecords);
+                            newScanRecords.All(records);
                             fetched.put(tableBucket, newScanRecords);
                         }
 
@@ -259,7 +259,7 @@ public class LogFetchCollector {
                     "Error in fetch for bucket {}: {}:{}", tb, error.exceptionName(), errorMessage);
             metadataUpdater.checkAndUpdateMetadata(tablePath, tb);
         } else if (error == Errors.UNKNOWN_TABLE_OR_BUCKET_EXCEPTION) {
-            // ADD: Check if bucket should be removed from scanner status to stop repeated fetch
+            // Check if bucket should be removed from scanner status to stop repeated fetch
             // attempts
             Long currentOffset = logScannerStatus.getBucketOffset(tb);
             if (currentOffset != null) {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
@@ -36,7 +36,7 @@ public class FlinkRowAssertionsUtils {
             List<String> actual = new ArrayList<>(expectRecords);
 
             long startTime = System.currentTimeMillis();
-            int maxWaitTime = 10000; // 10 seconds
+            int maxWaitTime = 60000; // 60 seconds
 
             for (int i = 0; i < expectRecords; i++) {
                 // Wait for next record with timeout

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/source/testutils/FlinkRowAssertionsUtils.java
@@ -82,6 +82,7 @@ public class FlinkRowAssertionsUtils {
         }
     }
 
+    // expects exact order
     public static void assertQueryResultExactOrder(
             TableEnvironment env, String query, List<String> expected) throws Exception {
         try (CloseableIterator<Row> rowIter = env.executeSql(query).collect()) {


### PR DESCRIPTION

### Purpose

FLINK - CI Times out randomly due to Job failure/resource clean up issue.

Linked issue: close #934 

<!-- What is the purpose of the change -->

### Brief change log

> LogFetchCollector Changes:

Before: When we got an “unknown table or bucket” error, we would just log a warning and update metadata. Then the system would keep trying to fetch from that same non-existent bucket over and over again.

After: Now when we get an `UNKNOWN_TABLE_OR_BUCKET_EXCEPTION` error, we first check if the bucket is still assigned in our scanner status. If it is, we log the warning AND immediately remove that bucket from the scanner status so we stop trying to fetch from it. If the bucket was already unassigned, we just log a debug message instead of a warning to reduce noise.

>  AssertResultsIgnoreOrder utility method that reads results from Flink job iterators:

 
Before: The method would call `iterator.next()` in a simple for-loop, expecting to get exactly the number of records we wanted. But `iterator.next()` blocks forever if there’s no more data coming.

After: Now we check `iterator.hasNext()` before calling next(), and if there’s no data available, we wait up to 10 seconds. If we still don’t get data after the timeout, we assume the job finished normally and stop waiting.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
