### PR TITLE
[server] Coordinator reject the adjustIsr request if the expected adjusted isr contains shutdown tabletServers

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/exception/IneligibleReplicaException.java
+++ b/fluss-common/src/main/java/org/apache/fluss/exception/IneligibleReplicaException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.exception;
+
+/** Exception for ineligible replica. */
+public class IneligibleReplicaException extends ApiException {
+
+    private static final long serialVersionUID = 1L;
+
+    public IneligibleReplicaException(String message) {
+        super(message);
+    }
+}

--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/Errors.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/protocol/Errors.java
@@ -28,6 +28,7 @@ import org.apache.fluss.exception.DatabaseNotExistException;
 import org.apache.fluss.exception.DuplicateSequenceException;
 import org.apache.fluss.exception.FencedLeaderEpochException;
 import org.apache.fluss.exception.FencedTieringEpochException;
+import org.apache.fluss.exception.IneligibleReplicaException;
 import org.apache.fluss.exception.InvalidColumnProjectionException;
 import org.apache.fluss.exception.InvalidConfigException;
 import org.apache.fluss.exception.InvalidCoordinatorException;
@@ -217,7 +218,11 @@ public enum Errors {
     LAKE_SNAPSHOT_NOT_EXIST(
             53, "The lake snapshot is not exist.", LakeTableSnapshotNotExistException::new),
     LAKE_TABLE_ALREADY_EXIST(
-            54, "The lake table already exists.", LakeTableAlreadyExistException::new);
+            54, "The lake table already exists.", LakeTableAlreadyExistException::new),
+    INELIGIBLE_REPLICA_EXCEPTION(
+            55,
+            "The new ISR contains at least one ineligible replica.",
+            IneligibleReplicaException::new);
 
     private static final Logger LOG = LoggerFactory.getLogger(Errors.class);
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -1649,6 +1649,7 @@ public final class Replica {
         failedIsrUpdates.inc();
         switch (error) {
             case OPERATION_NOT_ATTEMPTED_EXCEPTION:
+            case INELIGIBLE_REPLICA_EXCEPTION:
                 // Care must be taken when resetting to the last committed state since we may not
                 // know in general whether the request was applied or not taking into account
                 // retries and controller changes which might have occurred before we received the

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
@@ -408,6 +408,10 @@ public class ZooKeeperClient implements AutoCloseable {
                 .forPath(bucketsParentPath);
 
         for (RegisterTableBucketLeadAndIsrInfo info : registerList) {
+            LOG.info(
+                    "Batch Register {} for bucket {} in Zookeeper.",
+                    info.getLeaderAndIsr(),
+                    info.getTableBucket());
             byte[] data = LeaderAndIsrZNode.encode(info.getLeaderAndIsr());
             // create direct parent node
             CuratorOp parentNodeCreate =
@@ -487,6 +491,7 @@ public class ZooKeeperClient implements AutoCloseable {
             TableBucket tableBucket = entry.getKey();
             LeaderAndIsr leaderAndIsr = entry.getValue();
 
+            LOG.info("Batch Update {} for bucket {} in Zookeeper.", leaderAndIsr, tableBucket);
             String path = LeaderAndIsrZNode.path(tableBucket);
             byte[] data = LeaderAndIsrZNode.encode(leaderAndIsr);
             CuratorOp updateOp = zkClient.transactionOp().setData().forPath(path, data);


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: #1733 

<!-- What is the purpose of the change -->

The  `TabletServerShutdownITCase.testControlledShutdownRetriesFailover()` is unstable because` coordinator` would receive and accept the `excepted isr set` in ·AdjustIsr· request even if the expected isr set contains the shutdown `tabletServers`. `Coordinator` reject the `adjustIsr` request if the expected adjusted isr contains shutdown `tabletServers`

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
