### PR TITLE
[lake/iceberg] thrown Exception when partition columns are of non-String type

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalog.java
@@ -220,8 +220,7 @@ public class IcebergLakeCatalog implements LakeCatalog {
                 // TODO: Support other types of partition keys
                 throw new InvalidTableException(
                         String.format(
-                                "Iceberg partition key only support string type, "
-                                        + "%s is not string type.",
+                                "Partition key only support string type for iceberg currently. Column `%s` is not string type.",
                                 partitionKey));
             }
             builder.identity(partitionKey);

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalogTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/IcebergLakeCatalogTest.java
@@ -435,6 +435,6 @@ class IcebergLakeCatalogTest {
                         () -> flussIcebergCatalog.createTable(t1, tableDescriptor.build()))
                 .isInstanceOf(InvalidTableException.class)
                 .hasMessage(
-                        "Iceberg partition key only support string type, c1 is not string type.");
+                        "Partition key only support string type for iceberg currently. Column `c1` is not string type.");
     }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1821 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Partitions in Fluss Tiering split are Strings, but Iceberg partition transforms require data in actual types. For now, we throw an exception and will implement the type conversion later.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
