### PR TITLE
[lake] improve logging for lake tiering

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumerator.java
@@ -239,7 +239,10 @@ public class TieringSourceEnumerator
     private void generateAndAssignSplits(
             @Nullable Tuple3<Long, Long, TablePath> tieringTable, Throwable throwable) {
         if (throwable != null) {
-            LOG.warn("Failed to request tiering table, will retry later.", throwable);
+            LOG.warn(
+                    "Failed to request tiering table {}, will retry later.",
+                    tieringTable != null ? tieringTable.f2 : null,
+                    throwable);
         }
         if (tieringTable != null) {
             generateTieringSplits(tieringTable);
@@ -259,6 +262,11 @@ public class TieringSourceEnumerator
                     }
                     if (!pendingSplits.isEmpty()) {
                         TieringSplit tieringSplit = pendingSplits.remove(0);
+                        LOG.info(
+                                "Assigning split {} of table {} to reader {}",
+                                tieringSplit.splitId(),
+                                tieringSplit.getTablePath(),
+                                nextAwaitingReader);
                         context.assignSplit(tieringSplit, nextAwaitingReader);
                         readersAwaitingSplit.remove(nextAwaitingReader);
                     }

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/source/split/TieringSplitGenerator.java
@@ -66,7 +66,7 @@ public class TieringSplitGenerator {
         LakeSnapshot lakeSnapshotInfo;
         try {
             lakeSnapshotInfo = flussAdmin.getLatestLakeSnapshot(tableInfo.getTablePath()).get();
-            LOG.info("Last committed lake table snapshot info is:{}", lakeSnapshotInfo);
+            LOG.debug("Last committed lake table snapshot info is:{}", lakeSnapshotInfo);
         } catch (Exception e) {
             Throwable t = ExceptionUtils.stripExecutionException(e);
             if (t instanceof LakeTableSnapshotNotExistException) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #1899 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

1. Changed LOG.info to LOG.debug for lake snapshot info
File: TieringSplitGenerator.java
Changed the log level from info to debug for the message "Last committed lake table snapshot info is:{}" to reduce verbose logging

2. Added logging for reader-split assignments
File: TieringSourceEnumerator.java
Added logging to show which reader is being assigned which split.

3. Added commit status logging in commit operator
File: TieringCommitOperator.java
Added multiple logging statements to track commit progress:
- Log when starting a commit
- Log when a commit is successful or skipped
- Log when notifying the coordinator
- Log when committing to lake storage
- Log when committing to Fluss
- Enhanced error logging with table ID context


### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
