### PR TITLE
[doc]Remove 'testcatalog'. 'testdb' from the ddl statement

### DIFF
--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -68,7 +68,7 @@ Benchmark results show that column pruning can reach 10x read performance improv
 
 **1. Create a table**
 ```sql title="Flink SQL"
-CREATE TABLE `testcatalog`.`testdb`.`log_table` (
+CREATE TABLE `log_table` (
     `c_custkey` INT NOT NULL,
     `c_name` STRING NOT NULL,
     `c_address` STRING NOT NULL,
@@ -82,12 +82,12 @@ CREATE TABLE `testcatalog`.`testdb`.`log_table` (
 
 **2. Query a single column:**
 ```sql title="Flink SQL"
-SELECT `c_name` FROM `testcatalog`.`testdb`.`log_table`;
+SELECT `c_name` FROM `log_table`;
 ```
 
 **3. Verify with `EXPLAIN`:**
 ```sql title="Flink SQL"
-EXPLAIN SELECT `c_name` FROM `testcatalog`.`testdb`.`log_table`;
+EXPLAIN SELECT `c_name` FROM `log_table`;
 ```
 
 **Output:**
@@ -113,7 +113,7 @@ The partition pruning also supports dynamically pruning new created partitions d
 
 **1. Create a partitioned table:**
 ```sql title="Flink SQL"
-CREATE TABLE `testcatalog`.`testdb`.`log_partitioned_table` (
+CREATE TABLE `log_partitioned_table` (
     `c_custkey` INT NOT NULL,
     `c_name` STRING NOT NULL,
     `c_address` STRING NOT NULL,
@@ -128,7 +128,7 @@ CREATE TABLE `testcatalog`.`testdb`.`log_partitioned_table` (
 
 **2. Query with partition filter:**
 ```sql title="Flink SQL"
-SELECT * FROM `testcatalog`.`testdb`.`log_partitioned_table` WHERE `c_nationkey` = 'US';
+SELECT * FROM `log_partitioned_table` WHERE `c_nationkey` = 'US';
 ```
 
 Fluss source will scan only the partitions where `c_nationkey = 'US'`.
@@ -145,7 +145,7 @@ As new partitions like `US,2025-06-15`, `China,2025-06-15` are created, partitio
 **3. Verify with `EXPLAIN`:**
 
 ```sql title="Flink SQL"
-EXPLAIN SELECT * FROM `testcatalog`.`testdb`.`log_partitioned_table` WHERE `c_nationkey` = 'US';
+EXPLAIN SELECT * FROM `log_partitioned_table` WHERE `c_nationkey` = 'US';
 ```
 
 **Output:**

--- a/website/docs/engine-flink/reads.md
+++ b/website/docs/engine-flink/reads.md
@@ -94,7 +94,7 @@ EXPLAIN SELECT `c_name` FROM `log_table`;
 
 ```
 == Optimized Execution Plan ==
-TableSourceScan(table=[[testcatalog, testdb, log_table, project=[c_name]]], fields=[c_name])
+TableSourceScan(table=[[fluss_catalog, fluss, log_table, project=[c_name]]], fields=[c_name])
 ```
 
 This confirms that only the `c_name` column is being read from storage.
@@ -152,7 +152,7 @@ EXPLAIN SELECT * FROM `log_partitioned_table` WHERE `c_nationkey` = 'US';
 
 ```text
 == Optimized Execution Plan ==
-TableSourceScan(table=[[testcatalog, testdb, log_partitioned_table, filter=[=(c_nationkey, _UTF-16LE'US':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment, dt])
+TableSourceScan(table=[[fluss_catalog, fluss, log_partitioned_table, filter=[=(c_nationkey, _UTF-16LE'US':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")]]], fields=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment, dt])
 ```
 
 This confirms that only partitions matching `c_nationkey = 'US'` will be scanned.


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
Remove 'testcatalog'. 'testdb' from the ddl statement
See the picture for details：
![9949983ad933037152a55f6218b9198](https://github.com/user-attachments/assets/8b19b3f1-a1a8-43c8-aa27-49ab310bac39)
![1751117465098](https://github.com/user-attachments/assets/deb17da0-cb1e-43fd-92e9-2c5ab14a0a93)
![1751117465130](https://github.com/user-attachments/assets/e058da7d-7037-4307-b34f-366db418ceb6)

### Brief change log

**Please describe the changes**:
1、Remove testcatalog.testdb. from the streaming section
2、Maintain consistency in the ddl statements for document streaming read and batch read