### PR TITLE
[flink] Use ordered set in PojoToRowConverter to make test stable

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/utils/PojoToRowConverter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/utils/PojoToRowConverter.java
@@ -22,7 +22,6 @@ import com.alibaba.fluss.row.GenericRow;
 import com.alibaba.fluss.row.InternalRow;
 import com.alibaba.fluss.row.TimestampLtz;
 import com.alibaba.fluss.row.TimestampNtz;
-import com.alibaba.fluss.shaded.guava32.com.google.common.collect.Sets;
 import com.alibaba.fluss.types.DataType;
 import com.alibaba.fluss.types.DataTypeRoot;
 import com.alibaba.fluss.types.DecimalType;
@@ -42,7 +41,9 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -74,27 +75,27 @@ public class PojoToRowConverter<T> {
     private static final Map<DataTypeRoot, Set<Class<?>>> SUPPORTED_TYPES = new HashMap<>();
 
     static {
-        SUPPORTED_TYPES.put(DataTypeRoot.BOOLEAN, Sets.newHashSet(Boolean.class, boolean.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.TINYINT, Sets.newHashSet(Byte.class, byte.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.SMALLINT, Sets.newHashSet(Short.class, short.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.INTEGER, Sets.newHashSet(Integer.class, int.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.BIGINT, Sets.newHashSet(Long.class, long.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.FLOAT, Sets.newHashSet(Float.class, float.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.DOUBLE, Sets.newHashSet(Double.class, double.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.BOOLEAN, orderedSet(Boolean.class, boolean.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.TINYINT, orderedSet(Byte.class, byte.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.SMALLINT, orderedSet(Short.class, short.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.INTEGER, orderedSet(Integer.class, int.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.BIGINT, orderedSet(Long.class, long.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.FLOAT, orderedSet(Float.class, float.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.DOUBLE, orderedSet(Double.class, double.class));
         SUPPORTED_TYPES.put(
-                DataTypeRoot.CHAR, Sets.newHashSet(String.class, Character.class, char.class));
+                DataTypeRoot.CHAR, orderedSet(String.class, Character.class, char.class));
         SUPPORTED_TYPES.put(
-                DataTypeRoot.STRING, Sets.newHashSet(String.class, Character.class, char.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.BINARY, Sets.newHashSet(byte[].class));
-        SUPPORTED_TYPES.put(DataTypeRoot.BYTES, Sets.newHashSet(byte[].class));
-        SUPPORTED_TYPES.put(DataTypeRoot.DECIMAL, Sets.newHashSet(BigDecimal.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.DATE, Sets.newHashSet(LocalDate.class));
-        SUPPORTED_TYPES.put(DataTypeRoot.TIME_WITHOUT_TIME_ZONE, Sets.newHashSet(LocalTime.class));
+                DataTypeRoot.STRING, orderedSet(String.class, Character.class, char.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.BINARY, orderedSet(byte[].class));
+        SUPPORTED_TYPES.put(DataTypeRoot.BYTES, orderedSet(byte[].class));
+        SUPPORTED_TYPES.put(DataTypeRoot.DECIMAL, orderedSet(BigDecimal.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.DATE, orderedSet(LocalDate.class));
+        SUPPORTED_TYPES.put(DataTypeRoot.TIME_WITHOUT_TIME_ZONE, orderedSet(LocalTime.class));
         SUPPORTED_TYPES.put(
-                DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, Sets.newHashSet(LocalDateTime.class));
+                DataTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, orderedSet(LocalDateTime.class));
         SUPPORTED_TYPES.put(
                 DataTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE,
-                Sets.newHashSet(Instant.class, OffsetDateTime.class));
+                orderedSet(Instant.class, OffsetDateTime.class));
         // Add more supported types as needed
 
     }
@@ -331,5 +332,20 @@ public class PojoToRowConverter<T> {
         }
 
         return row;
+    }
+
+    /**
+     * Utility method to create an ordered {@link LinkedHashSet} containing the specified Java type
+     * classes.
+     *
+     * <p>The returned set maintains the insertion order of the provided classes.
+     *
+     * @param javaTypes The Java type classes to include in the set. May be one or more classes.
+     * @return A new {@link LinkedHashSet} containing the given classes, preserving their order.
+     */
+    private static LinkedHashSet<Class<?>> orderedSet(Class<?>... javaTypes) {
+        LinkedHashSet<Class<?>> linkedHashSet = new LinkedHashSet<>();
+        linkedHashSet.addAll(Arrays.asList(javaTypes));
+        return linkedHashSet;
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/utils/PojoToRowConverterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/com/alibaba/fluss/flink/utils/PojoToRowConverterTest.java
@@ -234,7 +234,7 @@ public class PojoToRowConverterTest {
         assertThatThrownBy(() -> new PojoToRowConverter<>(ProductWithPrice.class, rowType))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessageContaining(
-                        "Field Java type class java.lang.Long for field id is not supported, the supported Java types are [int, class java.lang.Integer]");
+                        "Field Java type class java.lang.Long for field id is not supported, the supported Java types are [class java.lang.Integer, int]");
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
This PR is a minor improvement for PojoToRowConverterTest.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Use ordered set in PojoToRowConverter to make test stable, because the key order of HashSet is not predictable which make s the test unstable especially when we use different JDK versions.

### Tests

<!-- List UT and IT cases to verify this change -->
covered by PojoToRowConverterTest

### API and Format

<!-- Does this change affect API or storage format -->
no

### Documentation

<!-- Does this change introduce a new feature -->
no
