### PR TITLE
[doc]The DDL and DQL column names in the context do not match

### DIFF
--- a/website/docs/table-design/table-types/log-table.md
+++ b/website/docs/table-design/table-types/log-table.md
@@ -34,7 +34,8 @@ CREATE TABLE log_table (
   order_id BIGINT,
   item_id BIGINT,
   amount INT,
-  address STRING
+  address STRING,
+  `timestamp` DATE
 )
 WITH ('bucket.num' = '3');
 ```
@@ -75,10 +76,10 @@ During query execution, query engines like Flink analyzes the query to identify 
 For example the following streaming query:
 
 ```sql
-SELECT id, name FROM log_table WHERE timestamp > '2023-01-01';
+SELECT order_id, item_id FROM log_table WHERE timestamp > '2023-01-01';
 ```
 
-In this query, only the `id`, `name`, and `timestamp` columns are accessed. Other columns (e.g., `address`, `status`) are pruned and not read from storage.
+In this query, only the `order_id`, `item_id`, and `timestamp` columns are accessed. Other columns (e.g., `address`, `amount`) are pruned and not read from storage.
 
 
 ## Log Compression

--- a/website/docs/table-design/table-types/log-table.md
+++ b/website/docs/table-design/table-types/log-table.md
@@ -35,7 +35,7 @@ CREATE TABLE log_table (
   item_id BIGINT,
   amount INT,
   address STRING,
-  `timestamp` DATE
+  dt DATE
 )
 WITH ('bucket.num' = '3');
 ```
@@ -76,10 +76,10 @@ During query execution, query engines like Flink analyzes the query to identify 
 For example the following streaming query:
 
 ```sql
-SELECT order_id, item_id FROM log_table WHERE timestamp > '2023-01-01';
+SELECT order_id, item_id FROM log_table WHERE dt > '2023-01-01';
 ```
 
-In this query, only the `order_id`, `item_id`, and `timestamp` columns are accessed. Other columns (e.g., `address`, `amount`) are pruned and not read from storage.
+In this query, only the `order_id`, `item_id`, and `dt` columns are accessed. Other columns (e.g., `address`, `amount`) are pruned and not read from storage.
 
 
 ## Log Compression


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Fix the issue of mismatched DDL and DQL column names in the context, ensuring that the query statement is consistent with the table structure definition.


### Brief change log

**Please describe the changes**:
https://alibaba.github.io/fluss-docs/docs/table-design/table-types/log-table/
The DDL and DQL column names in the context do not match:
1. Added a 'timestamp' column in the DDL definition to ensure that the table structure includes a timestamp field.
2. Modified the 'SELECT' statement to explicitly specify the column names for the query:
-Original statement: ` SELECT * FROM log_table WHERE timestamp>'2023-01-01'; `
-New statement: ` SELECT order_i, item_id FROM log_table WHERE timestamp>'2023-01-01'; `
3. Optimized the description of query columns, clearly stating that only the 'order_id', 'item_id', and 'timestamp' columns are accessed, and other columns (such as' address' and 'amount') will be automatically pruned by the database and will not participate in storage and reading.
![1750813668440](https://github.com/user-attachments/assets/9e230f73-a2e2-450e-b216-0b807880713f)
![1750813681293](https://github.com/user-attachments/assets/b9a81b37-fc44-4357-8cef-5e4fb1b125f7)




### API and Format

**Does this change affect API or storage format**:
- [ ] 是  
- [x] 否  
本次修改仅调整了 SQL 查询语句和表结构定义，不影响对外 API 或数据存储格式。


### Documentation

**Does this change introduce a new feature**:
- [ ] 是  
- [x] 否  
本次修改是对现有功能的修复和优化，无需新增文档。