### PR TITLE
[doc]Without switching the query mode of FlinkSQL, an exception will be thrown when deleting data from the fluss primary key table

### DIFF
--- a/website/docs/table-design/table-types/pk-table/index.md
+++ b/website/docs/table-design/table-types/pk-table/index.md
@@ -153,12 +153,14 @@ SELECT * FROM T;
 
 Generate the following change data:
 
-```text
-+I(1, 2.0, 'apple')
--U(1, 2.0, 'apple')
-+U(1, 4.0, 'banana')
--D(1, 4.0, 'banana')
-```
+
+
+| op   | k    | v1   | v2     |
+| ---- | ---- | ---- | ------ |
+| +I   | 1    | 2.0  | apple  |
+| -U   | 1    | 2.0  | apple  |
+| +U   | 1    | 4.0  | banana |
+| -D   | 1    | 4.0  | banana |
 
 ## Data Queries
 


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx （请替换为你关联的 GitHub Issue 编号）

**What is the purpose of the change**:
https://alibaba.github.io/fluss-docs/docs/table-design/table-types/pk-table/
![dc8d31bae1f7be8987fee8ae78bbc6c](https://github.com/user-attachments/assets/3a506154-c188-4ae5-be6c-74ef08a5356e)
![83c43f3f46e8e9a5bf1ab74ad6929f2](https://github.com/user-attachments/assets/33bae61a-b809-43f0-8a84-32e90d522159)


### Brief change log

**Please describe the changes**:
1. Added an example of correct operation
2. Verified without any issues




### API and Format

**Does this change affect API or storage format**:
- [ ] 是  
- [x] 否  
本次修改仅调整了 SQL 查询语句和表结构定义，不影响对外 API 或数据存储格式。


### Documentation

**Does this change introduce a new feature**:
- [ ] 是  
- [x] 否  
本次修改是对现有功能的修复和优化，无需新增文档。