### PR TITLE
[hotfix][tests] Speed up ArrayUtils#removeSet and intersection for empty and same arrays

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/utils/ArrayUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/utils/ArrayUtils.java
@@ -77,6 +77,9 @@ public final class ArrayUtils {
      *     array.
      */
     public static int[] removeSet(int[] a, int[] b) {
+        if (b.length == 0) {
+            return a;
+        }
         // Iterate over each element in the second array
         // and check if the element exists in the first array
         if (!isSubset(a, b)) {
@@ -84,6 +87,10 @@ public final class ArrayUtils {
         }
         // Remove the elements of the second array from the first array
         int[] resultArray = new int[a.length - b.length];
+        if (resultArray.length == 0) {
+            return resultArray;
+        }
+
         int index = 0;
         for (int elementA : a) {
             boolean found = false;


### PR DESCRIPTION
### Purpose

There is a couple of cases where ArrayUtils#removeSet  and as a result intersection might be improved
e.g. same/equal array or empty array

### Brief change log

ArrayUtils

### Tests

ArrayUtilsTest

### API and Format

no

### Documentation

no
