### PR TITLE
[server] Re-register server-node when ZkClient is session expired

### DIFF
--- a/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/coordinator/CoordinatorServer.java
@@ -42,6 +42,7 @@ import com.alibaba.fluss.server.metrics.group.CoordinatorMetricGroup;
 import com.alibaba.fluss.server.zk.ZooKeeperClient;
 import com.alibaba.fluss.server.zk.ZooKeeperUtils;
 import com.alibaba.fluss.server.zk.data.CoordinatorAddress;
+import com.alibaba.fluss.shaded.zookeeper3.org.apache.zookeeper.KeeperException;
 import com.alibaba.fluss.utils.ExceptionUtils;
 import com.alibaba.fluss.utils.ExecutorUtils;
 import com.alibaba.fluss.utils.concurrent.ExecutorThreadFactory;
@@ -53,6 +54,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -204,6 +206,7 @@ public class CoordinatorServer extends ServerBase {
             rpcServer.start();
 
             registerCoordinatorLeader();
+            registerZookeeperClientReconnectedListener();
 
             this.clientMetricGroup = new ClientMetricGroup(metricRegistry, SERVER_NAME);
             this.rpcClient = RpcClient.create(conf, clientMetricGroup);
@@ -280,6 +283,47 @@ public class CoordinatorServer extends ServerBase {
                 new CoordinatorAddress(
                         this.serverId, Endpoint.loadAdvertisedEndpoints(bindEndpoints, conf));
         zkClient.registerCoordinatorLeader(coordinatorAddress);
+    }
+
+    private void registerZookeeperClientReconnectedListener() {
+        ZooKeeperUtils.registerZookeeperClientReInitSessionListener(
+                zkClient,
+                () -> {
+                    // we need to retry to register since although
+                    // zkClient reconnect, the ephemeral node may still exist
+                    // for a while time, retry to wait the ephemeral node removed
+                    // see ZOOKEEPER-2985
+                    long startTime = System.currentTimeMillis();
+                    long retryWaitIntervalMs = Duration.ofSeconds(3).toMillis();
+                    long retryTotalWaitTimeMs = Duration.ofMinutes(1).toMillis();
+                    while (true) {
+                        try {
+                            this.registerCoordinatorLeader();
+                            break;
+                        } catch (KeeperException.NodeExistsException nodeExistsException) {
+                            long elapsedTime = System.currentTimeMillis() - startTime;
+                            if (elapsedTime >= retryTotalWaitTimeMs) {
+                                LOG.error(
+                                        "Coordinator Server register to Zookeeper exceeded total retry time of {} ms. "
+                                                + "Aborting registration attempts.",
+                                        retryTotalWaitTimeMs);
+                                throw nodeExistsException;
+                            }
+
+                            LOG.warn(
+                                    "Coordinator server already registered in Zookeeper. "
+                                            + "retrying register after {} ms....",
+                                    retryWaitIntervalMs);
+                            try {
+                                Thread.sleep(retryWaitIntervalMs);
+                            } catch (InterruptedException interruptedException) {
+                                Thread.currentThread().interrupt();
+                                break;
+                            }
+                        }
+                    }
+                },
+                this);
     }
 
     private void createDefaultDatabase() {

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/tablet/TabletServer.java
@@ -246,6 +246,9 @@ public class TabletServer extends ServerBase {
             rpcServer.start();
 
             registerTabletServer();
+            // when init session, register tablet server again
+            ZooKeeperUtils.registerZookeeperClientReInitSessionListener(
+                    zkClient, this::registerTabletServer, this);
         }
     }
 

--- a/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/com/alibaba/fluss/server/zk/ZooKeeperClient.java
@@ -783,7 +783,7 @@ public class ZooKeeperClient implements AutoCloseable {
     public Optional<Stat> getStat(String path) throws Exception {
         try {
             Stat stat = zkClient.checkExists().forPath(path);
-            return Optional.of(stat);
+            return Optional.ofNullable(stat);
         } catch (KeeperException.NoNodeException e) {
             return Optional.empty();
         }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1000 

<!-- What is the purpose of the change -->

### Brief change log
To re-register server node when zkClient is session expired

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
