### PR TITLE
[doc]The type of Sink is incorrect. FinkSink is not public and cannot be referenced from outside the package

### DIFF
--- a/website/docs/engine-flink/datastream.mdx
+++ b/website/docs/engine-flink/datastream.mdx
@@ -262,7 +262,7 @@ In this example, `OrderPartial` is a class that only contains the `orderId` and 
 The main entry point for the Fluss DataStream Sink API is the `FlussSink` class. You create a `FlussSink` instance using the `FlussSinkBuilder`, which allows for step-by-step configuration of the sink connector.
 
 ```java
-FlinkSink<RowData> flussSink =
+FlussSink<RowData> flussSink =
         FlussSink.<RowData>builder()
                 .setBootstrapServers("localhost:9123")
                 .setDatabase("mydb")


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
https://alibaba.github.io/fluss-docs/docs/engine-flink/datastream/#datastream-sink
The type of Sink is incorrect. FinkSink is not public and cannot be referenced from outside the package

### Brief change log

**Please describe the changes**:
1. FlinkSink in the document has been changed to FlussSink
![a18cfef9c327f806b86542de4de6845](https://github.com/user-attachments/assets/b53c5735-d83d-4d0f-a480-d0de8dc4ea4a)
![eb2681845121cd8bb9b5bcb03cb245e](https://github.com/user-attachments/assets/a65d47ef-0889-4a68-8428-a4ccea44ec1f)
![a68686851b42226b46dc8d56c3ef6f2](https://github.com/user-attachments/assets/1607b94d-f9b0-4890-8512-2b18513452c2)
![dcbe5ebe55be7e1c17425d213744da8](https://github.com/user-attachments/assets/f760d975-160f-42ff-a665-a8003feb0437)
![image](https://github.com/user-attachments/assets/5048d746-b908-42aa-85c7-b2fc8d9422ca)





### API and Format

**Does this change affect API or storage format**:
- [ ] 是  
- [x] 否  
本次修改仅调整了 SQL 查询语句和表结构定义，不影响对外 API 或数据存储格式。


### Documentation

**Does this change introduce a new feature**:
- [ ] 是  
- [x] 否  
本次修改是对现有功能的修复和优化，无需新增文档。