### PR TITLE
[log] Recycle ArrowWriter when MemoryLogRecordsArrowBuilder close ins…

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/ArrowLogWriteBatch.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/ArrowLogWriteBatch.java
@@ -119,7 +119,7 @@ public class ArrowLogWriteBatch extends WriteBatch {
     @Override
     public void resetWriterState(long writerId, int batchSequence) {
         super.resetWriterState(writerId, batchSequence);
-        recordsBuilder.resetWriterState(writerId, batchSequence);
+        recordsBuilder.setWriterState(writerId, batchSequence);
     }
 
     @Override

--- a/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilder.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilder.java
@@ -180,15 +180,10 @@ public class MemoryLogRecordsArrowBuilder implements AutoCloseable {
     }
 
     public void setWriterState(long writerId, int batchBaseSequence) {
-        this.writerId = writerId;
-        this.batchSequence = batchBaseSequence;
-    }
-
-    public void resetWriterState(long writerId, int batchSequence) {
         // trigger to rewrite batch header when next build.
         this.resetBatchHeader = true;
         this.writerId = writerId;
-        this.batchSequence = batchSequence;
+        this.batchSequence = batchBaseSequence;
     }
 
     public boolean isClosed() {
@@ -200,6 +195,9 @@ public class MemoryLogRecordsArrowBuilder implements AutoCloseable {
         if (isClosed) {
             return;
         }
+
+        // Build arrowBatch when batch close to recycle arrow writer.
+        build();
 
         isClosed = true;
     }

--- a/fluss-common/src/test/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilderTest.java
+++ b/fluss-common/src/test/java/com/alibaba/fluss/record/MemoryLogRecordsArrowBuilderTest.java
@@ -327,7 +327,7 @@ public class MemoryLogRecordsArrowBuilderTest {
 
         // test reset writer state and build (This situation will happen when the produceLog request
         // failed and the batch is re-enqueue to send with different write state).
-        builder.resetWriterState(1L, 1);
+        builder.setWriterState(1L, 1);
         records = MemoryLogRecords.pointToBytesView(builder.build());
         assertLogRecordsEquals(DATA1_ROW_TYPE, records, expectedResult);
         recordBatch = records.batches().iterator().next();


### PR DESCRIPTION
…tead of build

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #971 

<!-- What is the purpose of the change -->

Currently, In recent write to Fluss production tasks, we frequently encountered OOM when acquire non-heap memory for ArrowSchemaRoot. Debugging revealed that the MemoryLogRecordsArrowBuilder does not return the ArrowWriter to the ArrowWriterPool immediately after close(). Instead, it waits until the network sends the buffers. This results in an excessively long recycling cycle for individual ArrowWriter instances, leading to the allocation of large amounts of memory. A more efficient approach would be to return the writer to the pool immediately after close() to avoid excessive memory allocation.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
