### PR TITLE
[doc]Remove `testcatalog`.`testdb`. from the ddl statement

### DIFF
--- a/website/docs/engine-flink/ddl.md
+++ b/website/docs/engine-flink/ddl.md
@@ -39,7 +39,7 @@ USE CATALOG fluss_catalog;
 
 The following properties can be set if using the Fluss catalog:
 
-| Option                         | Required | Default   | Description                                                                                                                                                                          | 
+| Option                         | Required | Default   | Description                                                                                                                                                                          |
 |--------------------------------|----------|-----------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | type                           | required | (none)    | Catalog type, must to be 'fluss' here.                                                                                                                                               |
 | bootstrap.servers              | required | (none)    | Comma separated list of Fluss servers.                                                                                                                                               |
@@ -238,6 +238,24 @@ DROP TABLE my_table;
 
 This will entirely remove all the data of the table in the Fluss cluster.
 
+## Add Partition
+
+Fluss support manually add partitions to an exists partitioned table by Fluss Catalog. If the specified partition 
+not exists, Fluss will create the partition. If the specified partition already exists, Fluss will ignore the request 
+or throw an exception.
+
+To add partitions, run:
+
+```sql title="Flink SQL"
+-- Add a partition to a single field partitioned table
+ALTER TABLE my_part_pk_table ADD PARTITION (dt = '2025-03-05');
+
+-- Add a partition to a multi-field partitioned table
+ALTER TABLE my_multi_fields_part_log_table ADD PARTITION (dt = '2025-03-05', nation = 'US');
+```
+
+For more details, refer to the [Flink ALTER TABLE(ADD)](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/sql/alter/#add) documentation.
+
 ## Show Partitions
 
 To show all the partitions of a partitioned table, run:
@@ -256,23 +274,6 @@ SHOW PARTITIONS my_multi_fields_part_log_table PARTITION (dt = '2025-03-05', nat
 ```
 
 For more details, refer to the [Flink SHOW PARTITIONS](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/sql/show/#show-partitions) documentation.
-
-## Add Partition
-
-Fluss support manually add partitions to an exists partitioned table by Fluss Catalog. If the specified partition 
-not exists, Fluss will create the partition. If the specified partition already exists, Fluss will ignore the request 
-or throw an exception.
-
-To add partitions, run:
-```sql title="Flink SQL"
--- Add a partition to a single field partitioned table
-ALTER TABLE my_part_pk_table ADD PARTITION (dt = '2025-03-05');
-
--- Add a partition to a multi-field partitioned table
-ALTER TABLE my_multi_fields_part_log_table ADD PARTITION (dt = '2025-03-05', nation = 'US');
-```
-
-For more details, refer to the [Flink ALTER TABLE(ADD)](https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/dev/table/sql/alter/#add) documentation.
 
 ## Drop Partition
 

--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -68,7 +68,7 @@ Benchmark results show that column pruning can reach 10x read performance improv
 
 **1. Create a table**
 ```sql title="Flink SQL"
-CREATE TABLE `testcatalog`.`testdb`.`log_table` (
+CREATE TABLE `log_table` (
     `c_custkey` INT NOT NULL,
     `c_name` STRING NOT NULL,
     `c_address` STRING NOT NULL,
@@ -82,12 +82,12 @@ CREATE TABLE `testcatalog`.`testdb`.`log_table` (
 
 **2. Query a single column:**
 ```sql title="Flink SQL"
-SELECT `c_name` FROM `testcatalog`.`testdb`.`log_table`;
+SELECT `c_name` FROM `log_table`;
 ```
 
 **3. Verify with `EXPLAIN`:**
 ```sql title="Flink SQL"
-EXPLAIN SELECT `c_name` FROM `testcatalog`.`testdb`.`log_table`;
+EXPLAIN SELECT `c_name` FROM `log_table`;
 ```
 
 **Output:**
@@ -113,7 +113,7 @@ The partition pruning also supports dynamically pruning new created partitions d
 
 **1. Create a partitioned table:**
 ```sql title="Flink SQL"
-CREATE TABLE `testcatalog`.`testdb`.`log_partitioned_table` (
+CREATE TABLE `log_partitioned_table` (
     `c_custkey` INT NOT NULL,
     `c_name` STRING NOT NULL,
     `c_address` STRING NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE `testcatalog`.`testdb`.`log_partitioned_table` (
 
 **2. Query with partition filter:**
 ```sql title="Flink SQL"
-SELECT * FROM `testcatalog`.`testdb`.`log_partitioned_table` WHERE `c_nationkey` = 'US';
+SELECT * FROM `log_partitioned_table` WHERE `c_nationkey` = 'US';
 ```
 
 Fluss source will scan only the partitions where `c_nationkey = 'US'`.
@@ -145,7 +145,7 @@ As new partitions like `US,2025-06-15`, `China,2025-06-15` are created, partitio
 **3. Verify with `EXPLAIN`:**
 
 ```sql title="Flink SQL"
-EXPLAIN SELECT * FROM `testcatalog`.`testdb`.`log_partitioned_table` WHERE `c_nationkey` = 'US';
+EXPLAIN SELECT * FROM `log_partitioned_table` WHERE `c_nationkey` = 'US';
 ```
 
 **Output:**


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Remove 'testcatalog'. 'testdb' from the ddl statement
See the picture for details：
![9949983ad933037152a55f6218b9198](https://github.com/user-attachments/assets/a20dd807-df41-4c13-bdc8-c7368d4092e2)
![1751116473755](https://github.com/user-attachments/assets/99e3ef91-f73c-4b57-bb1f-b76a0bcefd1d)
![1751116576585](https://github.com/user-attachments/assets/7821634b-0ce9-4ac7-bbdf-8395565100ee)


### Brief change log

**Please describe the changes**:
1. Remove `testcatalog`.`testdb`. from the streaming section
2. Maintain consistency in the ddl statements for document streaming read and batch read

