### PR TITLE
[doc] fix typos, format in installation overview

### DIFF
--- a/website/docs/install-deploy/overview.md
+++ b/website/docs/install-deploy/overview.md
@@ -70,7 +70,7 @@ We have listed them in the table below the figure.
             <td>
                 <p>
                 CoordinatorServer is the name of the central work coordination component of Fluss. 
-                The coordinator server is responsible to:
+                The coordinator server is responsible for:
                 </p>
                 <ul>
                     <li>Manage the TabletServer</li>
@@ -103,7 +103,7 @@ We have listed them in the table below the figure.
                 <td>ZooKeeper</td>
                     <td>
                         :::warning
-                        Zookeeper will be removed to simplify deployment in the near future. For more details, please checkout [Roadmap](/roadmap/).
+                        ZooKeeper will be removed to simplify deployment in the near future. For more details, please checkout [Roadmap](/roadmap/).
                         :::
                         <p>
                         Fluss leverages ZooKeeper for distributed coordination between all running CoordinatorServer instances and for metadata management.
@@ -111,7 +111,7 @@ We have listed them in the table below the figure.
                     </td>
                     <td>
                         <ul>
-                            <li><a href="https://zookeeper.apache.org/">Zookeeper</a></li>
+                            <li><a href="https://zookeeper.apache.org/">ZooKeeper</a></li>
                         </ul>
                     </td>
                 </tr>
@@ -156,7 +156,7 @@ We have listed them in the table below the figure.
 Fluss can be deployed in three different ways:
 - [Local Cluster](install-deploy/deploying-local-cluster.md)
 - [Distributed Cluster](install-deploy/deploying-distributed-cluster.md)
-- [Docker run/ Docker compose](install-deploy/deploying-with-docker.md)
+- [Docker run / Docker Compose](install-deploy/deploying-with-docker.md)
 
 **NOTE**:
 - Local Cluster is for testing purpose only.

--- a/website/docs/quickstart/security.md
+++ b/website/docs/quickstart/security.md
@@ -226,7 +226,7 @@ CALL admin_catalog.sys.add_acl(
 Allow `consumer` user to read data:
 ```sql
 CALL admin_catalog.sys.add_acl(
-   resource => 'cluster', 
+    resource => 'cluster', 
     permission => 'ALLOW',
     principal => 'User:consumer', 
     operation => 'READ'
@@ -242,13 +242,13 @@ CALL admin_catalog.sys.list_acl(
 Output will show like:
 
 ```text
-+-------------------------------------------------------------------------------------------------------+
-|                                                                                                result |
-+-------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------+
+|                                                                                      result |
++---------------------------------------------------------------------------------------------+
 |  resource="cluster";permission="ALLOW";principal="User:developer";operation="READ";host="*" |
 | resource="cluster";permission="ALLOW";principal="User:developer";operation="WRITE";host="*" |
 |   resource="cluster";permission="ALLOW";principal="User:consumer";operation="READ";host="*" |
-+-------------------------------------------------------------------------------------------------------+
++---------------------------------------------------------------------------------------------+
 3 rows in set
 ```
 
@@ -260,7 +260,7 @@ USE CATALOG admin_catalog;
 
 -- create table using admin credentials
 CREATE TABLE fluss_order (
-     `order_key`  INT NOT NULL,
+    `order_key`  INT NOT NULL,
     `total_price` DECIMAL(15, 2),
     PRIMARY KEY (`order_key`) NOT ENFORCED
 );
@@ -540,12 +540,12 @@ CALL admin_catalog.sys.list_acl(
 ```
 Output will show like:
 ```text
-+----------------------------------------------------------------------------------------------------+
-|                                                                                             result |
-+----------------------------------------------------------------------------------------------------+
++--------------------------------------------------------------------------------------------------------+
+|                                                                                                 result |
++--------------------------------------------------------------------------------------------------------+
 | resource="cluster.marketing_db";permission="ALLOW";principal="User:marketing";operation="ALL";host="*" |
 |     resource="cluster.finance_db";permission="ALLOW";principal="User:finance";operation="ALL";host="*" |
-+----------------------------------------------------------------------------------------------------+
++--------------------------------------------------------------------------------------------------------+
 2 rows in set
 ```
 
@@ -594,7 +594,7 @@ The `marketing` user can operate on their own database:
 USE CATALOG marketing_catalog;
 -- create table using marketing user credentials
 CREATE TABLE `marketing_db`.`order` (
-     `order_key`  INT NOT NULL,
+    `order_key`  INT NOT NULL,
     `total_price` DECIMAL(15, 2),
     PRIMARY KEY (`order_key`) NOT ENFORCED
 );
@@ -612,7 +612,7 @@ The `finance` user cannot access the `marketing` database:
 USE CATALOG finance_catalog;
 -- create table using finance user credentials
 CREATE TABLE `marketing_db`.`order` (
-     `order_key`  INT NOT NULL,
+    `order_key`  INT NOT NULL,
     `total_price` DECIMAL(15, 2),
     PRIMARY KEY (`order_key`) NOT ENFORCED
 );


### PR DESCRIPTION
### Purpose

Linked issue: close #xxx 

**What is the purpose of the change**:
fix typos, format in installation overview


### Brief change log

**Please describe the changes**:
1、“Zookeeper” → ZooKeeper
2、“Docker run/ Docker compose” → Docker run / Docker Compose（斜杠前后空格、Compose 大写）
3、…responsible to: …  →  responsible for …