### PR TITLE
[hotfix][build] Add distributionSha256Sum check for maven wrapper

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -17,3 +17,4 @@
 wrapperVersion=3.3.2
 distributionType=only-script
 distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+distributionSha256Sum=ccf20a80e75a17ffc34d47c5c95c98c39d426ca17d670f09cd91e877072a9309


### PR DESCRIPTION

### Purpose

`./mvnw` downloads some binaries without any check, in maven-wrapper 3.2.0 there was added a feature to have sha256 check https://issues.apache.org/jira/browse/MWRAPPER-75
So this PR just adds it here

### Brief change log

sha256 chack

### Tests

drop maven wrapper then ./mvnw

### API and Format

no

### Documentation

no
