### PR TITLE
[bugfix] Fix a bug which makes memory allocation stuck

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/memory/LazyMemorySegmentPool.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/memory/LazyMemorySegmentPool.java
@@ -231,7 +231,7 @@ public class LazyMemorySegmentPool implements MemorySegmentPool, Closeable {
                     pageUsage = newPageUsage;
                     cachePages.addAll(memory);
                     for (int i = 0; i < memory.size() && !waiters.isEmpty(); i++) {
-                        waiters.pollFirst().signal();
+                        waiters.peekFirst().signal();
                     }
                 });
     }


### PR DESCRIPTION

### Purpose
When `public void returnAll(List<MemorySegment> memory) {`
returns memory segment, it polls the first waiter and wakes it up in Deque to judge if freePages is less than requiredPages. If not, this waiter calls await() again and will no longer be waked up. This should cause memory allocation stuck and can't recover.
### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
