### PR TITLE
[hotfix] Use literal directly  instead of PARTITION_GENERATE_LEGCY_NAME to avoid NoSuchField error

### DIFF
--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/utils/PaimonConversions.java
@@ -49,6 +49,13 @@ import static org.apache.fluss.lake.paimon.PaimonLakeCatalog.SYSTEM_COLUMNS;
 /** Utils for conversion between Paimon and Fluss. */
 public class PaimonConversions {
 
+    // use literal directly, a future paimon version will rename
+    // the variable PARTITION_GENERATE_LEGCY_NAME to PARTITION_GENERATE_LEGACY_NAME, use literal
+    // can help avoid NoSuchField error
+    // todo: after upgrade paimon version, we call fall back to use PARTITION_GENERATE_LEGACY_NAME
+    // again
+    private static final String PARTITION_GENERATE_LEGACY_NAME_OPTION_KEY = "partition.legacy-name";
+
     // for fluss config
     private static final String FLUSS_CONF_PREFIX = "fluss.";
     // for paimon config
@@ -60,10 +67,7 @@ public class PaimonConversions {
     static {
         PAIMON_UNSETTABLE_OPTIONS.add(CoreOptions.BUCKET.key());
         PAIMON_UNSETTABLE_OPTIONS.add(CoreOptions.BUCKET_KEY.key());
-        // use literal directly, a future paimon version will rename
-        // the variable PARTITION_GENERATE_LEGCY_NAME to PARTITION_GENERATE_LEGACY_NAME, use literal
-        // can help avoid NoSuchField error
-        PAIMON_UNSETTABLE_OPTIONS.add("partition.legacy-name");
+        PAIMON_UNSETTABLE_OPTIONS.add(PARTITION_GENERATE_LEGACY_NAME_OPTION_KEY);
     }
 
     public static RowKind toRowKind(ChangeType changeType) {
@@ -222,7 +226,7 @@ public class PaimonConversions {
     private static void setPaimonDefaultProperties(Options options) {
         // set partition.legacy-name to false, otherwise paimon will use toString for all types,
         // which will cause inconsistent partition value for the same binary value
-        options.set(CoreOptions.PARTITION_GENERATE_LEGCY_NAME, false);
+        options.set(PARTITION_GENERATE_LEGACY_NAME_OPTION_KEY, Boolean.FALSE.toString());
     }
 
     private static void setFlussPropertyToPaimon(String key, String value, Options options) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
 Use literal directly  instead of PARTITION_GENERATE_LEGCY_NAME to avoid NoSuchField error when mix with a paimon with higher version which has changed `PARTITION_GENERATE_LEGCY_NAME` to `PARTITION_GENERATE_LEGACY_NAME`

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
