### PR TITLE
[Lake/paimon] Tiering for multi partition paimon table

### DIFF
--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -126,6 +126,12 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba.fluss</groupId>
+            <artifactId>fluss-common</artifactId>
+            <version>0.7-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 
 

--- a/fluss-lake/fluss-lake-paimon/pom.xml
+++ b/fluss-lake/fluss-lake-paimon/pom.xml
@@ -126,12 +126,6 @@
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>com.alibaba.fluss</groupId>
-            <artifactId>fluss-common</artifactId>
-            <version>0.7-SNAPSHOT</version>
-            <scope>compile</scope>
-        </dependency>
     </dependencies>
 
 

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRow.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRow.java
@@ -27,31 +27,42 @@ import org.apache.paimon.data.InternalRow;
 import org.apache.paimon.data.Timestamp;
 import org.apache.paimon.types.RowKind;
 
+import javax.annotation.Nullable;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 import static com.alibaba.fluss.lake.paimon.utils.PaimonConversions.toRowKind;
 
 /** To wrap Fluss {@link LogRecord} as paimon {@link InternalRow}. */
 public class FlussRecordAsPaimonRow implements InternalRow {
 
     private final int bucket;
+    private final List<String> partitionKeys;
+    private final int partitionFieldCount;
+
     private LogRecord logRecord;
     private int originRowFieldCount;
     private com.alibaba.fluss.row.InternalRow internalRow;
+    private Map<String, String> partitionValues;
 
-    public FlussRecordAsPaimonRow(int bucket) {
+    public FlussRecordAsPaimonRow(int bucket, List<String> partitionKeys) {
         this.bucket = bucket;
+        this.partitionKeys = partitionKeys;
+        this.partitionFieldCount = partitionKeys.size();
     }
 
-    public void setFlussRecord(LogRecord logRecord) {
+    public void setFlussRecord(LogRecord logRecord, @Nullable String partitionString) {
         this.logRecord = logRecord;
         this.internalRow = logRecord.getRow();
         this.originRowFieldCount = internalRow.getFieldCount();
+        this.partitionValues = parsePartitionString(partitionString);
     }
 
     @Override
     public int getFieldCount() {
-        return
-        // three system fields: bucket, offset, timestamp
-        originRowFieldCount + 3;
+        return originRowFieldCount + partitionFieldCount + 3; // business + partition + system
     }
 
     @Override
@@ -67,93 +78,141 @@ public class FlussRecordAsPaimonRow implements InternalRow {
     @Override
     public boolean isNullAt(int pos) {
         if (pos < originRowFieldCount) {
-            return internalRow.isNullAt(pos);
+            return internalRow.isNullAt(pos); // Business fields
+        } else if (pos < originRowFieldCount + partitionFieldCount) {
+            return getPartitionValue(pos) == null; // Partition fields
+        } else {
+            return false; // System fields (never null)
         }
-        // is the last three system fields: bucket, offset, timestamp which are never null
-        return false;
     }
 
     @Override
     public boolean getBoolean(int pos) {
-        return internalRow.getBoolean(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getBoolean(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not boolean");
+        }
     }
 
     @Override
     public byte getByte(int pos) {
-        return internalRow.getByte(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getByte(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not byte");
+        }
     }
 
     @Override
     public short getShort(int pos) {
-        return internalRow.getShort(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getShort(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not short");
+        }
     }
 
     @Override
     public int getInt(int pos) {
-        if (pos == originRowFieldCount) {
-            // bucket system column
-            return bucket;
+        if (pos < originRowFieldCount) {
+            return internalRow.getInt(pos); // Business fields
+        } else if (pos < originRowFieldCount + partitionFieldCount) {
+            throw new UnsupportedOperationException("Partition fields are strings, not ints");
+        } else if (pos == originRowFieldCount + partitionFieldCount) {
+            return bucket; // System field: bucket
+        } else {
+            throw new UnsupportedOperationException("Invalid field position for int: " + pos);
         }
-        return internalRow.getInt(pos);
     }
 
     @Override
     public long getLong(int pos) {
-        if (pos == originRowFieldCount + 1) {
-            //  offset system column
-            return logRecord.logOffset();
-        } else if (pos == originRowFieldCount + 2) {
-            //  timestamp system column
-            return logRecord.timestamp();
+        if (pos < originRowFieldCount) {
+            return internalRow.getLong(pos); // Business fields
+        } else if (pos < originRowFieldCount + partitionFieldCount) {
+            throw new UnsupportedOperationException("Partition fields are strings, not longs");
+        } else if (pos == originRowFieldCount + partitionFieldCount + 1) {
+            return logRecord.logOffset(); // System field: offset
+        } else if (pos == originRowFieldCount + partitionFieldCount + 2) {
+            return logRecord.timestamp(); // System field: timestamp
+        } else {
+            throw new UnsupportedOperationException("Invalid field position for long: " + pos);
         }
-        //  the origin RowData
-        return internalRow.getLong(pos);
     }
 
     @Override
     public float getFloat(int pos) {
-        return internalRow.getFloat(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getFloat(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not float");
+        }
     }
 
     @Override
     public double getDouble(int pos) {
-        return internalRow.getDouble(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getDouble(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not double");
+        }
     }
 
     @Override
     public BinaryString getString(int pos) {
-        return BinaryString.fromBytes(internalRow.getString(pos).toBytes());
+        if (pos < originRowFieldCount) {
+            return BinaryString.fromBytes(internalRow.getString(pos).toBytes()); // Business fields
+        } else if (pos < originRowFieldCount + partitionFieldCount) {
+            String partitionValue = getPartitionValue(pos); // Partition fields
+            return partitionValue != null ? BinaryString.fromString(partitionValue) : null;
+        } else {
+            throw new UnsupportedOperationException("System fields are not strings");
+        }
     }
 
     @Override
     public Decimal getDecimal(int pos, int precision, int scale) {
-        com.alibaba.fluss.row.Decimal flussDecimal = internalRow.getDecimal(pos, precision, scale);
-        if (flussDecimal.isCompact()) {
-            return Decimal.fromUnscaledLong(flussDecimal.toUnscaledLong(), precision, scale);
+        if (pos < originRowFieldCount) {
+            com.alibaba.fluss.row.Decimal flussDecimal =
+                    internalRow.getDecimal(pos, precision, scale);
+            if (flussDecimal.isCompact()) {
+                return Decimal.fromUnscaledLong(flussDecimal.toUnscaledLong(), precision, scale);
+            } else {
+                return Decimal.fromBigDecimal(flussDecimal.toBigDecimal(), precision, scale);
+            }
         } else {
-            return Decimal.fromBigDecimal(flussDecimal.toBigDecimal(), precision, scale);
+            throw new UnsupportedOperationException("Partition and system fields are not decimal");
         }
     }
 
     @Override
     public Timestamp getTimestamp(int pos, int precision) {
-        // it's timestamp system column
-        if (pos == originRowFieldCount + 2) {
-            return Timestamp.fromEpochMillis(logRecord.timestamp());
-        }
-        if (TimestampLtz.isCompact(precision)) {
-            return Timestamp.fromEpochMillis(
-                    internalRow.getTimestampLtz(pos, precision).getEpochMillisecond());
+        if (pos < originRowFieldCount) {
+            if (TimestampLtz.isCompact(precision)) {
+                return Timestamp.fromEpochMillis(
+                        internalRow.getTimestampLtz(pos, precision).getEpochMillisecond());
+            } else {
+                TimestampLtz timestampLtz = internalRow.getTimestampLtz(pos, precision);
+                return Timestamp.fromEpochMillis(
+                        timestampLtz.getEpochMillisecond(), timestampLtz.getNanoOfMillisecond());
+            }
+        } else if (pos < originRowFieldCount + partitionFieldCount) {
+            throw new UnsupportedOperationException("Partition fields are not timestamp");
+        } else if (pos == originRowFieldCount + partitionFieldCount + 2) {
+            return Timestamp.fromEpochMillis(logRecord.timestamp()); // System field: timestamp
         } else {
-            TimestampLtz timestampLtz = internalRow.getTimestampLtz(pos, precision);
-            return Timestamp.fromEpochMillis(
-                    timestampLtz.getEpochMillisecond(), timestampLtz.getNanoOfMillisecond());
+            throw new UnsupportedOperationException("Invalid field position for timestamp: " + pos);
         }
     }
 
     @Override
     public byte[] getBinary(int pos) {
-        return internalRow.getBytes(pos);
+        if (pos < originRowFieldCount) {
+            return internalRow.getBytes(pos);
+        } else {
+            throw new UnsupportedOperationException("Partition and system fields are not binary");
+        }
     }
 
     @Override
@@ -172,5 +231,40 @@ public class FlussRecordAsPaimonRow implements InternalRow {
     public InternalRow getRow(int pos, int pos1) {
         throw new UnsupportedOperationException(
                 "getRow is not support for Fluss record currently.");
+    }
+
+    private String getPartitionValue(int pos) {
+        int partitionIndex = pos - originRowFieldCount;
+        if (partitionIndex >= 0 && partitionIndex < partitionKeys.size()) {
+            String partitionKey = partitionKeys.get(partitionIndex);
+            return partitionValues.get(partitionKey);
+        }
+        return null;
+    }
+
+    private Map<String, String> parsePartitionString(@Nullable String partitionString) {
+        Map<String, String> values = new LinkedHashMap<>();
+
+        if (partitionString == null || partitionKeys.isEmpty()) {
+            return values;
+        }
+
+        if (partitionKeys.size() == 1) {
+            // Single partition: entire string is the value
+            values.put(partitionKeys.get(0), partitionString);
+        } else {
+            // Multi-partition: parse "key1=value1/key2=value2"
+            String[] parts = partitionString.split("/");
+            for (String part : parts) {
+                String[] keyValue = part.split("=", 2);
+                if (keyValue.length == 2) {
+                    String key = keyValue[0].trim();
+                    String value = keyValue[1].trim();
+                    values.put(key, value);
+                }
+            }
+        }
+
+        return values;
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/PaimonLakeWriter.java
@@ -28,6 +28,7 @@ import org.apache.paimon.table.FileStoreTable;
 import org.apache.paimon.table.sink.CommitMessage;
 
 import java.io.IOException;
+import java.util.List;
 
 import static com.alibaba.fluss.lake.paimon.utils.PaimonConversions.toPaimon;
 
@@ -43,16 +44,20 @@ public class PaimonLakeWriter implements LakeWriter<PaimonWriteResult> {
         this.paimonCatalog = paimonCatalogProvider.get();
         FileStoreTable fileStoreTable = getTable(writerInitContext.tablePath());
 
+        List<String> partitionKeys = fileStoreTable.partitionKeys();
+
         this.recordWriter =
                 fileStoreTable.primaryKeys().isEmpty()
                         ? new AppendOnlyWriter(
                                 fileStoreTable,
                                 writerInitContext.tableBucket(),
-                                writerInitContext.partition())
+                                writerInitContext.partition(),
+                                partitionKeys)
                         : new MergeTreeWriter(
                                 fileStoreTable,
                                 writerInitContext.tableBucket(),
-                                writerInitContext.partition());
+                                writerInitContext.partition(),
+                                partitionKeys);
     }
 
     @Override

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/RecordWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/RecordWriter.java
@@ -36,7 +36,6 @@ public abstract class RecordWriter<T> implements AutoCloseable {
     protected final TableWriteImpl<T> tableWrite;
     protected final int bucket;
     @Nullable protected final BinaryRow partition;
-    @Nullable protected final String partitionString;
     protected final FlussRecordAsPaimonRow flussRecordAsPaimonRow;
 
     public RecordWriter(
@@ -47,9 +46,7 @@ public abstract class RecordWriter<T> implements AutoCloseable {
         this.tableWrite = tableWrite;
         this.bucket = tableBucket.getBucket();
         this.partition = toPaimonPartitionBinaryRow(partitionKeys, partition);
-        this.partitionString = partition; // Store for FlussRecordAsPaimonRow
-        this.flussRecordAsPaimonRow =
-                new FlussRecordAsPaimonRow(tableBucket.getBucket(), partitionKeys);
+        this.flussRecordAsPaimonRow = new FlussRecordAsPaimonRow(tableBucket.getBucket());
     }
 
     public abstract void write(LogRecord record) throws Exception;

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
@@ -26,25 +26,31 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+
 import static com.alibaba.fluss.lake.paimon.tiering.PaimonLakeTieringFactory.FLUSS_LAKE_TIERING_COMMIT_USER;
 
 /** A {@link RecordWriter} to write to Paimon's append-only table. */
 public class AppendOnlyWriter extends RecordWriter<InternalRow> {
 
     public AppendOnlyWriter(
-            FileStoreTable fileStoreTable, TableBucket tableBucket, @Nullable String partition) {
+            FileStoreTable fileStoreTable,
+            TableBucket tableBucket,
+            @Nullable String partition,
+            List<String> partitionKeys) {
         //noinspection unchecked
         super(
                 (TableWriteImpl<InternalRow>)
                         // todo: set ioManager to support write-buffer-spillable
                         fileStoreTable.newWrite(FLUSS_LAKE_TIERING_COMMIT_USER),
                 tableBucket,
-                partition);
+                partition,
+                partitionKeys);
     }
 
     @Override
     public void write(LogRecord record) throws Exception {
-        flussRecordAsPaimonRow.setFlussRecord(record);
+        flussRecordAsPaimonRow.setFlussRecord(record, partitionString);
         // hacky, call internal method tableWrite.getWrite() to support
         // to write to given partition, otherwise, it'll always extract a partition from Paimon row
         // which may be costly

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
@@ -41,6 +41,7 @@ public class AppendOnlyWriter extends RecordWriter<InternalRow> {
         //noinspection unchecked
         super(
                 (TableWriteImpl<InternalRow>)
+                        // todo: set ioManager to support write-buffer-spillable
                         fileStoreTable.newWrite(FLUSS_LAKE_TIERING_COMMIT_USER),
                 tableBucket,
                 partition,

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/append/AppendOnlyWriter.java
@@ -41,16 +41,15 @@ public class AppendOnlyWriter extends RecordWriter<InternalRow> {
         //noinspection unchecked
         super(
                 (TableWriteImpl<InternalRow>)
-                        // todo: set ioManager to support write-buffer-spillable
                         fileStoreTable.newWrite(FLUSS_LAKE_TIERING_COMMIT_USER),
                 tableBucket,
                 partition,
-                partitionKeys);
+                partitionKeys); // Pass to parent
     }
 
     @Override
     public void write(LogRecord record) throws Exception {
-        flussRecordAsPaimonRow.setFlussRecord(record, partitionString);
+        flussRecordAsPaimonRow.setFlussRecord(record);
         // hacky, call internal method tableWrite.getWrite() to support
         // to write to given partition, otherwise, it'll always extract a partition from Paimon row
         // which may be costly

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
@@ -27,6 +27,8 @@ import org.apache.paimon.table.sink.TableWriteImpl;
 
 import javax.annotation.Nullable;
 
+import java.util.List;
+
 import static com.alibaba.fluss.lake.paimon.tiering.PaimonLakeTieringFactory.FLUSS_LAKE_TIERING_COMMIT_USER;
 import static com.alibaba.fluss.lake.paimon.utils.PaimonConversions.toRowKind;
 
@@ -38,8 +40,11 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
     private final RowKeyExtractor rowKeyExtractor;
 
     public MergeTreeWriter(
-            FileStoreTable fileStoreTable, TableBucket tableBucket, @Nullable String partition) {
-        super(createTableWrite(fileStoreTable), tableBucket, partition);
+            FileStoreTable fileStoreTable,
+            TableBucket tableBucket,
+            @Nullable String partition,
+            List<String> partitionKeys) {
+        super(createTableWrite(fileStoreTable), tableBucket, partition, partitionKeys);
         this.rowKeyExtractor = fileStoreTable.createRowKeyExtractor();
     }
 
@@ -50,7 +55,7 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
 
     @Override
     public void write(LogRecord record) throws Exception {
-        flussRecordAsPaimonRow.setFlussRecord(record);
+        flussRecordAsPaimonRow.setFlussRecord(record, partitionString);
         rowKeyExtractor.setRecord(flussRecordAsPaimonRow);
         keyValue.replace(
                 rowKeyExtractor.trimmedPrimaryKey(),

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/tiering/mergetree/MergeTreeWriter.java
@@ -55,7 +55,7 @@ public class MergeTreeWriter extends RecordWriter<KeyValue> {
 
     @Override
     public void write(LogRecord record) throws Exception {
-        flussRecordAsPaimonRow.setFlussRecord(record, partitionString);
+        flussRecordAsPaimonRow.setFlussRecord(record);
         rowKeyExtractor.setRecord(flussRecordAsPaimonRow);
         keyValue.replace(
                 rowKeyExtractor.trimmedPrimaryKey(),

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
@@ -28,7 +28,6 @@ import org.apache.paimon.types.RowKind;
 
 import javax.annotation.Nullable;
 
-import java.util.Arrays;
 import java.util.List;
 
 /** Utils for conversion between Paimon and Fluss. */
@@ -77,9 +76,5 @@ public class PaimonConversions {
 
         writer.complete();
         return partitionBinaryRow;
-    }
-
-    public static BinaryRow toPaimonBinaryRow(@Nullable String value) {
-        return toPaimonPartitionBinaryRow(Arrays.asList("partition"), value);
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.fluss.lake.paimon.utils;
 
+import com.alibaba.fluss.metadata.ResolvedPartitionSpec;
 import com.alibaba.fluss.metadata.TablePath;
 import com.alibaba.fluss.record.ChangeType;
 
@@ -28,9 +29,7 @@ import org.apache.paimon.types.RowKind;
 import javax.annotation.Nullable;
 
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 
 /** Utils for conversion between Paimon and Fluss. */
 public class PaimonConversions {
@@ -55,75 +54,31 @@ public class PaimonConversions {
         return Identifier.create(tablePath.getDatabaseName(), tablePath.getTableName());
     }
 
-    // NEW METHOD: Handle multiple partitions
     public static BinaryRow toPaimonPartitionBinaryRow(
             List<String> partitionKeys, @Nullable String partitionName) {
         if (partitionName == null || partitionKeys.isEmpty()) {
             return BinaryRow.EMPTY_ROW;
         }
 
-        // Parse partition specification manually
-        Map<String, String> partitionSpec = parsePartitionName(partitionKeys, partitionName);
+        //  Fluss's existing utility
+        ResolvedPartitionSpec resolvedPartitionSpec =
+                ResolvedPartitionSpec.fromPartitionName(partitionKeys, partitionName);
 
         BinaryRow partitionBinaryRow = new BinaryRow(partitionKeys.size());
         BinaryRowWriter writer = new BinaryRowWriter(partitionBinaryRow);
 
-        // Convert each partition field
+        List<String> partitionValues = resolvedPartitionSpec.getPartitionValues();
         for (int i = 0; i < partitionKeys.size(); i++) {
-            String partitionKey = partitionKeys.get(i);
-            String partitionValue = partitionSpec.get(partitionKey);
-
-            if (partitionValue == null) {
-                writer.setNullAt(i);
-            } else {
-                writer.writeString(i, BinaryString.fromString(partitionValue));
-            }
+            // Todo Currently, partition column must be String datatype, so we can always use
+            // `BinaryString.fromString` to convert to Paimon's data structure. Revisit here when
+            // #489 is finished.
+            writer.writeString(i, BinaryString.fromString(partitionValues.get(i)));
         }
 
         writer.complete();
         return partitionBinaryRow;
     }
 
-    // Helper method to parse partition name manually
-    private static Map<String, String> parsePartitionName(
-            List<String> partitionKeys, String partitionName) {
-        Map<String, String> partitionSpec = new LinkedHashMap<>();
-
-        if (partitionKeys.size() == 1) {
-            // Simple case: single partition field, value is the entire string
-            partitionSpec.put(partitionKeys.get(0), partitionName);
-        } else {
-            // Multi-partition case: parse "key1=value1/key2=value2/..."
-            String[] parts = partitionName.split("/");
-            for (String part : parts) {
-                String[] keyValue = part.split("=", 2);
-                if (keyValue.length == 2) {
-                    String key = keyValue[0].trim();
-                    String value = keyValue[1].trim();
-                    partitionSpec.put(key, value);
-                } else {
-                    throw new IllegalArgumentException(
-                            "Invalid partition part: " + part + " in partition: " + partitionName);
-                }
-            }
-
-            // Validate that all required partition keys are present
-            for (String partitionKey : partitionKeys) {
-                if (!partitionSpec.containsKey(partitionKey)) {
-                    throw new IllegalArgumentException(
-                            "Missing partition key: "
-                                    + partitionKey
-                                    + " in partition: "
-                                    + partitionName);
-                }
-            }
-        }
-
-        return partitionSpec;
-    }
-
-    // Keeping old method for backward compatibility
-    @Deprecated
     public static BinaryRow toPaimonBinaryRow(@Nullable String value) {
         return toPaimonPartitionBinaryRow(Arrays.asList("partition"), value);
     }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/com/alibaba/fluss/lake/paimon/utils/PaimonConversions.java
@@ -27,6 +27,11 @@ import org.apache.paimon.types.RowKind;
 
 import javax.annotation.Nullable;
 
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 /** Utils for conversion between Paimon and Fluss. */
 public class PaimonConversions {
 
@@ -50,14 +55,76 @@ public class PaimonConversions {
         return Identifier.create(tablePath.getDatabaseName(), tablePath.getTableName());
     }
 
-    public static BinaryRow toPaimonBinaryRow(@Nullable String value) {
-        if (value == null) {
+    // NEW METHOD: Handle multiple partitions
+    public static BinaryRow toPaimonPartitionBinaryRow(
+            List<String> partitionKeys, @Nullable String partitionName) {
+        if (partitionName == null || partitionKeys.isEmpty()) {
             return BinaryRow.EMPTY_ROW;
         }
-        BinaryRow binaryRow = new BinaryRow(1);
-        BinaryRowWriter writer = new BinaryRowWriter(binaryRow);
-        writer.writeString(0, BinaryString.fromString(value));
+
+        // Parse partition specification manually
+        Map<String, String> partitionSpec = parsePartitionName(partitionKeys, partitionName);
+
+        BinaryRow partitionBinaryRow = new BinaryRow(partitionKeys.size());
+        BinaryRowWriter writer = new BinaryRowWriter(partitionBinaryRow);
+
+        // Convert each partition field
+        for (int i = 0; i < partitionKeys.size(); i++) {
+            String partitionKey = partitionKeys.get(i);
+            String partitionValue = partitionSpec.get(partitionKey);
+
+            if (partitionValue == null) {
+                writer.setNullAt(i);
+            } else {
+                writer.writeString(i, BinaryString.fromString(partitionValue));
+            }
+        }
+
         writer.complete();
-        return binaryRow;
+        return partitionBinaryRow;
+    }
+
+    // Helper method to parse partition name manually
+    private static Map<String, String> parsePartitionName(
+            List<String> partitionKeys, String partitionName) {
+        Map<String, String> partitionSpec = new LinkedHashMap<>();
+
+        if (partitionKeys.size() == 1) {
+            // Simple case: single partition field, value is the entire string
+            partitionSpec.put(partitionKeys.get(0), partitionName);
+        } else {
+            // Multi-partition case: parse "key1=value1/key2=value2/..."
+            String[] parts = partitionName.split("/");
+            for (String part : parts) {
+                String[] keyValue = part.split("=", 2);
+                if (keyValue.length == 2) {
+                    String key = keyValue[0].trim();
+                    String value = keyValue[1].trim();
+                    partitionSpec.put(key, value);
+                } else {
+                    throw new IllegalArgumentException(
+                            "Invalid partition part: " + part + " in partition: " + partitionName);
+                }
+            }
+
+            // Validate that all required partition keys are present
+            for (String partitionKey : partitionKeys) {
+                if (!partitionSpec.containsKey(partitionKey)) {
+                    throw new IllegalArgumentException(
+                            "Missing partition key: "
+                                    + partitionKey
+                                    + " in partition: "
+                                    + partitionName);
+                }
+            }
+        }
+
+        return partitionSpec;
+    }
+
+    // Keeping old method for backward compatibility
+    @Deprecated
+    public static BinaryRow toPaimonBinaryRow(@Nullable String value) {
+        return toPaimonPartitionBinaryRow(Arrays.asList("partition"), value);
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
@@ -45,9 +45,7 @@ class FlussRecordAsPaimonRowTest {
     void testLogTableRecordAllTypes() {
         // Construct a FlussRecordAsPaimonRow instance
         int bucket = 0;
-        List<String> partitionKeys = Collections.emptyList(); // No partitions for this test
-        FlussRecordAsPaimonRow flussRecordAsPaimonRow =
-                new FlussRecordAsPaimonRow(bucket, partitionKeys);
+        FlussRecordAsPaimonRow flussRecordAsPaimonRow = new FlussRecordAsPaimonRow(bucket);
         long logOffset = 0;
         long timeStamp = System.currentTimeMillis();
         GenericRow genericRow = new GenericRow(14);
@@ -66,7 +64,7 @@ class FlussRecordAsPaimonRowTest {
         genericRow.setField(12, new byte[] {1, 2, 3, 4});
         genericRow.setField(13, null);
         LogRecord logRecord = new GenericRecord(logOffset, timeStamp, APPEND_ONLY, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord, null); // Pass null partition string
+        flussRecordAsPaimonRow.setFlussRecord(logRecord); // Pass null partition string
 
         // verify FlussRecordAsPaimonRow normal columns
         assertThat(flussRecordAsPaimonRow.getBoolean(0)).isTrue();
@@ -104,15 +102,14 @@ class FlussRecordAsPaimonRowTest {
     void testPrimaryKeyTableRecord() {
         int bucket = 0;
         List<String> partitionKeys = Collections.emptyList();
-        FlussRecordAsPaimonRow flussRecordAsPaimonRow =
-                new FlussRecordAsPaimonRow(bucket, partitionKeys);
+        FlussRecordAsPaimonRow flussRecordAsPaimonRow = new FlussRecordAsPaimonRow(bucket);
         long logOffset = 0;
         long timeStamp = System.currentTimeMillis();
         GenericRow genericRow = new GenericRow(1);
         genericRow.setField(0, true);
 
         LogRecord logRecord = new GenericRecord(logOffset, timeStamp, INSERT, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord, null);
+        flussRecordAsPaimonRow.setFlussRecord(logRecord);
 
         assertThat(flussRecordAsPaimonRow.getBoolean(0)).isTrue();
         // normal columns + system columns
@@ -121,15 +118,15 @@ class FlussRecordAsPaimonRowTest {
         assertThat(flussRecordAsPaimonRow.getRowKind()).isEqualTo(RowKind.INSERT);
 
         logRecord = new GenericRecord(logOffset, timeStamp, UPDATE_BEFORE, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord, null);
+        flussRecordAsPaimonRow.setFlussRecord(logRecord);
         assertThat(flussRecordAsPaimonRow.getRowKind()).isEqualTo(RowKind.UPDATE_BEFORE);
 
         logRecord = new GenericRecord(logOffset, timeStamp, UPDATE_AFTER, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord, null);
+        flussRecordAsPaimonRow.setFlussRecord(logRecord);
         assertThat(flussRecordAsPaimonRow.getRowKind()).isEqualTo(RowKind.UPDATE_AFTER);
 
         logRecord = new GenericRecord(logOffset, timeStamp, DELETE, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord, null);
+        flussRecordAsPaimonRow.setFlussRecord(logRecord);
         assertThat(flussRecordAsPaimonRow.getRowKind()).isEqualTo(RowKind.DELETE);
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
@@ -95,7 +95,7 @@ class FlussRecordAsPaimonRowTest {
         assertThat(flussRecordAsPaimonRow.getRowKind()).isEqualTo(RowKind.INSERT);
 
         assertThat(flussRecordAsPaimonRow.getFieldCount())
-                .isEqualTo(14 + 0 + 3); // business + partition + system = 14 + 0 + 3 = 17
+                .isEqualTo(14 + 3); // business  + system = 14 + 0 + 3 = 17
     }
 
     @Test

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/FlussRecordAsPaimonRowTest.java
@@ -28,8 +28,6 @@ import org.apache.paimon.types.RowKind;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
-import java.util.Collections;
-import java.util.List;
 
 import static com.alibaba.fluss.record.ChangeType.APPEND_ONLY;
 import static com.alibaba.fluss.record.ChangeType.DELETE;
@@ -64,7 +62,7 @@ class FlussRecordAsPaimonRowTest {
         genericRow.setField(12, new byte[] {1, 2, 3, 4});
         genericRow.setField(13, null);
         LogRecord logRecord = new GenericRecord(logOffset, timeStamp, APPEND_ONLY, genericRow);
-        flussRecordAsPaimonRow.setFlussRecord(logRecord); // Pass null partition string
+        flussRecordAsPaimonRow.setFlussRecord(logRecord);
 
         // verify FlussRecordAsPaimonRow normal columns
         assertThat(flussRecordAsPaimonRow.getBoolean(0)).isTrue();
@@ -101,7 +99,6 @@ class FlussRecordAsPaimonRowTest {
     @Test
     void testPrimaryKeyTableRecord() {
         int bucket = 0;
-        List<String> partitionKeys = Collections.emptyList();
         FlussRecordAsPaimonRow flussRecordAsPaimonRow = new FlussRecordAsPaimonRow(bucket);
         long logOffset = 0;
         long timeStamp = System.currentTimeMillis();

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
@@ -284,7 +284,7 @@ class PaimonTieringTest {
             throws Exception {
         for (LogRecord expectRecord : expectRecords) {
             InternalRow actualRow = actualRecords.next();
-            // check normal columns:
+            // check business columns:
             assertThat(actualRow.getInt(0)).isEqualTo(expectRecord.getRow().getInt(0));
             assertThat(actualRow.getString(1).toString())
                     .isEqualTo(expectRecord.getRow().getString(1).toString());
@@ -393,7 +393,7 @@ class PaimonTieringTest {
             throws Exception {
         for (LogRecord expectRecord : expectRecords) {
             InternalRow actualRow = actualRecords.next();
-            // check normal columns:
+            // check business columns:
             assertThat(actualRow.getInt(0)).isEqualTo(expectRecord.getRow().getInt(0));
             assertThat(actualRow.getString(1).toString())
                     .isEqualTo(expectRecord.getRow().getString(1).toString());


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #953

<!-- What is the purpose of the change -->

Implement multi-partition support for Paimon lake tiering to enable tables with multiple partition fields (e.g., region=us-east/year=2024/month=01) instead of only single partition support.

### Brief change log
<!-- Please describe the changes made in this pull request and explain how they address the issue -->

- Enhanced partition conversion logic: Added toPaimonPartitionBinaryRow() method in PaimonConversions to parse multi-partition strings and create correctly sized BinaryRow objects
- Redesigned row adapter: Modified FlussRecordAsPaimonRow to support dynamic field layout with business + partition + system fields, extracting partition values from metadata instead of record data
- Updated writer infrastructure: Enhanced RecordWriter, AppendOnlyWriter, MergeTreeWriter, and PaimonLakeWriter to pass partition schema information and handle multi-partition field mapping
- Fixed field index mapping: Implemented 3-tier field access routing (business fields from Fluss record, partition fields from metadata, system fields from record metadata)
- Maintained backward compatibility: Preserved existing single-partition functionality with deprecated methods

### Tests
<!-- List UT and IT cases to verify this change -->

- Enhanced existing tests: Modified testTieringWriteTable to support both partitioned and non-partitioned scenarios
- Added testMultiPartitionTiering: Tests 2-partition tables with region=us-east/year=2024 format
- Added testThreePartitionTiering: Tests 3-partition tables with region=us-east/year=2024/month=01 format
- Updated verification methods: Enhanced field validation to handle dynamic partition field counts
- Fixed test data generation: Aligned Fluss record field counts with actual table schemas

###  API and Format
<!-- Does this change affect API or storage format -->
API Changes:

Breaking: FlussRecordAsPaimonRow constructor now requires List<String> partitionKeys parameter
Breaking: setFlussRecord() method now requires String partitionString parameter
Breaking: Writer constructors now require List<String> partitionKeys parameter
Backward Compatible: Original toPaimonBinaryRow() method preserved (deprecated)

Storage Format:

No change: Paimon storage format remains unchanged
Schema compatible: Existing single-partition tables continue to work

### Documentation
<!-- Does this change introduce a new feature -->

New Feature: Multi-partition support for lake tiering

- Enables hierarchical partitioning schemes (e.g., time-based: year/month/day, geo-based: region/country/city)
- Supports standard Hive partition naming convention (key1=value1/key2=value2)