### PR TITLE
[lake/flink] Introduce committer operator

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessage.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessage.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import java.io.Serializable;
+
+/** A class wrapping {@link Committable} to commit to lake. */
+public class CommittableMessage<Committable> implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final Committable committable;
+
+    public CommittableMessage(Committable committable) {
+        this.committable = committable;
+    }
+
+    public Committable committable() {
+        return committable;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessageTypeInfo.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessageTypeInfo.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.flink.tiering.source.TableBucketWriteResult;
+import com.alibaba.fluss.lakehouse.serializer.SimpleVersionedSerializer;
+
+import org.apache.flink.api.common.ExecutionConfig;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.core.io.SimpleVersionedSerializerTypeSerializerProxy;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import java.io.IOException;
+
+/** A {@link TypeInformation} for {@link CommittableMessage}. */
+public class CommittableMessageTypeInfo<Committable>
+        extends TypeInformation<CommittableMessage<Committable>> {
+
+    private final SerializableSupplier<SimpleVersionedSerializer<Committable>>
+            committableSerializerFactory;
+
+    private CommittableMessageTypeInfo(
+            SerializableSupplier<SimpleVersionedSerializer<Committable>>
+                    committableSerializerFactory) {
+        this.committableSerializerFactory = committableSerializerFactory;
+    }
+
+    public static <Committable> TypeInformation<CommittableMessage<Committable>> of(
+            SerializableSupplier<SimpleVersionedSerializer<Committable>>
+                    committableSerializerFactory) {
+        return new CommittableMessageTypeInfo<>(committableSerializerFactory);
+    }
+
+    @Override
+    public boolean isBasicType() {
+        return false;
+    }
+
+    @Override
+    public boolean isTupleType() {
+        return false;
+    }
+
+    @Override
+    public int getArity() {
+        return 1;
+    }
+
+    @Override
+    public int getTotalFields() {
+        return 1;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Override
+    public Class<CommittableMessage<Committable>> getTypeClass() {
+        return (Class) TableBucketWriteResult.class;
+    }
+
+    @Override
+    public boolean isKeyType() {
+        return false;
+    }
+
+    @Override
+    public TypeSerializer<CommittableMessage<Committable>> createSerializer(
+            ExecutionConfig executionConfig) {
+        // no copy, so that data from writer is directly going into upstream operator while chaining
+        SimpleVersionedSerializer<Committable> committableSerializer =
+                committableSerializerFactory.get();
+        return new SimpleVersionedSerializerTypeSerializerProxy<CommittableMessage<Committable>>(
+                () ->
+                        new org.apache.flink.core.io.SimpleVersionedSerializer<
+                                CommittableMessage<Committable>>() {
+                            @Override
+                            public int getVersion() {
+                                return committableSerializer.getVersion();
+                            }
+
+                            @Override
+                            public byte[] serialize(
+                                    CommittableMessage<Committable> committableCommittableMessage)
+                                    throws IOException {
+                                return committableSerializer.serialize(
+                                        committableCommittableMessage.committable());
+                            }
+
+                            @Override
+                            public CommittableMessage<Committable> deserialize(
+                                    int version, byte[] serialized) throws IOException {
+                                return new CommittableMessage<>(
+                                        committableSerializer.deserialize(version, serialized));
+                            }
+                        }) {
+            // nothing
+            @Override
+            public CommittableMessage<Committable> copy(CommittableMessage<Committable> from) {
+                return from;
+            }
+
+            @Override
+            public CommittableMessage<Committable> copy(
+                    CommittableMessage<Committable> from, CommittableMessage<Committable> reuse) {
+                return from;
+            }
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "LakeCommittableTypeInfo";
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof CommittableMessageTypeInfo;
+    }
+
+    @Override
+    public int hashCode() {
+        return getClass().hashCode();
+    }
+
+    @Override
+    public boolean canEqual(Object obj) {
+        return obj instanceof CommittableMessageTypeInfo;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/FlussTableLakeSnapshot.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/FlussTableLakeSnapshot.java
@@ -20,8 +20,8 @@ import com.alibaba.fluss.metadata.TableBucket;
 
 import java.util.Map;
 
-/** A lake snapshot for a table. */
-public class TableLakeSnapshot {
+/** A lake snapshot for a Fluss table. */
+public class FlussTableLakeSnapshot {
 
     private final long tableId;
 
@@ -29,7 +29,7 @@ public class TableLakeSnapshot {
 
     private final Map<TableBucket, Long> logEndOffsets;
 
-    public TableLakeSnapshot(
+    public FlussTableLakeSnapshot(
             long tableId, long lakeSnapshotId, Map<TableBucket, Long> logEndOffsets) {
         this.tableId = tableId;
         this.lakeSnapshotId = lakeSnapshotId;
@@ -50,7 +50,7 @@ public class TableLakeSnapshot {
 
     @Override
     public String toString() {
-        return "TableLakeSnapshot{"
+        return "FlussTableLakeSnapshot{"
                 + "tableId="
                 + tableId
                 + ", lakeSnapshotId="

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/FlussTableLakeSnapshotCommitter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/FlussTableLakeSnapshotCommitter.java
@@ -33,7 +33,7 @@ import com.alibaba.fluss.utils.ExceptionUtils;
 import java.io.IOException;
 import java.util.Map;
 
-/** Committer to commit {@link TableLakeSnapshot} of lake to Fluss. */
+/** Committer to commit {@link FlussTableLakeSnapshot} of lake to Fluss. */
 public class FlussTableLakeSnapshotCommitter implements AutoCloseable {
 
     private final Configuration flussConf;
@@ -57,30 +57,31 @@ public class FlussTableLakeSnapshotCommitter implements AutoCloseable {
                         metadataUpdater::getCoordinatorServer, rpcClient, CoordinatorGateway.class);
     }
 
-    public void commit(TableLakeSnapshot tableLakeSnapshot) throws IOException {
+    public void commit(FlussTableLakeSnapshot flussTableLakeSnapshot) throws IOException {
         try {
             CommitLakeTableSnapshotRequest request =
-                    toCommitLakeTableSnapshotRequest(tableLakeSnapshot);
+                    toCommitLakeTableSnapshotRequest(flussTableLakeSnapshot);
             coordinatorGateway.commitLakeTableSnapshot(request).get();
         } catch (Exception e) {
             throw new IOException(
                     String.format(
-                            "Fail to commit table lake snapshot %s to Fluss.", tableLakeSnapshot),
+                            "Fail to commit table lake snapshot %s to Fluss.",
+                            flussTableLakeSnapshot),
                     ExceptionUtils.stripExecutionException(e));
         }
     }
 
     private CommitLakeTableSnapshotRequest toCommitLakeTableSnapshotRequest(
-            TableLakeSnapshot tableLakeSnapshot) {
+            FlussTableLakeSnapshot flussTableLakeSnapshot) {
         CommitLakeTableSnapshotRequest commitLakeTableSnapshotRequest =
                 new CommitLakeTableSnapshotRequest();
         PbLakeTableSnapshotInfo pbLakeTableSnapshotInfo =
                 commitLakeTableSnapshotRequest.addTablesReq();
 
-        pbLakeTableSnapshotInfo.setTableId(tableLakeSnapshot.tableId());
-        pbLakeTableSnapshotInfo.setSnapshotId(tableLakeSnapshot.lakeSnapshotId());
+        pbLakeTableSnapshotInfo.setTableId(flussTableLakeSnapshot.tableId());
+        pbLakeTableSnapshotInfo.setSnapshotId(flussTableLakeSnapshot.lakeSnapshotId());
         for (Map.Entry<TableBucket, Long> bucketEndOffsetEntry :
-                tableLakeSnapshot.logEndOffsets().entrySet()) {
+                flussTableLakeSnapshot.logEndOffsets().entrySet()) {
             PbLakeTableOffsetForBucket pbLakeTableOffsetForBucket =
                     pbLakeTableSnapshotInfo.addBucketsReq();
             TableBucket tableBucket = bucketEndOffsetEntry.getKey();

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshot.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshot.java
@@ -25,13 +25,14 @@ public class TableLakeSnapshot {
 
     private final long tableId;
 
-    private final long snapshotId;
+    private final long lakeSnapshotId;
 
     private final Map<TableBucket, Long> logEndOffsets;
 
-    public TableLakeSnapshot(long tableId, long snapshotId, Map<TableBucket, Long> logEndOffsets) {
+    public TableLakeSnapshot(
+            long tableId, long lakeSnapshotId, Map<TableBucket, Long> logEndOffsets) {
         this.tableId = tableId;
-        this.snapshotId = snapshotId;
+        this.lakeSnapshotId = lakeSnapshotId;
         this.logEndOffsets = logEndOffsets;
     }
 
@@ -39,11 +40,23 @@ public class TableLakeSnapshot {
         return tableId;
     }
 
-    public long snapshotId() {
-        return snapshotId;
+    public long lakeSnapshotId() {
+        return lakeSnapshotId;
     }
 
     public Map<TableBucket, Long> logEndOffsets() {
         return logEndOffsets;
+    }
+
+    @Override
+    public String toString() {
+        return "TableLakeSnapshot{"
+                + "tableId="
+                + tableId
+                + ", lakeSnapshotId="
+                + lakeSnapshotId
+                + ", logEndOffsets="
+                + logEndOffsets
+                + '}';
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshot.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshot.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.metadata.TableBucket;
+
+import java.util.Map;
+
+/** A lake snapshot for a table. */
+public class TableLakeSnapshot {
+
+    private final long tableId;
+
+    private final long snapshotId;
+
+    private final Map<TableBucket, Long> logEndOffsets;
+
+    public TableLakeSnapshot(long tableId, long snapshotId, Map<TableBucket, Long> logEndOffsets) {
+        this.tableId = tableId;
+        this.snapshotId = snapshotId;
+        this.logEndOffsets = logEndOffsets;
+    }
+
+    public long tableId() {
+        return tableId;
+    }
+
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    public Map<TableBucket, Long> logEndOffsets() {
+        return logEndOffsets;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshotCommitter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TableLakeSnapshotCommitter.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.client.ConnectionFactory;
+import com.alibaba.fluss.client.FlussConnection;
+import com.alibaba.fluss.client.metadata.MetadataUpdater;
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.rpc.GatewayClientProxy;
+import com.alibaba.fluss.rpc.RpcClient;
+import com.alibaba.fluss.rpc.gateway.CoordinatorGateway;
+import com.alibaba.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
+import com.alibaba.fluss.rpc.messages.PbLakeTableOffsetForBucket;
+import com.alibaba.fluss.rpc.messages.PbLakeTableSnapshotInfo;
+import com.alibaba.fluss.utils.ExceptionUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+/** Committer to commit {@link TableLakeSnapshot} of lake to Fluss. */
+public class TableLakeSnapshotCommitter implements AutoCloseable {
+
+    private final Configuration flussConf;
+
+    private CoordinatorGateway coordinatorGateway;
+    private FlussConnection connection;
+
+    public TableLakeSnapshotCommitter(Configuration flussConf) {
+        this.flussConf = flussConf;
+    }
+
+    public void open() {
+        // init coordinator gateway
+        connection = (FlussConnection) ConnectionFactory.createConnection(flussConf);
+        RpcClient rpcClient = connection.getRpcClient();
+        MetadataUpdater metadataUpdater = new MetadataUpdater(flussConf, rpcClient);
+        this.coordinatorGateway =
+                GatewayClientProxy.createGatewayProxy(
+                        metadataUpdater::getCoordinatorServer, rpcClient, CoordinatorGateway.class);
+    }
+
+    public void commit(TableLakeSnapshot tableLakeSnapshot) throws IOException {
+        try {
+            CommitLakeTableSnapshotRequest request =
+                    toCommitLakeTableSnapshotRequest(tableLakeSnapshot);
+            coordinatorGateway.commitLakeTableSnapshot(request).get();
+        } catch (Exception e) {
+            throw new IOException(
+                    String.format(
+                            "Fail to commit table lake snapshot %s to Fluss.", tableLakeSnapshot),
+                    ExceptionUtils.stripExecutionException(e));
+        }
+    }
+
+    private CommitLakeTableSnapshotRequest toCommitLakeTableSnapshotRequest(
+            TableLakeSnapshot tableLakeSnapshot) {
+        CommitLakeTableSnapshotRequest commitLakeTableSnapshotRequest =
+                new CommitLakeTableSnapshotRequest();
+        PbLakeTableSnapshotInfo pbLakeTableSnapshotInfo =
+                commitLakeTableSnapshotRequest.addTablesReq();
+
+        pbLakeTableSnapshotInfo.setTableId(tableLakeSnapshot.tableId());
+        pbLakeTableSnapshotInfo.setSnapshotId(tableLakeSnapshot.snapshotId());
+        for (Map.Entry<TableBucket, Long> bucketEndOffsetEntry :
+                tableLakeSnapshot.logEndOffsets().entrySet()) {
+            PbLakeTableOffsetForBucket pbLakeTableOffsetForBucket =
+                    pbLakeTableSnapshotInfo.addBucketsReq();
+            TableBucket tableBucket = bucketEndOffsetEntry.getKey();
+            long endOffset = bucketEndOffsetEntry.getValue();
+            if (tableBucket.getPartitionId() != null) {
+                pbLakeTableOffsetForBucket.setPartitionId(tableBucket.getPartitionId());
+            }
+            pbLakeTableOffsetForBucket.setBucketId(tableBucket.getBucket());
+            pbLakeTableOffsetForBucket.setLogEndOffset(endOffset);
+        }
+        return commitLakeTableSnapshotRequest;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (connection != null) {
+            connection.close();
+        }
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperator.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.flink.tiering.source.TableBucketWriteResult;
+import com.alibaba.fluss.lakehouse.committer.LakeCommitter;
+import com.alibaba.fluss.lakehouse.writer.LakeTieringFactory;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TablePath;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.alibaba.fluss.utils.Preconditions.checkState;
+
+/**
+ * A Flink operator to aggregate {@link WriteResult}s by table to {@link Committable} which will
+ * then be committed to lake & Fluss cluster.
+ */
+public class TieringCommitOperator<WriteResult, Committable>
+        extends AbstractStreamOperator<CommittableMessage<Committable>>
+        implements OneInputStreamOperator<
+                TableBucketWriteResult<WriteResult>, CommittableMessage<Committable>> {
+
+    private static final long serialVersionUID = 1L;
+
+    private final LakeTieringFactory<WriteResult, Committable> lakeTieringFactory;
+    private final TableLakeSnapshotCommitter tableLakeSnapshotCommitter;
+
+    // tableid -> write results
+    private final Map<Long, List<TableBucketWriteResult<WriteResult>>>
+            collectedTableBucketWriteResults;
+
+    public TieringCommitOperator(
+            StreamOperatorParameters<CommittableMessage<Committable>> parameters,
+            Configuration flussConf,
+            LakeTieringFactory<WriteResult, Committable> lakeTieringFactory) {
+        this.lakeTieringFactory = lakeTieringFactory;
+        this.tableLakeSnapshotCommitter = new TableLakeSnapshotCommitter(flussConf);
+        this.collectedTableBucketWriteResults = new HashMap<>();
+        this.setup(
+                parameters.getContainingTask(),
+                parameters.getStreamConfig(),
+                parameters.getOutput());
+    }
+
+    @Override
+    public void open() {
+        tableLakeSnapshotCommitter.open();
+    }
+
+    @Override
+    public void processElement(StreamRecord<TableBucketWriteResult<WriteResult>> streamRecord)
+            throws Exception {
+        TableBucketWriteResult<WriteResult> tableBucketWriteResult = streamRecord.getValue();
+        TableBucket tableBucket = tableBucketWriteResult.tableBucket();
+        long tableId = tableBucket.getTableId();
+        registerTableBucketWriteResult(tableId, tableBucketWriteResult);
+
+        // may collect all write results for the table
+        List<TableBucketWriteResult<WriteResult>> committableWriteResults =
+                collectTableAllBucketWriteResult(tableId);
+
+        if (committableWriteResults != null) {
+            Committable committable =
+                    commitWriteResults(
+                            tableId, tableBucketWriteResult.tablePath(), committableWriteResults);
+            collectedTableBucketWriteResults.remove(tableId);
+            // todo: uncomment it in next pr // notify that the table id has been finished tier
+            //            operatorEventGateway.sendEventToCoordinator(
+            //                    new SourceEventWrapper(new FinishTieringEvent(tableId)));
+            output.collect(new StreamRecord<>(new CommittableMessage<>(committable)));
+            // only emit when committable is not-null
+            if (committable != null) {
+                output.collect(new StreamRecord<>(new CommittableMessage<>(committable)));
+            }
+        }
+    }
+
+    @Nullable
+    private Committable commitWriteResults(
+            long tableId,
+            TablePath tablePath,
+            List<TableBucketWriteResult<WriteResult>> committableWriteResults)
+            throws Exception {
+        // filter out non-null write result
+        List<WriteResult> writeResults =
+                committableWriteResults.stream()
+                        .map(TableBucketWriteResult::writeResult)
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList());
+        // empty, means all write result is null, which is a empty commit,
+        // return null to skip the empty commit
+        if (writeResults.isEmpty()) {
+            return null;
+        }
+        try (LakeCommitter<WriteResult, Committable> lakeCommitter =
+                lakeTieringFactory.createLakeCommitter(
+                        new TieringCommitterInitContext(tablePath))) {
+            // to committable
+            Committable committable = lakeCommitter.toCommitable(writeResults);
+            long commitedSnapshotId = lakeCommitter.commit(committable);
+            // commit to fluss
+            Map<TableBucket, Long> logEndOffsets = new HashMap<>();
+            for (TableBucketWriteResult<WriteResult> writeResult : committableWriteResults) {
+                logEndOffsets.put(writeResult.tableBucket(), writeResult.logEndOffset());
+            }
+            tableLakeSnapshotCommitter.commit(
+                    new TableLakeSnapshot(tableId, commitedSnapshotId, logEndOffsets));
+            return committable;
+        }
+    }
+
+    private void registerTableBucketWriteResult(
+            long tableId, TableBucketWriteResult<WriteResult> tableBucketWriteResult) {
+        collectedTableBucketWriteResults
+                .computeIfAbsent(tableId, k -> new ArrayList<>())
+                .add(tableBucketWriteResult);
+    }
+
+    @Nullable
+    private List<TableBucketWriteResult<WriteResult>> collectTableAllBucketWriteResult(
+            long tableId) {
+        Set<TableBucket> collectedBuckets = new HashSet<>();
+        Integer numberOfWriteResults = null;
+        List<TableBucketWriteResult<WriteResult>> writeResults = new ArrayList<>();
+        for (TableBucketWriteResult<WriteResult> tableBucketWriteResult :
+                collectedTableBucketWriteResults.get(tableId)) {
+            if (!collectedBuckets.add(tableBucketWriteResult.tableBucket())) {
+                // it means the write results contain more than two write result
+                // for same table, it shouldn't happen, let's throw exception to
+                // avoid unexpected behavior
+                throw new IllegalStateException(
+                        String.format(
+                                "Found duplicate write results for bucket %s of table %s.",
+                                tableBucketWriteResult.tableBucket(), tableId));
+            }
+            if (numberOfWriteResults == null) {
+                numberOfWriteResults = tableBucketWriteResult.numberOfWriteResults();
+            } else {
+                // the numberOfWriteResults must be same across tableBucketWriteResults
+                checkState(
+                        numberOfWriteResults == tableBucketWriteResult.numberOfWriteResults(),
+                        "numberOfWriteResults is not same across TableBucketWriteResults for table %s, got %s and %s.",
+                        tableId,
+                        numberOfWriteResults,
+                        tableBucketWriteResult.numberOfWriteResults());
+            }
+            writeResults.add(tableBucketWriteResult);
+        }
+
+        if (numberOfWriteResults != null && writeResults.size() == numberOfWriteResults) {
+            return writeResults;
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        tableLakeSnapshotCommitter.close();
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperator.java
@@ -151,7 +151,7 @@ public class TieringCommitOperator<WriteResult, Committable>
                 logEndOffsets.put(writeResult.tableBucket(), writeResult.logEndOffset());
             }
             flussTableLakeSnapshotCommitter.commit(
-                    new TableLakeSnapshot(tableId, commitedSnapshotId, logEndOffsets));
+                    new FlussTableLakeSnapshot(tableId, commitedSnapshotId, logEndOffsets));
             return committable;
         }
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperatorFactory.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperatorFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.config.Configuration;
+import com.alibaba.fluss.lakehouse.writer.LakeTieringFactory;
+
+import org.apache.flink.streaming.api.operators.AbstractStreamOperatorFactory;
+import org.apache.flink.streaming.api.operators.StreamOperator;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+
+/** The factory to create {@link TieringCommitOperator}. */
+public class TieringCommitOperatorFactory<WriteResult, Committable>
+        extends AbstractStreamOperatorFactory<CommittableMessage<Committable>> {
+
+    private final Configuration flussConfig;
+    private final LakeTieringFactory<WriteResult, Committable> lakeTieringFactory;
+
+    public TieringCommitOperatorFactory(
+            Configuration flussConfig,
+            LakeTieringFactory<WriteResult, Committable> lakeTieringFactory) {
+        this.flussConfig = flussConfig;
+        this.lakeTieringFactory = lakeTieringFactory;
+    }
+
+    @Override
+    public <T extends StreamOperator<CommittableMessage<Committable>>> T createStreamOperator(
+            StreamOperatorParameters<CommittableMessage<Committable>> parameters) {
+
+        TieringCommitOperator<WriteResult, Committable> commitOperator =
+                new TieringCommitOperator<>(parameters, flussConfig, lakeTieringFactory);
+
+        @SuppressWarnings("unchecked")
+        final T castedOperator = (T) commitOperator;
+
+        return castedOperator;
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public Class<? extends StreamOperator> getStreamOperatorClass(ClassLoader classLoader) {
+        return TieringCommitOperator.class;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitterInitContext.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitterInitContext.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.lakehouse.committer.CommitterInitContext;
+import com.alibaba.fluss.metadata.TablePath;
+
+/** The implementation of {@link CommitterInitContext}. */
+public class TieringCommitterInitContext implements CommitterInitContext {
+
+    private final TablePath tablePath;
+
+    public TieringCommitterInitContext(TablePath tablePath) {
+        this.tablePath = tablePath;
+    }
+
+    @Override
+    public TablePath tablePath() {
+        return tablePath;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitterInitContext.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitterInitContext.java
@@ -17,9 +17,10 @@
 package com.alibaba.fluss.flink.tiering.committer;
 
 import com.alibaba.fluss.lakehouse.committer.CommitterInitContext;
+import com.alibaba.fluss.lakehouse.committer.LakeCommitter;
 import com.alibaba.fluss.metadata.TablePath;
 
-/** The implementation of {@link CommitterInitContext}. */
+/** The {@link CommitterInitContext} implementation for {@link LakeCommitter}. */
 public class TieringCommitterInitContext implements CommitterInitContext {
 
     private final TablePath tablePath;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/event/FinishTieringEvent.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/event/FinishTieringEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.event;
+
+import org.apache.flink.api.connector.source.SourceEvent;
+
+/** Event for mark a table as tiering finished. */
+public class FinishTieringEvent implements SourceEvent {
+
+    private static final long serialVersionUID = 1L;
+
+    private final long tableId;
+
+    public FinishTieringEvent(long tableId) {
+        this.tableId = tableId;
+    }
+
+    public long getTableId() {
+        return tableId;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/event/FinishTieringEvent.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/event/FinishTieringEvent.java
@@ -18,7 +18,7 @@ package com.alibaba.fluss.flink.tiering.event;
 
 import org.apache.flink.api.connector.source.SourceEvent;
 
-/** Event for mark a table as tiering finished. */
+/** SourceEvent used to represent a Fluss table has been tiered finished. */
 public class FinishTieringEvent implements SourceEvent {
 
     private static final long serialVersionUID = 1L;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResult.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResult.java
@@ -38,6 +38,7 @@ public class TableBucketWriteResult<WriteResult> implements Serializable {
 
     private final TableBucket tableBucket;
 
+    // will be null when no any data write, such as for tiering a empty log split
     @Nullable private final WriteResult writeResult;
 
     // the end offset of tiering, should be the last tiered record's offset + 1

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResult.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResult.java
@@ -26,8 +26,9 @@ import java.io.Serializable;
 
 /**
  * This class contains the {@link WriteResult} of {@link LakeWriter}, the table path and the bucket
- * that the write result is for, the end log offset of tiering. It'll be passed to downstream
- * operators to collect all the write results of a table and do commit.
+ * that the write result is for, the end log offset of tiering, the total number of write results in
+ * one round of tiering. It'll be passed to downstream committer operator to collect all the write
+ * results of a table and do commit.
  */
 public class TableBucketWriteResult<WriteResult> implements Serializable {
 
@@ -42,15 +43,22 @@ public class TableBucketWriteResult<WriteResult> implements Serializable {
     // the end offset of tiering, should be the last tiered record's offset + 1
     private final long logEndOffset;
 
+    // the total number of write results in one round of tiering,
+    // used for downstream commiter operator to determine when all write results
+    // for the round of tiering is finished
+    private final int numberOfWriteResults;
+
     public TableBucketWriteResult(
             TablePath tablePath,
             TableBucket tableBucket,
             @Nullable WriteResult writeResult,
-            long logEndOffset) {
+            long logEndOffset,
+            int numberOfWriteResults) {
         this.tablePath = tablePath;
         this.tableBucket = tableBucket;
         this.writeResult = writeResult;
         this.logEndOffset = logEndOffset;
+        this.numberOfWriteResults = numberOfWriteResults;
     }
 
     public TablePath tablePath() {
@@ -64,6 +72,10 @@ public class TableBucketWriteResult<WriteResult> implements Serializable {
     @Nullable
     public WriteResult writeResult() {
         return writeResult;
+    }
+
+    public int numberOfWriteResults() {
+        return numberOfWriteResults;
     }
 
     public long logEndOffset() {

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResultSerializer.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResultSerializer.java
@@ -83,6 +83,9 @@ public class TableBucketWriteResultSerializer<WriteResult>
         // serialize log end offset
         out.writeLong(tableBucketWriteResult.logEndOffset());
 
+        // serialize number of write results
+        out.writeInt(tableBucketWriteResult.numberOfWriteResults());
+
         final byte[] result = out.getCopyOfBuffer();
         out.clear();
         return result;
@@ -122,6 +125,9 @@ public class TableBucketWriteResultSerializer<WriteResult>
 
         // deserialize log end offset
         long logEndOffset = in.readLong();
-        return new TableBucketWriteResult<>(tablePath, tableBucket, writeResult, logEndOffset);
+        // deserialize number of write results
+        int numberOfWriteResults = in.readInt();
+        return new TableBucketWriteResult<>(
+                tablePath, tableBucket, writeResult, logEndOffset, numberOfWriteResults);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringLogSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringLogSplit.java
@@ -43,7 +43,7 @@ public class TieringLogSplit extends TieringSplit {
                 partitionName,
                 startingOffset,
                 stoppingOffset,
-                UNKNOW_NUMBER_OF_SPLITS);
+                UNKNOWN_NUMBER_OF_SPLITS);
     }
 
     public TieringLogSplit(

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringLogSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringLogSplit.java
@@ -37,7 +37,23 @@ public class TieringLogSplit extends TieringSplit {
             @Nullable String partitionName,
             long startingOffset,
             long stoppingOffset) {
-        super(tablePath, tableBucket, partitionName);
+        this(
+                tablePath,
+                tableBucket,
+                partitionName,
+                startingOffset,
+                stoppingOffset,
+                UNKNOW_NUMBER_OF_SPLITS);
+    }
+
+    public TieringLogSplit(
+            TablePath tablePath,
+            TableBucket tableBucket,
+            @Nullable String partitionName,
+            long startingOffset,
+            long stoppingOffset,
+            int numberOfSplits) {
+        super(tablePath, tableBucket, partitionName, numberOfSplits);
         this.startingOffset = startingOffset;
         this.stoppingOffset = stoppingOffset;
     }
@@ -69,7 +85,20 @@ public class TieringLogSplit extends TieringSplit {
                 + startingOffset
                 + ", stoppingOffset="
                 + stoppingOffset
+                + ", numberOfSplits="
+                + numberOfSplits
                 + '}';
+    }
+
+    @Override
+    public TieringLogSplit copy(int numberOfSplits) {
+        return new TieringLogSplit(
+                tablePath,
+                tableBucket,
+                partitionName,
+                startingOffset,
+                stoppingOffset,
+                numberOfSplits);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSnapshotSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSnapshotSplit.java
@@ -43,7 +43,19 @@ public class TieringSnapshotSplit extends TieringSplit {
             @Nullable String partitionName,
             long snapshotId,
             long logOffsetOfSnapshot) {
-        super(tablePath, tableBucket, partitionName);
+        super(tablePath, tableBucket, partitionName, UNKNOW_NUMBER_OF_SPLITS);
+        this.snapshotId = snapshotId;
+        this.logOffsetOfSnapshot = logOffsetOfSnapshot;
+    }
+
+    public TieringSnapshotSplit(
+            TablePath tablePath,
+            TableBucket tableBucket,
+            @Nullable String partitionName,
+            long snapshotId,
+            long logOffsetOfSnapshot,
+            int numberOfSplits) {
+        super(tablePath, tableBucket, partitionName, numberOfSplits);
         this.snapshotId = snapshotId;
         this.logOffsetOfSnapshot = logOffsetOfSnapshot;
     }
@@ -75,7 +87,20 @@ public class TieringSnapshotSplit extends TieringSplit {
                 + snapshotId
                 + ", logOffsetOfSnapshot="
                 + logOffsetOfSnapshot
+                + ", numberOfSplits="
+                + numberOfSplits
                 + '}';
+    }
+
+    @Override
+    public TieringSnapshotSplit copy(int numberOfSplits) {
+        return new TieringSnapshotSplit(
+                tablePath,
+                tableBucket,
+                partitionName,
+                snapshotId,
+                logOffsetOfSnapshot,
+                numberOfSplits);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSnapshotSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSnapshotSplit.java
@@ -43,7 +43,7 @@ public class TieringSnapshotSplit extends TieringSplit {
             @Nullable String partitionName,
             long snapshotId,
             long logOffsetOfSnapshot) {
-        super(tablePath, tableBucket, partitionName, UNKNOW_NUMBER_OF_SPLITS);
+        super(tablePath, tableBucket, partitionName, UNKNOWN_NUMBER_OF_SPLITS);
         this.snapshotId = snapshotId;
         this.logOffsetOfSnapshot = logOffsetOfSnapshot;
     }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplit.java
@@ -31,12 +31,20 @@ public abstract class TieringSplit implements SourceSplit {
     public static final byte TIERING_SNAPSHOT_SPLIT_FLAG = 1;
     public static final byte TIERING_LOG_SPLIT_FLAG = 2;
 
+    protected static final int UNKNOW_NUMBER_OF_SPLITS = -1;
+
     protected final TablePath tablePath;
     protected final TableBucket tableBucket;
     @Nullable protected final String partitionName;
 
+    // the total number of splits in one round of tiering
+    protected final int numberOfSplits;
+
     public TieringSplit(
-            TablePath tablePath, TableBucket tableBucket, @Nullable String partitionName) {
+            TablePath tablePath,
+            TableBucket tableBucket,
+            @Nullable String partitionName,
+            int numberOfSplits) {
         this.tablePath = tablePath;
         this.tableBucket = tableBucket;
         this.partitionName = partitionName;
@@ -45,6 +53,7 @@ public abstract class TieringSplit implements SourceSplit {
             throw new IllegalArgumentException(
                     "Partition name and partition id must be both null or both not null.");
         }
+        this.numberOfSplits = numberOfSplits;
     }
 
     /** Checks whether this split is a primary key table split to tier. */
@@ -77,6 +86,10 @@ public abstract class TieringSplit implements SourceSplit {
         }
     }
 
+    public int getNumberOfSplits() {
+        return numberOfSplits;
+    }
+
     protected static String toSplitId(String splitPrefix, TableBucket tableBucket) {
         if (tableBucket.getPartitionId() != null) {
             return splitPrefix
@@ -103,6 +116,8 @@ public abstract class TieringSplit implements SourceSplit {
         return partitionName;
     }
 
+    public abstract TieringSplit copy(int numberOfSplits);
+
     @Override
     public boolean equals(Object object) {
         if (!(object instanceof TieringSplit)) {
@@ -111,11 +126,12 @@ public abstract class TieringSplit implements SourceSplit {
         TieringSplit that = (TieringSplit) object;
         return Objects.equals(tablePath, that.tablePath)
                 && Objects.equals(tableBucket, that.tableBucket)
-                && Objects.equals(partitionName, that.partitionName);
+                && Objects.equals(partitionName, that.partitionName)
+                && numberOfSplits == that.numberOfSplits;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tablePath, tableBucket, partitionName);
+        return Objects.hash(tablePath, tableBucket, partitionName, numberOfSplits);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplit.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplit.java
@@ -31,7 +31,7 @@ public abstract class TieringSplit implements SourceSplit {
     public static final byte TIERING_SNAPSHOT_SPLIT_FLAG = 1;
     public static final byte TIERING_LOG_SPLIT_FLAG = 2;
 
-    protected static final int UNKNOW_NUMBER_OF_SPLITS = -1;
+    protected static final int UNKNOWN_NUMBER_OF_SPLITS = -1;
 
     protected final TablePath tablePath;
     protected final TableBucket tableBucket;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitGenerator.java
@@ -19,7 +19,7 @@ package com.alibaba.fluss.flink.tiering.source.split;
 import com.alibaba.fluss.client.admin.Admin;
 import com.alibaba.fluss.client.metadata.KvSnapshots;
 import com.alibaba.fluss.client.metadata.LakeSnapshot;
-import com.alibaba.fluss.exception.UnknownServerException;
+import com.alibaba.fluss.exception.LakeTableSnapshotNotExistException;
 import com.alibaba.fluss.flink.source.enumerator.initializer.BucketOffsetsRetrieverImpl;
 import com.alibaba.fluss.flink.source.enumerator.initializer.OffsetsInitializer.BucketOffsetsRetriever;
 import com.alibaba.fluss.metadata.PartitionInfo;
@@ -68,9 +68,7 @@ public class TieringSplitGenerator {
             LOG.info("Last committed lake table snapshot info is:{}", lakeSnapshotInfo);
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
-            if (t instanceof UnknownServerException
-                    && t.getMessage().contains("LakeTableSnapshotNotExistException")) {
-                // TODO: we can improve here without judging by specific exception int the future
+            if (t instanceof LakeTableSnapshotNotExistException) {
                 lakeSnapshotInfo = null;
             } else {
                 throw new FlinkRuntimeException(

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitSerializer.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitSerializer.java
@@ -73,6 +73,8 @@ public class TieringSplitSerializer implements SimpleVersionedSerializer<Tiering
             out.writeBoolean(false);
         }
 
+        // write number of splits
+        out.writeInt(split.getNumberOfSplits());
         if (split.isTieringSnapshotSplit()) {
             // Snapshot split
             TieringSnapshotSplit tieringSnapshotSplit = split.asTieringSnapshotSplit();
@@ -123,20 +125,33 @@ public class TieringSplitSerializer implements SimpleVersionedSerializer<Tiering
         }
         TableBucket tableBucket = new TableBucket(tableId, partitionId, bucketId);
 
+        // deserialize number of splits
+        int numberOfSplits = in.readInt();
+
         if (splitKind == TIERING_SNAPSHOT_SPLIT_FLAG) {
             // deserialize snapshot id
             long snapshotId = in.readLong();
             // deserialize log offset of snapshot
             long logOffsetOfSnapshot = in.readLong();
             return new TieringSnapshotSplit(
-                    tablePath, tableBucket, partitionName, snapshotId, logOffsetOfSnapshot);
+                    tablePath,
+                    tableBucket,
+                    partitionName,
+                    snapshotId,
+                    logOffsetOfSnapshot,
+                    numberOfSplits);
         } else {
             // deserialize starting offset
             long startingOffset = in.readLong();
             // deserialize starting offset
             long stoppingOffset = in.readLong();
             return new TieringLogSplit(
-                    tablePath, tableBucket, partitionName, startingOffset, stoppingOffset);
+                    tablePath,
+                    tableBucket,
+                    partitionName,
+                    startingOffset,
+                    stoppingOffset,
+                    numberOfSplits);
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/state/TieringSplitState.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/state/TieringSplitState.java
@@ -43,7 +43,8 @@ public class TieringSplitState {
                     split.getTableBucket(),
                     split.getPartitionName(),
                     split.getSnapshotId(),
-                    split.getLogOffsetOfSnapshot());
+                    split.getLogOffsetOfSnapshot(),
+                    split.getNumberOfSplits());
         } else {
             final TieringLogSplit split = (TieringLogSplit) tieringSplit;
             return new TieringLogSplit(
@@ -51,7 +52,8 @@ public class TieringSplitState {
                     split.getTableBucket(),
                     split.getPartitionName(),
                     split.getStartingOffset(),
-                    split.getStoppingOffset());
+                    split.getStoppingOffset(),
+                    split.getNumberOfSplits());
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/TestingWriteResult.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/TestingWriteResult.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.alibaba.fluss.flink.tiering.source;
+package com.alibaba.fluss.flink.tiering;
 
 /** A WriteResult for testing purpose. */
 public class TestingWriteResult {

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessageTypeInfoTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/CommittableMessageTypeInfoTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import org.apache.flink.api.common.typeutils.TypeInformationTestBase;
+
+/** Test for {@link CommittableMessageTypeInfo}. */
+class CommittableMessageTypeInfoTest
+        extends TypeInformationTestBase<CommittableMessageTypeInfo<?>> {
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    protected CommittableMessageTypeInfo<?>[] getTestData() {
+        return new CommittableMessageTypeInfo[] {
+            (CommittableMessageTypeInfo)
+                    CommittableMessageTypeInfo.of(TestingCommittableSerializer::new)
+        };
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/TestingCommittable.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/TestingCommittable.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import java.io.Serializable;
+import java.util.List;
+
+/** A committable for testing purpose. */
+public class TestingCommittable implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final List<Integer> writeResults;
+
+    public TestingCommittable(List<Integer> writeResults) {
+        this.writeResults = writeResults;
+    }
+
+    public List<Integer> writeResults() {
+        return writeResults;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/committer/TieringCommitOperatorTest.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2025 Alibaba Group Holding Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.alibaba.fluss.flink.tiering.committer;
+
+import com.alibaba.fluss.client.metadata.LakeSnapshot;
+import com.alibaba.fluss.exception.LakeTableSnapshotNotExistException;
+import com.alibaba.fluss.flink.tiering.TestingLakeTieringFactory;
+import com.alibaba.fluss.flink.tiering.TestingWriteResult;
+import com.alibaba.fluss.flink.tiering.source.TableBucketWriteResult;
+import com.alibaba.fluss.flink.utils.FlinkTestBase;
+import com.alibaba.fluss.metadata.TableBucket;
+import com.alibaba.fluss.metadata.TablePath;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
+import org.apache.flink.streaming.api.operators.StreamOperatorParameters;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.runtime.tasks.SourceOperatorStreamTask;
+import org.apache.flink.streaming.util.MockOutput;
+import org.apache.flink.streaming.util.MockStreamConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.alibaba.fluss.record.TestData.DATA1_PARTITIONED_TABLE_DESCRIPTOR;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** UT for {@link TieringCommitOperator}. */
+class TieringCommitOperatorTest extends FlinkTestBase {
+
+    private TieringCommitOperator<TestingWriteResult, TestingCommittable> committerOperator;
+
+    @BeforeEach
+    void beforeEach() throws Exception {
+        StreamOperatorParameters<CommittableMessage<TestingCommittable>> parameters =
+                new StreamOperatorParameters<>(
+                        new SourceOperatorStreamTask<String>(new DummyEnvironment()),
+                        new MockStreamConfig(new Configuration(), 1),
+                        new MockOutput<>(new ArrayList<>()),
+                        null,
+                        null,
+                        null);
+
+        committerOperator =
+                new TieringCommitOperator<>(
+                        parameters,
+                        FLUSS_CLUSTER_EXTENSION.getClientConfig(),
+                        new TestingLakeTieringFactory());
+        committerOperator.open();
+    }
+
+    @AfterEach
+    void afterEach() throws Exception {
+        committerOperator.close();
+    }
+
+    @Test
+    void testCommitNonPartitionedTable() throws Exception {
+        TablePath tablePath1 = TablePath.of("fluss", "test1");
+        TablePath tablePath2 = TablePath.of("fluss", "test2");
+
+        long tableId1 = createTable(tablePath1, DEFAULT_PK_TABLE_DESCRIPTOR);
+        long tableId2 = createTable(tablePath2, DEFAULT_PK_TABLE_DESCRIPTOR);
+        int numberOfWriteResults = 3;
+
+        // table1, bucket 0
+        TableBucket t1b0 = new TableBucket(tableId1, 0);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath1, t1b0, 1, 11, numberOfWriteResults));
+        // table1, bucket 1
+        TableBucket t1b1 = new TableBucket(tableId1, 1);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath1, t1b1, 2, 12, numberOfWriteResults));
+        verifyNoLakeSnapshot(tablePath1);
+
+        // table2, bucket0
+        TableBucket t2b0 = new TableBucket(tableId2, 0);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath2, t2b0, 1, 21, numberOfWriteResults));
+
+        // table2, bucket1
+        TableBucket t2b1 = new TableBucket(tableId2, 1);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath2, t2b1, 2, 22, numberOfWriteResults));
+        verifyNoLakeSnapshot(tablePath2);
+
+        // add table1, bucket2
+        TableBucket t1b2 = new TableBucket(tableId1, 2);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath1, t1b2, 3, 13, numberOfWriteResults));
+        // verify lake snapshot
+        Map<TableBucket, Long> expectedLogEndOffsets = new HashMap<>();
+        expectedLogEndOffsets.put(t1b0, 11L);
+        expectedLogEndOffsets.put(t1b1, 12L);
+        expectedLogEndOffsets.put(t1b2, 13L);
+        verifyLakeSnapshot(tablePath1, 0, expectedLogEndOffsets);
+
+        // add table2, bucket2
+        TableBucket t2b2 = new TableBucket(tableId2, 2);
+        committerOperator.processElement(
+                createTableBucketWriteResultStreamRecord(
+                        tablePath2, t2b2, 4, 23, numberOfWriteResults));
+        expectedLogEndOffsets = new HashMap<>();
+        expectedLogEndOffsets.put(t2b0, 21L);
+        expectedLogEndOffsets.put(t2b1, 22L);
+        expectedLogEndOffsets.put(t2b2, 23L);
+        verifyLakeSnapshot(tablePath2, 0, expectedLogEndOffsets);
+
+        // let's process one round of TableBucketWriteResult again
+        expectedLogEndOffsets = new HashMap<>();
+        for (int bucket = 0; bucket < 3; bucket++) {
+            TableBucket tableBucket = new TableBucket(tableId1, bucket);
+            long offset = bucket * bucket;
+            committerOperator.processElement(
+                    createTableBucketWriteResultStreamRecord(
+                            tablePath1, tableBucket, bucket, offset, numberOfWriteResults));
+            expectedLogEndOffsets.put(tableBucket, offset);
+        }
+        verifyLakeSnapshot(tablePath1, 0, expectedLogEndOffsets);
+    }
+
+    @Test
+    void testCommitPartitionedTable() throws Exception {
+        TablePath tablePath = TablePath.of("fluss", "partitioned_table");
+        long tableId = createTable(tablePath, DATA1_PARTITIONED_TABLE_DESCRIPTOR);
+        Map<String, Long> partitionIdByNames =
+                FLUSS_CLUSTER_EXTENSION.waitUntilPartitionAllReady(tablePath);
+        Map<TableBucket, Long> expectedLogEndOffsets = new HashMap<>();
+        int numberOfWriteResults = 3 * partitionIdByNames.size();
+        long offset = 0;
+        for (int bucket = 0; bucket < 3; bucket++) {
+            for (Map.Entry<String, Long> partitionIdAndNameEntry : partitionIdByNames.entrySet()) {
+                long partitionId = partitionIdAndNameEntry.getValue();
+                TableBucket tableBucket = new TableBucket(tableId, partitionId, bucket);
+                long currentOffset = offset++;
+                committerOperator.processElement(
+                        createTableBucketWriteResultStreamRecord(
+                                tablePath, tableBucket, 1, currentOffset, numberOfWriteResults));
+                expectedLogEndOffsets.put(tableBucket, currentOffset);
+            }
+            if (bucket == 2) {
+                verifyLakeSnapshot(tablePath, 0, expectedLogEndOffsets);
+            } else {
+                verifyNoLakeSnapshot(tablePath);
+            }
+        }
+    }
+
+    private StreamRecord<TableBucketWriteResult<TestingWriteResult>>
+            createTableBucketWriteResultStreamRecord(
+                    TablePath tablePath,
+                    TableBucket tableBucket,
+                    int writeResult,
+                    long logEndOffset,
+                    int numberOfWriteResults) {
+        TableBucketWriteResult<TestingWriteResult> tableBucketWriteResult =
+                new TableBucketWriteResult<>(
+                        tablePath,
+                        tableBucket,
+                        new TestingWriteResult(writeResult),
+                        logEndOffset,
+                        numberOfWriteResults);
+        return new StreamRecord<>(tableBucketWriteResult);
+    }
+
+    private void verifyNoLakeSnapshot(TablePath tablePath) {
+        assertThatThrownBy(() -> admin.getLatestLakeSnapshot(tablePath).get())
+                .cause()
+                .isInstanceOf(LakeTableSnapshotNotExistException.class);
+    }
+
+    private void verifyLakeSnapshot(
+            TablePath tablePath,
+            long expectedSnapshotId,
+            Map<TableBucket, Long> expectedLogEndOffsets)
+            throws Exception {
+        LakeSnapshot lakeSnapshot = admin.getLatestLakeSnapshot(tablePath).get();
+        assertThat(lakeSnapshot.getSnapshotId()).isEqualTo(expectedSnapshotId);
+        assertThat(lakeSnapshot.getTableBucketsOffset()).isEqualTo(expectedLogEndOffsets);
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResultSerializerTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/TableBucketWriteResultSerializerTest.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.flink.tiering.source;
 
+import com.alibaba.fluss.flink.tiering.TestingWriteResult;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
 
@@ -40,7 +41,7 @@ class TableBucketWriteResultSerializerTest {
         TableBucket tableBucket =
                 isPartitioned ? new TableBucket(1, 2) : new TableBucket(1, 1000L, 2);
         TableBucketWriteResult<TestingWriteResult> tableBucketWriteResult =
-                new TableBucketWriteResult<>(tablePath, tableBucket, testingWriteResult, 10);
+                new TableBucketWriteResult<>(tablePath, tableBucket, testingWriteResult, 10, 20);
 
         // test serialize and deserialize
         byte[] serialized = tableBucketWriteResultSerializer.serialize(tableBucketWriteResult);
@@ -54,9 +55,10 @@ class TableBucketWriteResultSerializerTest {
         assertThat(deserializedWriteResult).isNotNull();
         assertThat(deserializedWriteResult.getWriteResult())
                 .isEqualTo(testingWriteResult.getWriteResult());
+        assertThat(deserialized.numberOfWriteResults()).isEqualTo(20);
 
         // verify when writeResult is null
-        tableBucketWriteResult = new TableBucketWriteResult<>(tablePath, tableBucket, null, 20);
+        tableBucketWriteResult = new TableBucketWriteResult<>(tablePath, tableBucket, null, 20, 30);
         serialized = tableBucketWriteResultSerializer.serialize(tableBucketWriteResult);
         deserialized =
                 tableBucketWriteResultSerializer.deserialize(
@@ -64,5 +66,6 @@ class TableBucketWriteResultSerializerTest {
         assertThat(deserialized.tablePath()).isEqualTo(tablePath);
         assertThat(deserialized.tableBucket()).isEqualTo(tableBucket);
         assertThat(deserialized.writeResult()).isNull();
+        assertThat(deserialized.numberOfWriteResults()).isEqualTo(30);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/TieringSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/TieringSplitReaderTest.java
@@ -21,6 +21,8 @@ import com.alibaba.fluss.client.table.writer.AppendWriter;
 import com.alibaba.fluss.client.table.writer.TableWriter;
 import com.alibaba.fluss.client.table.writer.UpsertWriter;
 import com.alibaba.fluss.client.write.HashBucketAssigner;
+import com.alibaba.fluss.flink.tiering.TestingLakeTieringFactory;
+import com.alibaba.fluss.flink.tiering.TestingWriteResult;
 import com.alibaba.fluss.flink.tiering.source.split.TieringLogSplit;
 import com.alibaba.fluss.flink.tiering.source.split.TieringSnapshotSplit;
 import com.alibaba.fluss.flink.tiering.source.split.TieringSplit;
@@ -322,13 +324,13 @@ class TieringSplitReaderTest extends FlinkTestBase {
             long startingOffset,
             long stoppingOffset) {
         TableBucket tableBucket = new TableBucket(tableId, bucket);
-        return new TieringLogSplit(tablePath, tableBucket, null, startingOffset, stoppingOffset);
+        return new TieringLogSplit(tablePath, tableBucket, null, startingOffset, stoppingOffset, 3);
     }
 
     private TieringSnapshotSplit createSnapshotSplit(
             TablePath tablePath, long tableId, int bucket, long snapshotId) {
         TableBucket tableBucket = new TableBucket(tableId, bucket);
-        return new TieringSnapshotSplit(tablePath, tableBucket, null, snapshotId, 10);
+        return new TieringSnapshotSplit(tablePath, tableBucket, null, snapshotId, 10, 3);
     }
 
     private Map<TableBucket, List<InternalRow>> putRows(long tableId, TablePath tablePath, int rows)

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitSerializerTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/split/TieringSplitSerializerTest.java
@@ -44,7 +44,7 @@ class TieringSplitSerializerTest {
         TablePath path = isPartitionedTable ? partitionedTablePath : tablePath;
         String partitionName = isPartitionedTable ? "1024" : null;
         TieringSnapshotSplit tieringSplit =
-                new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L);
+                new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L, 10);
 
         byte[] serialized = serializer.serialize(tieringSplit);
         TieringSnapshotSplit deserializedSplit =
@@ -62,14 +62,14 @@ class TieringSplitSerializerTest {
                 isPartitionedTable
                         ? "tiering-snapshot-split-1-p100-2"
                         : "tiering-snapshot-split-1-2";
-        assertThat(new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L).splitId())
+        assertThat(new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L, 20).splitId())
                 .isEqualTo(expectedSplitId);
 
         String expectedSplitString =
                 isPartitionedTable
-                        ? "TieringSnapshotSplit{tablePath=test_db.test_partitioned_table, tableBucket=TableBucket{tableId=1, partitionId=100, bucket=2}, partitionName='1024', snapshotId=0, logOffsetOfSnapshot=200}"
-                        : "TieringSnapshotSplit{tablePath=test_db.test_table, tableBucket=TableBucket{tableId=1, bucket=2}, partitionName='null', snapshotId=0, logOffsetOfSnapshot=200}";
-        assertThat(new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L).toString())
+                        ? "TieringSnapshotSplit{tablePath=test_db.test_partitioned_table, tableBucket=TableBucket{tableId=1, partitionId=100, bucket=2}, partitionName='1024', snapshotId=0, logOffsetOfSnapshot=200, numberOfSplits=30}"
+                        : "TieringSnapshotSplit{tablePath=test_db.test_table, tableBucket=TableBucket{tableId=1, bucket=2}, partitionName='null', snapshotId=0, logOffsetOfSnapshot=200, numberOfSplits=30}";
+        assertThat(new TieringSnapshotSplit(path, bucket, partitionName, 0L, 200L, 30).toString())
                 .isEqualTo(expectedSplitString);
     }
 
@@ -79,7 +79,8 @@ class TieringSplitSerializerTest {
         TableBucket bucket = isPartitionedTable ? partitionedTableBucket : tableBucket;
         TablePath path = isPartitionedTable ? partitionedTablePath : tablePath;
         String partitionName = isPartitionedTable ? "1024" : null;
-        TieringLogSplit tieringSplit = new TieringLogSplit(path, bucket, partitionName, 100, 200);
+        TieringLogSplit tieringSplit =
+                new TieringLogSplit(path, bucket, partitionName, 100, 200, 40);
 
         byte[] serialized = serializer.serialize(tieringSplit);
         TieringLogSplit deserializedSplit =
@@ -95,14 +96,14 @@ class TieringSplitSerializerTest {
         String partitionName = isPartitionedTable ? "1024" : null;
         String expectedSplitId =
                 isPartitionedTable ? "tiering-log-split-1-p100-2" : "tiering-log-split-1-2";
-        assertThat(new TieringLogSplit(path, bucket, partitionName, 100, 200).splitId())
+        assertThat(new TieringLogSplit(path, bucket, partitionName, 100, 200, 3).splitId())
                 .isEqualTo(expectedSplitId);
 
         String expectedSplitString =
                 isPartitionedTable
-                        ? "TieringLogSplit{tablePath=test_db.test_partitioned_table, tableBucket=TableBucket{tableId=1, partitionId=100, bucket=2}, partitionName='1024', startingOffset=100, stoppingOffset=200}"
-                        : "TieringLogSplit{tablePath=test_db.test_table, tableBucket=TableBucket{tableId=1, bucket=2}, partitionName='null', startingOffset=100, stoppingOffset=200}";
-        assertThat(new TieringLogSplit(path, bucket, partitionName, 100, 200).toString())
+                        ? "TieringLogSplit{tablePath=test_db.test_partitioned_table, tableBucket=TableBucket{tableId=1, partitionId=100, bucket=2}, partitionName='1024', startingOffset=100, stoppingOffset=200, numberOfSplits=2}"
+                        : "TieringLogSplit{tablePath=test_db.test_table, tableBucket=TableBucket{tableId=1, bucket=2}, partitionName='null', startingOffset=100, stoppingOffset=200, numberOfSplits=2}";
+        assertThat(new TieringLogSplit(path, bucket, partitionName, 100, 200, 2).toString())
                 .isEqualTo(expectedSplitString);
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/state/TieringSplitStateTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/tiering/source/state/TieringSplitStateTest.java
@@ -35,7 +35,7 @@ class TieringSplitStateTest {
 
         // verify conversion between TieringSnapshotSplitState and TieringSnapshotSplit
         TieringSnapshotSplit tieringSnapshotSplit =
-                new TieringSnapshotSplit(tablePath, tableBucket, "partition1", 0L, 200L);
+                new TieringSnapshotSplit(tablePath, tableBucket, "partition1", 0L, 200L, 10);
         TieringSplitState tieringSnapshotSplitState = new TieringSplitState(tieringSnapshotSplit);
         assertThat(tieringSnapshotSplitState.toSourceSplit()).isEqualTo(tieringSnapshotSplit);
     }
@@ -47,7 +47,7 @@ class TieringSplitStateTest {
 
         // verify conversion between TieringLogSplitState and TieringLogSplit
         TieringLogSplit tieringLogSplit =
-                new TieringLogSplit(tablePath, tableBucket, "partition1", 100L, 200L);
+                new TieringLogSplit(tablePath, tableBucket, "partition1", 100L, 200L, 20);
         TieringSplitState tieringLogSplitState = new TieringSplitState(tieringLogSplit);
         assertThat(tieringLogSplitState.toSourceSplit()).isEqualTo(tieringLogSplit);
     }

--- a/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/com/alibaba/fluss/rpc/protocol/Errors.java
@@ -42,6 +42,7 @@ import com.alibaba.fluss.exception.InvalidUpdateVersionException;
 import com.alibaba.fluss.exception.KvSnapshotNotExistException;
 import com.alibaba.fluss.exception.KvStorageException;
 import com.alibaba.fluss.exception.LakeStorageNotConfiguredException;
+import com.alibaba.fluss.exception.LakeTableSnapshotNotExistException;
 import com.alibaba.fluss.exception.LeaderNotAvailableException;
 import com.alibaba.fluss.exception.LogOffsetOutOfRangeException;
 import com.alibaba.fluss.exception.LogStorageException;
@@ -210,7 +211,9 @@ public enum Errors {
             "Authentication failed with retriable exception. ",
             RetriableAuthenticationException::new),
     INVALID_SERVER_RACK_INFO_EXCEPTION(
-            52, "The server rack info is invalid.", InvalidServerRackInfoException::new);
+            52, "The server rack info is invalid.", InvalidServerRackInfoException::new),
+    LAKE_SNAPSHOT_NOT_EXIST(
+            53, "The lake snapshot is not exist.", LakeTableSnapshotNotExistException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-test-coverage/pom.xml
+++ b/fluss-test-coverage/pom.xml
@@ -347,6 +347,8 @@
                                         <exclude>com.alibaba.fluss.flink.tiering.source.TieringSourceReader</exclude>
                                         <exclude>com.alibaba.fluss.flink.tiering.source.TableBucketWriteResultEmitter</exclude>
                                         <exclude>com.alibaba.fluss.flink.tiering.source.TableBucketWriteResultTypeInfo*</exclude>
+                                        <exclude>com.alibaba.fluss.flink.tiering.committer.TieringCommitOperatorFactory</exclude>
+                                        <exclude>com.alibaba.fluss.flink.tiering.committer.CommittableMessageTypeInfo*</exclude>
                                         <!-- end exclude for flink tiering service -->
                                     </excludes>
                                 </rule>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #876 

<!-- What is the purpose of the change -->
Introduce a Flink committer operator to collect all `WriteResult`s emitted of a table in one round of tiering,  and then commit to lake & fluss.

### Brief change log

1. Introduce `numberOfWriteResults` in `TableBucketWriteResult`, so that the committer operator can know when collect how many write results, it can commit to lake.
In one round of tiering for a table, source enumerator will generate a series of splits, each split will generate a `TableBucketWriteResult`, so that committer operator can know when one round of tiering of a table is finished.
2. Introduce Flink operator `LakeTieringCommitOperator` to collect `TableBucketWriteResult` to commit to lake
3. Considering in `LakeTieringCommitOperator`, we will need to notify to enumerator that some tables has been finish one round of tiering, we introduce `LakeTieringCommitOperatorFactory` to register `OperatorEventGateway` to send event to source enumerator. Although not used in this pr, but in the following pr. So introduce in here.
 

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->
LakeTieringCommitOperatorTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
