### PR TITLE
[CI] switch to apache rat for license check

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           java-version: 8
           distribution: 'temurin'
+
       - name: Build
         run: |
           set -o pipefail
@@ -45,10 +46,8 @@ jobs:
             -DaltDeploymentRepository=validation_repository::default::file:${{ env.MVN_VALIDATION_DIR }} \
             | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
 
-      - name: Check License
+      - name: Check License Headers with Apache RAT
         run: |
-          ./mvnw ${{ env.MVN_COMMON_OPTIONS }} exec:java@check-license -N \
-            -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) ${{ env.MVN_VALIDATION_DIR }}" \
-            -Dlog4j.configurationFile=file://$(pwd)/tools/ci/fluss-ci-tools/src/main/resources/log4j2.properties
+          ./mvnw ${{ env.MVN_COMMON_OPTIONS }} apache-rat:check
         env:
           MAVEN_OPTS: -Xmx4096m

--- a/pom.xml
+++ b/pom.xml
@@ -877,7 +877,7 @@
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
                     <configuration>
-                        <skip>true</skip>
+                        <skip>false</skip>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1215

Enable Apache RAT license header checking in CI pipeline to ensure all files have proper license headers

Brief change log
<!-- Please describe the changes made in this pull request and explain how they address the issue -->

CI Pipeline: 
Added Apache RAT license check step in GitHub Actions workflow` check-license.yml` to validate license headers on all source files
Maven Configuration: 
Removed <skip>true</skip> configuration from apache-rat-plugin in pluginManagement section to enable RAT execution
in parent pom


Tests
<!-- List UT and IT cases to verify this change -->

Caught java extension:
![image](https://github.com/user-attachments/assets/11031ac2-b3ff-4375-909b-1dc0a8136b73)

Caught md extension
![image](https://github.com/user-attachments/assets/e2d0d0b3-6800-47ce-89e6-4e970db196ee)



API and Format
<!-- Does this change affect API or storage format -->
None

Documentation
<!-- Does this change introduce a new feature -->
None