### PR TITLE
[Website] Fix responsiveness of button group on landing page

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -20,51 +20,49 @@
  */
 
 .heroBanner {
-  padding: 5rem 0 11rem 0;
-  text-align: center;
-  position: relative;
-  overflow: hidden;
-  margin-left: -1px;
+    padding: 5rem 0 11rem 0;
+    text-align: center;
+    position: relative;
+    overflow: hidden;
+    margin-left: -1px;
 
-  @media screen and (min-width: 997px) {
-    background: url("@site/static/img/background.jpg");
-    background-size: cover;
-  }
+    @media screen and (min-width: 997px) {
+        background: url("@site/static/img/background.jpg");
+        background-size: cover;
+    }
 
-  @media screen and (max-width: 996px) {
-    background: var(--ifm-color-primary-darkest);
-  }
+    @media screen and (max-width: 996px) {
+        background: var(--ifm-color-primary-darkest);
+    }
 
 }
 
 @media screen and (max-width: 996px) {
-  .heroBanner {
-    padding: 2rem;
-  }
+    .heroBanner {
+        padding: 2rem;
+    }
 }
 
 .buttons {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+    gap: 20px;
 }
 
-.join_slack_button {
-  margin-left: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.buttonWidth {
+    width: 200px;
 }
 
-.github_button {
-  margin-left: 20px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+.buttonWithIcon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
 .buttonIcon {
-  margin-right: 8px;
-  width: 20px;
-  height: 20px;
+    margin-right: 8px;
+    width: 20px;
+    height: 20px;
 }

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -25,59 +25,59 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 function HomepageHeader() {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-    <header className={clsx('hero hero--primary', styles.heroBanner)}>
-      <div className="container">
-        <Heading as="h1" className="hero__title">
-          {siteConfig.title}
-        </Heading>
-        <p className="hero__subtitle">{siteConfig.tagline}</p>
-        <div className={styles.buttons}>
-          <Link
-            className="hero_button button button--primary button--lg"
-            to="/docs/quickstart/flink">
-            Quick Start
-          </Link>
+    const {siteConfig} = useDocusaurusContext();
+    return (
+        <header className={clsx('hero hero--primary', styles.heroBanner)}>
+            <div className="container">
+                <Heading as="h1" className="hero__title">
+                    {siteConfig.title}
+                </Heading>
+                <p className="hero__subtitle">{siteConfig.tagline}</p>
+                <div className={styles.buttons}>
+                    <Link
+                        className={clsx("hero_button button button--primary button--lg", styles.buttonWidth)}
+                        to="/docs/quickstart/flink">
+                        Quick Start
+                    </Link>
 
-          <Link
-              className={clsx("button button--secondary button--lg", styles.github_button)}
-              to="https://github.com/alibaba/fluss">
-            <img
-                src="img/github_icon.svg"
-                alt="GitHub"
-                className={styles.buttonIcon}
-            />
-            GitHub
-          </Link>
+                    <Link
+                        className={clsx("button button--secondary button--lg", styles.buttonWithIcon, styles.buttonWidth)}
+                        to="https://github.com/alibaba/fluss">
+                        <img
+                            src="img/github_icon.svg"
+                            alt="GitHub"
+                            className={styles.buttonIcon}
+                        />
+                        GitHub
+                    </Link>
 
-          <Link
-              className={clsx("button button--secondary button--lg", styles.join_slack_button)}
-              to="https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw">
-            <img
-                src="img/slack_icon.svg"
-                alt="Slack"
-                className={styles.buttonIcon}
-            />
-            Slack
-          </Link>
-        </div>
-      </div>
-    </header>
-  );
+                    <Link
+                        className={clsx("button button--secondary button--lg", styles.buttonWithIcon, styles.buttonWidth)}
+                        to="https://join.slack.com/t/fluss-hq/shared_invite/zt-33wlna581-QAooAiCmnYboJS8D_JUcYw">
+                        <img
+                            src="img/slack_icon.svg"
+                            alt="Slack"
+                            className={styles.buttonIcon}
+                        />
+                        Slack
+                    </Link>
+                </div>
+            </div>
+        </header>
+    );
 }
 
 export default function Home(): JSX.Element {
-  const {siteConfig} = useDocusaurusContext();
-  return (
-    <Layout
-      title="Fluss"
-      description="Streaming Storage for Real-Time Analytics">
-      <HomepageHeader />
-      <main>
-        <HomepageIntroduce />
-        <HomepageFeatures />
-      </main>
-    </Layout>
-  );
+    const {siteConfig} = useDocusaurusContext();
+    return (
+        <Layout
+            title="Fluss"
+            description="Streaming Storage for Real-Time Analytics">
+            <HomepageHeader/>
+            <main>
+                <HomepageIntroduce/>
+                <HomepageFeatures/>
+            </main>
+        </Layout>
+    );
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: n/a

<!-- What is the purpose of the change -->

The button group on the landing page (quick start, github, slack) is not responsive and overflows on small screen resolutions (e.g., on mobile phones).

Example on an iPhone 12 Pro (note that the quick start and Slack button are cut off on the left and right hand side, respectively).

![overflow-iphone12pro](https://github.com/user-attachments/assets/0f2f1413-c618-4587-ba5f-2717524ddfc8)


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Make button fixed and same size
- Wrap when display resolution gets too small
- Remove redundant code

**Examples**

iPhone 12 Pro

![fixed-iphone12-pro](https://github.com/user-attachments/assets/551a7dc4-ab1d-4df2-a9aa-ded8e525c207)

600x750

![fixed-600x750](https://github.com/user-attachments/assets/dfd3b886-1e4a-4f99-b2f6-36c4da3623e1)


### Tests

<!-- List UT and IT cases to verify this change -->

n/a

### API and Format

<!-- Does this change affect API or storage format -->

n/a

### Documentation

<!-- Does this change introduce a new feature -->

n/a