### PR TITLE
[lake] Avoid create/drop connection frequently in TieringSourceReader

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSource.java
@@ -17,6 +17,8 @@
 
 package org.apache.fluss.flink.tiering.source;
 
+import org.apache.fluss.client.Connection;
+import org.apache.fluss.client.ConnectionFactory;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.flink.tiering.source.enumerator.TieringSourceEnumerator;
 import org.apache.fluss.flink.tiering.source.split.TieringSplit;
@@ -104,8 +106,9 @@ public class TieringSource<WriteResult>
 
     @Override
     public SourceReader<TableBucketWriteResult<WriteResult>, TieringSplit> createReader(
-            SourceReaderContext sourceReaderContext) throws Exception {
-        return new TieringSourceReader<>(sourceReaderContext, flussConf, lakeTieringFactory);
+            SourceReaderContext sourceReaderContext) {
+        Connection connection = ConnectionFactory.createConnection(flussConf);
+        return new TieringSourceReader<>(sourceReaderContext, connection, lakeTieringFactory);
     }
 
     /** This follows the operator uid hash generation logic of flink {@link StreamGraphHasherV2}. */

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSourceReader.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/TieringSourceReader.java
@@ -18,7 +18,7 @@
 package org.apache.fluss.flink.tiering.source;
 
 import org.apache.fluss.annotation.Internal;
-import org.apache.fluss.config.Configuration;
+import org.apache.fluss.client.Connection;
 import org.apache.fluss.flink.tiering.source.split.TieringSplit;
 import org.apache.fluss.flink.tiering.source.state.TieringSplitState;
 import org.apache.fluss.lake.writer.LakeTieringFactory;
@@ -40,15 +40,18 @@ public final class TieringSourceReader<WriteResult>
                 TieringSplit,
                 TieringSplitState> {
 
+    private final Connection connection;
+
     public TieringSourceReader(
             SourceReaderContext context,
-            Configuration flussConf,
+            Connection connection,
             LakeTieringFactory<WriteResult, ?> lakeTieringFactory) {
         super(
-                () -> new TieringSplitReader<>(flussConf, lakeTieringFactory),
+                () -> new TieringSplitReader<>(connection, lakeTieringFactory),
                 new TableBucketWriteResultEmitter<>(),
                 context.getConfiguration(),
                 context);
+        this.connection = connection;
     }
 
     @Override
@@ -84,5 +87,11 @@ public final class TieringSourceReader<WriteResult>
     @Override
     protected TieringSplit toSplitType(String splitId, TieringSplitState splitState) {
         return splitState.toSourceSplit();
+    }
+
+    @Override
+    public void close() throws Exception {
+        super.close();
+        connection.close();
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1827 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
create connection in `TieringSourceReader` instead of `TieringSourceSplitReader`

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
