### PR TITLE
[Website] Remove version from "Building Fluss from Source"

### DIFF
--- a/website/community/dev/building.md
+++ b/website/community/dev/building.md
@@ -23,9 +23,9 @@ title: Building Fluss
 
 # Building Fluss from Source
 
-This page covers how to build Fluss 0.6.0-SNAPSHOT from sources.
+This page covers how to build Fluss from sources.
 
-In order to build Fluss you need to get the source code by [clone the git repository](https://github.com/alibaba/fluss).
+In order to build Fluss you need to get the source code by [cloning the git repository](https://github.com/alibaba/fluss).
 
 In addition, you need **Maven 3.8.6** and a **JDK** (Java Development Kit). Fluss requires **Java 8 or Java 11** to build.
 
@@ -33,6 +33,18 @@ To clone from git, enter:
 
 ```bash
 git clone git@github.com:alibaba/fluss.git
+```
+
+If you want to build a specific release or release candidate, have a look at the existing tags using 
+
+```bash
+git tag -n
+```
+
+and checkout the corresponding branch using
+
+```bash
+git checkout <tag>
 ```
 
 The simplest way of building Fluss is by running:


### PR DESCRIPTION
NB: We cannot use the version placeholder, because the `Community` section is not versioned.