### PR TITLE
[lake] Avoid to generate empty split in tiering source enumerator

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
@@ -244,7 +244,7 @@ public class TieringSplitGenerator {
             @Nullable Long lastCommittedBucketOffset,
             long latestBucketOffset) {
         if (latestBucketOffset <= 0) {
-            LOG.info(
+            LOG.debug(
                     "The latestBucketOffset {} is equals or less than 0, skip generating split for bucket {}",
                     latestBucketOffset,
                     tableBucket);
@@ -304,7 +304,7 @@ public class TieringSplitGenerator {
             @Nullable Long lastCommittedBucketOffset,
             long latestBucketOffset) {
         if (latestBucketOffset <= 0) {
-            LOG.info(
+            LOG.debug(
                     "The latestBucketOffset {} is equals or less than 0, skip generating split for bucket {}",
                     latestBucketOffset,
                     tableBucket);

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
@@ -97,7 +97,7 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
             context.getSplitsAssignmentSequence()
                     .forEach(a -> a.assignment().values().forEach(actualAssignment::addAll));
 
-            // no spilt assignment for empty buckets
+            // no split assignment for empty buckets
             assertThat(actualAssignment).isEmpty();
 
             // mock finished tiered this round, check second round


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1900 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
