### PR TITLE
[hotfix][docs] Remove not related java11 profile info from ide-setup

### DIFF
--- a/website/community/dev/ide-setup.md
+++ b/website/community/dev/ide-setup.md
@@ -202,12 +202,6 @@ If you do not want to expose your email address in Git commits, you can activate
 
 This section lists issues that developers have run into in the past when working with IntelliJ.
 
-#### Compilation fails with `invalid flag: --add-exports=java.base/sun.net.util=ALL-UNNAMED`
-
-This happens if the "java11" Maven profile is active, but an older JDK version is used. Go to
-"View" → "Tool Windows" → "Maven" and uncheck the "java11" profile. Afterwards, reimport the
-project.
-
 #### Compilation fails with `package sun.misc does not exist`
 
 This happens if you are using JDK 11 and compile to Java 8 with the `--release` option. This option is currently incompatible with our build setup.


### PR DESCRIPTION
### Purpose

The `ide-setup` tells something about `java11` profile however there is no such profile at all (at least right now).
So it looks like it is completely unrelated.
Moreover the module is added to `add-opens` in pom.xml
### Brief change log

ide-setup

### Tests

no

### API and Format

no

### Documentation

the change is doc itself
