### PR TITLE
[hotfix] The DiscardingSink operator after LakeCommitter should always be with parallelism 1

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/com/alibaba/fluss/flink/tiering/LakeTieringJobBuilder.java
@@ -102,7 +102,9 @@ public class LakeTieringJobBuilder {
                         new TieringCommitOperatorFactory(flussConfig, lakeTieringFactory))
                 .setParallelism(1)
                 .setMaxParallelism(1)
-                .sinkTo(new DiscardingSink());
+                .sinkTo(new DiscardingSink())
+                .name("end")
+                .setParallelism(1);
         String jobName =
                 env.getConfiguration()
                         .getOptional(PipelineOptions.NAME)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/alibaba/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose
Always to set `DiscardingSink` operator  after LakeCommitter to parallelism 1 to make it can be chained with `LakeCommitter`  since it's just a discarded sink 

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
