### PR TITLE
[connector] pass Fluss schema to lake writer

### DIFF
--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/writer/WriterInitContext.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/writer/WriterInitContext.java
@@ -55,5 +55,10 @@ public interface WriterInitContext {
     @Nullable
     String partition();
 
+    /**
+     * Returns the table schema.
+     *
+     * @return the table schema
+     */
     Schema schema();
 }

--- a/fluss-common/src/main/java/com/alibaba/fluss/lake/writer/WriterInitContext.java
+++ b/fluss-common/src/main/java/com/alibaba/fluss/lake/writer/WriterInitContext.java
@@ -18,6 +18,7 @@
 package com.alibaba.fluss.lake.writer;
 
 import com.alibaba.fluss.annotation.PublicEvolving;
+import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
 
@@ -53,4 +54,6 @@ public interface WriterInitContext {
      */
     @Nullable
     String partition();
+
+    Schema schema();
 }

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TieringSplitReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TieringSplitReader.java
@@ -301,7 +301,11 @@ public class TieringSplitReader<WriteResult>
         if (lakeWriter == null) {
             lakeWriter =
                     lakeTieringFactory.createLakeWriter(
-                            new TieringWriterInitContext(currentTablePath, bucket, partitionName));
+                            new TieringWriterInitContext(
+                                    currentTablePath,
+                                    bucket,
+                                    partitionName,
+                                    currentTable.getTableInfo().getSchema()));
             lakeWriters.put(bucket, lakeWriter);
         }
         return lakeWriter;

--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TieringWriterInitContext.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/source/TieringWriterInitContext.java
@@ -18,6 +18,7 @@
 package com.alibaba.fluss.flink.tiering.source;
 
 import com.alibaba.fluss.lake.writer.WriterInitContext;
+import com.alibaba.fluss.metadata.Schema;
 import com.alibaba.fluss.metadata.TableBucket;
 import com.alibaba.fluss.metadata.TablePath;
 
@@ -28,17 +29,18 @@ public class TieringWriterInitContext implements WriterInitContext {
 
     private final TablePath tablePath;
     private final TableBucket tableBucket;
+    private final Schema schema;
     @Nullable private final String partition;
 
-    public TieringWriterInitContext(TablePath tablePath, TableBucket tableBucket) {
-        this(tablePath, tableBucket, null);
-    }
-
     public TieringWriterInitContext(
-            TablePath tablePath, TableBucket tableBucket, @Nullable String partition) {
+            TablePath tablePath,
+            TableBucket tableBucket,
+            @Nullable String partition,
+            Schema schema) {
         this.tablePath = tablePath;
         this.tableBucket = tableBucket;
         this.partition = partition;
+        this.schema = schema;
     }
 
     @Override
@@ -55,5 +57,10 @@ public class TieringWriterInitContext implements WriterInitContext {
     @Override
     public String partition() {
         return partition;
+    }
+
+    @Override
+    public Schema schema() {
+        return schema;
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
@@ -658,6 +658,11 @@ class PaimonTieringTest {
                     public String partition() {
                         return partition;
                     }
+
+                    @Override
+                    public com.alibaba.fluss.metadata.Schema schema() {
+                        return null;
+                    }
                 });
     }
 

--- a/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/com/alibaba/fluss/lake/paimon/tiering/PaimonTieringTest.java
@@ -661,7 +661,8 @@ class PaimonTieringTest {
 
                     @Override
                     public com.alibaba.fluss.metadata.Schema schema() {
-                        return null;
+                        throw new UnsupportedOperationException(
+                                "The lake writer in Paimon currently uses paimonCatalog to determine the schema.");
                     }
                 });
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

Use the schema in Fluss as the single source of truth for the lake writers to avoid any inconsistency.

Moreover, we sometimes need the Fluss schema to pick the correct field writers when creating lake writer. For example, currently the LocalZonedTimestampType and TimestampType type in Fluss map to the same Arrow type: 
https://github.com/alibaba/fluss/blob/main/fluss-common/src/main/java/com/alibaba/fluss/utils/ArrowUtils.java#L476
https://github.com/alibaba/fluss/blob/main/fluss-common/src/main/java/com/alibaba/fluss/utils/ArrowUtils.java#L489

When we tier the table to a data lake with Arrow schema, we are not able to choose the appropriate type of filed writers.

### Brief change log

Add the schema in Fluss to WriterInitContext.

### Tests

n/a

### API and Format

n/a

### Documentation

n/a