### PR TITLE
[hotfix] Adjust the writeBatch estimate logic to avoid buffer size always tending to decrease

### DIFF
--- a/fluss-client/src/main/java/com/alibaba/fluss/client/write/DynamicWriteBatchSizeEstimator.java
+++ b/fluss-client/src/main/java/com/alibaba/fluss/client/write/DynamicWriteBatchSizeEstimator.java
@@ -34,7 +34,7 @@ public class DynamicWriteBatchSizeEstimator {
 
     private static final Logger LOG = LoggerFactory.getLogger(DynamicWriteBatchSizeEstimator.class);
 
-    private static final double RATIO_TO_INCREASE_BATCH_SIZE = 0.9d;
+    private static final double RATIO_TO_INCREASE_BATCH_SIZE = 0.8d;
     private static final double RATIO_TO_DECREASE_BATCH_SIZE = 0.5d;
     private final int maxBatchSize;
     private final int pageSize;
@@ -63,18 +63,14 @@ public class DynamicWriteBatchSizeEstimator {
 
         int estimatedBatchSize =
                 estimatedBatchSizeMap.getOrDefault(physicalTablePath, maxBatchSize);
-        int newEstimatedBatchSize;
+        int newEstimatedBatchSize = estimatedBatchSize;
         if (observedBatchSize >= estimatedBatchSize
                 || observedBatchSize > estimatedBatchSize * RATIO_TO_INCREASE_BATCH_SIZE) {
-            // To increase 1%
+            // To increase 10%
             newEstimatedBatchSize = Math.min((int) (estimatedBatchSize * 1.1), maxBatchSize);
-        } else if (observedBatchSize < estimatedBatchSize * RATIO_TO_INCREASE_BATCH_SIZE
-                && observedBatchSize > estimatedBatchSize * RATIO_TO_DECREASE_BATCH_SIZE) {
+        } else if (observedBatchSize < estimatedBatchSize * RATIO_TO_DECREASE_BATCH_SIZE) {
             // To decrease 5%
-            newEstimatedBatchSize = Math.max((int) (estimatedBatchSize * 0.95), pageSize);
-        } else {
-            // To decrease 10%
-            newEstimatedBatchSize = Math.max((int) (estimatedBatchSize * 0.9), pageSize);
+            newEstimatedBatchSize = Math.max((int) (estimatedBatchSize * 0.95), 2 * pageSize);
         }
 
         estimatedBatchSizeMap.put(physicalTablePath, newEstimatedBatchSize);

--- a/fluss-client/src/test/java/com/alibaba/fluss/client/write/DynamicWriteBatchSizeEstimatorTest.java
+++ b/fluss-client/src/test/java/com/alibaba/fluss/client/write/DynamicWriteBatchSizeEstimatorTest.java
@@ -39,32 +39,36 @@ public class DynamicWriteBatchSizeEstimatorTest {
         assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(1000);
 
         estimator = new DynamicWriteBatchSizeEstimator(true, 1000, 100);
-        // test decrease 10%
-        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 450);
-        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(900);
-
         // test decrease 5%
-        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, (int) (900 * 0.9) - 10);
-        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(855);
-
-        // test increase 1%
-        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 852);
+        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 450);
+        int expectedSize = 950;
         assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH))
-                .isEqualTo((int) (855 * 1.1));
+                .isEqualTo(expectedSize);
+
+        // test increase 5%
+        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 350);
+        expectedSize = (int) (950 * 0.95);
+        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH))
+                .isEqualTo(expectedSize);
+
+        // test increase 10%
+        estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 930);
+        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH))
+                .isEqualTo((int) (expectedSize * 1.1));
     }
 
     @Test
     void testMinDecreaseToPageSize() {
         int estimatedSize = estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH);
         estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 1000);
-        while (estimatedSize > 100) {
+        while (estimatedSize > 2 * 100) {
             estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, (int) (estimatedSize * 0.5) - 10);
             estimatedSize = estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH);
         }
 
-        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(100);
+        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(200);
         estimator.updateEstimation(DATA1_PHYSICAL_TABLE_PATH, 0);
-        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(100);
+        assertThat(estimator.getEstimatedBatchSize(DATA1_PHYSICAL_TABLE_PATH)).isEqualTo(200);
     }
 
     @Test


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->

This is a hotfix to adjust the writeBatch estimate logic to avoid buffer size always tending to decrease

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
