### PR TITLE
[hotfix] Revert CURRENT_LOG_MAGIC_VALUE to LOG_MAGIC_VALUE_V0 for compatibility higher version client with lower version server

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatch.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatch.java
@@ -26,7 +26,7 @@ import org.apache.fluss.utils.CloseableIterator;
 
 import java.util.Iterator;
 
-import static org.apache.fluss.record.LogRecordBatchFormat.LOG_MAGIC_VALUE_V1;
+import static org.apache.fluss.record.LogRecordBatchFormat.LOG_MAGIC_VALUE_V0;
 import static org.apache.fluss.record.LogRecordBatchFormat.NO_WRITER_ID;
 
 /**
@@ -36,8 +36,15 @@ import static org.apache.fluss.record.LogRecordBatchFormat.NO_WRITER_ID;
  */
 @PublicEvolving
 public interface LogRecordBatch {
-    /** The current "magic" value. */
-    byte CURRENT_LOG_MAGIC_VALUE = LOG_MAGIC_VALUE_V1;
+    /**
+     * The current "magic" value. Even though we already support LOG_MAGIC_VALUE_V1, for
+     * compatibility reasons — specifically, a higher-version Fluss Client (which supports
+     * LOG_MAGIC_VALUE_V1) cannot write to a lower-version Fluss Server (which only supports
+     * LOG_MAGIC_VALUE_V0) — we are unable to guarantee compatibility at this time. Therefore, we
+     * will keep the current log magic value set to LOG_MAGIC_VALUE_V0 for now, and only upgrade it
+     * to LOG_MAGIC_VALUE_V1 once the compatibility issue is resolved.
+     */
+    byte CURRENT_LOG_MAGIC_VALUE = LOG_MAGIC_VALUE_V0;
 
     /**
      * Check whether the checksum of this batch is correct.


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

<!-- What is the purpose of the change -->
This pr is aims to  revert `CURRENT_LOG_MAGIC_VALUE` to `LOG_MAGIC_VALUE_V0` for compatibility higher version client with lower version server.


### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
