### PR TITLE
[FLUSS-1935][docs] Added Fluss Team Section

### DIFF
--- a/website/community/fluss-logos.md
+++ b/website/community/fluss-logos.md
@@ -1,6 +1,6 @@
 ---
 title: Fluss Logos
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 # Fluss Logos

--- a/website/community/fluss-team.md
+++ b/website/community/fluss-team.md
@@ -1,0 +1,39 @@
+---
+title: Fluss Team
+sidebar_position: 5
+---
+
+## Fluss Team
+We'd like to thank the following members and committers to the Apache Fluss project who have helped get the project to where it is today. This list might be stale, the canonical list of members is located on [Apache's website](https://people.apache.org/committers-by-project.html#fluss).
+
+### Members
+
+| Public Name          | GitHub Username                                    | Apache ID                                                                     | Role(s)             |
+| -------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------- |
+| Yu Li                | [@carp84](https://github.com/carp84)               | [liyu](https://people.apache.org/committer-index.html#liyu)                   | Mentor, PPMC Member |
+| Becket Qin           | [@becketqin](https://github.com/becketqin)         | [jqin](https://people.apache.org/committer-index.html#jqin)                   | Mentor, PPMC Member |
+| Jean-Baptiste Onofré | [@jbonofre](https://github.com/jbonofre)           | [jbonofre](https://people.apache.org/committer-index.html#jbonofre)           | Mentor, PPMC Member |
+| Jingsong Lee         | [@JingsongLi](https://github.com/JingsongLi)       | [lzljs3620320](https://people.apache.org/committer-index.html#lzljs3620320)   | Mentor, PPMC Member |
+| Zili Chen            | [@tisonkun](https://github.com/tisonkun)           | [tison](https://people.apache.org/committer-index.html#tison)                 | Mentor, PPMC Member |
+| Jark Wu              | [@wuchong](https://github.com/wuchong)             | [jark](https://people.apache.org/committer-index.html#jark)                   | PPMC Member         |
+| Giannis Polyzos      | [@polyzos](https://github.com/polyzos)             | [ipolyzos](https://people.apache.org/committer-index.html#ipolyzos)           | PPMC Member         |
+| Yuxia Luo            | [@luoyuxia](https://github.com/luoyuxia)           | [yuxia](https://people.apache.org/committer-index.html#yuxia)                 | PPMC Member         |
+| Yunhong Zheng        | [@swuferhong](https://github.com/swuferhong)       | [yunhong](https://people.apache.org/committer-index.html#yunhong)             | PPMC Member         |
+| Michael Koepf        | [@michaelkoepf](https://github.com/michaelkoepf)   | [michaelkoepf](https://people.apache.org/committer-index.html#michaelkoepf)   | PPMC Member         |
+| Nicholas Jiang       | [@SteNicholas](https://github.com/SteNicholas)     | [nicholasjiang](https://people.apache.org/committer-index.html#nicholasjiang) | PPMC Member         |
+| Feng Wang            | [@wangfengpro](https://github.com/wangfengpro)     | [fengwang](https://people.apache.org/committer-index.html#fengwang)           | PPMC Member         |
+| Benchao Li           | [@libenchao](https://github.com/libenchao)         | [libenchao](https://people.apache.org/committer-index.html#libenchao)         | PPMC Member         |
+| Hongshun Wang        | [@loserwang1024](https://github.com/loserwang1024) | [hongshun](https://people.apache.org/committer-index.html#hongshun)           | Committer           |
+| Mehul Batra          | [@MehulBatra](https://github.com/MehulBatra)       | [mehulbatra](https://people.apache.org/committer-index.html#mehulbatra)       | Committer           |
+
+
+The Apache Fluss project recognizes the following roles, each representing a distinct type of contribution to the project’s development:
+
+- **Mentor** - A mentor for an Apache Incubator project is an experienced ASF member who guides the podling through incubation. They help the project adopt "The Apache Way," ensure licensing and IP compliance, and support community growth. Mentors also advise on graduation readiness and represent the podling to the Incubator PMC.
+
+- **PPMC Member** - The podling project management committee (PPMC) is responsible for the management of the incubator project. The PPMC is the vehicle through which decision-making power and responsibility for oversight devolves to developers. While committers on a project have the ability to update the code, only the PPMC as a body has the authority to vote on formal releases of the project's software. The PPMC is also responsible for voting in new committers and PPMC members to the project, and following other policies as outlined in this document.
+
+- **Committer** - Committers have read-write access to the code repository, signed the CLA, and use an @apache.org email. There's no timeline or specific requirement to become a committer, but active contributors are strong candidates. As a committer, you shape the project's future by reviewing and merging code, testing release candidates, participating in discussions, and contributing in various ways. Active committers may be invited to join the PPMC.
+
+### Contributors
+A canonical list of contributors can be found in the [Apache Fluss GitHub repository](https://github.com/apache/fluss/graphs/contributors).

--- a/website/community/welcome.mdx
+++ b/website/community/welcome.mdx
@@ -57,36 +57,3 @@ import GoogleCalendarConsent from "@site/src/components/GoogleCalendarConsent";
 
 <GoogleCalendarConsent calendarId="25326691dcaf6dbb9939efe149bb85f2888a654c693763b2d45720502de526f8" />
 
-## Fluss Team
-We'd like to thank the following members and committers to the Apache Fluss project who have helped get the project to where it is today. This list might be stale, the canonical list of members is located on [Apache's website](https://people.apache.org/committers-by-project.html#fluss).
-
-### Members
-
-| Public Name          | GitHub Username                                    | Apache ID                                                                     | Role(s)             |
-| -------------------- | -------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------- |
-| Becket Qin           | [@becketqin](https://github.com/becketqin)         | [jqin](https://people.apache.org/committer-index.html#jqin)                   | Mentor, PPMC Member |
-| Benchao Li           | [@libenchao](https://github.com/libenchao)         | [libenchao](https://people.apache.org/committer-index.html#libenchao)         | PPMC Member         |
-| Feng Wang            | [@wangfengpro](https://github.com/wangfengpro)     | [fengwang](https://people.apache.org/committer-index.html#fengwang)           | PPMC Member         |
-| Giannis Polyzos      | [@polyzos](https://github.com/polyzos)             | [ipolyzos](https://people.apache.org/committer-index.html#ipolyzos)           | PPMC Member         |
-| Hongshun Wang        | [@loserwang1024](https://github.com/loserwang1024) | [hongshun](https://people.apache.org/committer-index.html#hongshun)           | Committer           |
-| Jean-Baptiste Onofré | [@jbonofre](https://github.com/jbonofre)           | [jbonofre](https://people.apache.org/committer-index.html#jbonofre)           | Mentor, PPMC Member |
-| Jark Wu              | [@wuchong](https://github.com/wuchong)             | [jark](https://people.apache.org/committer-index.html#jark)                   | PPMC Member         |
-| Jingsong Lee         | [@JingsongLi](https://github.com/JingsongLi)       | [lzljs3620320](https://people.apache.org/committer-index.html#lzljs3620320)   | Mentor, PPMC Member |
-| Mehul Batra          | [@MehulBatra](https://github.com/MehulBatra)       | [mehulbatra](https://people.apache.org/committer-index.html#mehulbatra)       | Committer           |
-| Michael Koepf        | [@michaelkoepf](https://github.com/michaelkoepf)   | [michaelkoepf](https://people.apache.org/committer-index.html#michaelkoepf)   | PPMC Member         |
-| Nicholas Jiang       | [@SteNicholas](https://github.com/SteNicholas)     | [nicholasjiang](https://people.apache.org/committer-index.html#nicholasjiang) | PPMC Member         |
-| Yu Li                | [@carp84](https://github.com/carp84)               | [liyu](https://people.apache.org/committer-index.html#liyu)                   | Mentor, PPMC Member |
-| Yuxia Luo            | [@luoyuxia](https://github.com/luoyuxia)           | [yuxia](https://people.apache.org/committer-index.html#yuxia)                 | PPMC Member         |
-| Yunhong Zheng        | [@swuferhong](https://github.com/swuferhong)       | [yunhong](https://people.apache.org/committer-index.html#yunhong)             | PPMC Member         |
-| Zili Chen            | [@tisonkun](https://github.com/tisonkun)           | [tison](https://people.apache.org/committer-index.html#tison)                 | Mentor, PPMC Member |
-
-### Roles
-
-The Apache Fluss project recognizes the following roles, each representing a distinct type of contribution to the project’s development:
-
-- **Mentor** - A mentor for an Apache Incubator project is an experienced ASF member who guides the podling through incubation. They help the project adopt "The Apache Way," ensure licensing and IP compliance, and support community growth. Mentors also advise on graduation readiness and represent the podling to the Incubator PMC.
-- **PPMC Member** - The podling project management committee (PPMC) is responsible for the management of the incubator project. The PPMC is the vehicle through which decision-making power and responsibility for oversight devolves to developers. While committers on a project have the ability to update the code, only the PPMC as a body has the authority to vote on formal releases of the project's software. The PPMC is also responsible for voting in new committers and PPMC members to the project, and following other policies as outlined in this document.
-- **Committer** - Committers have read-write access to the code repository, signed the CLA, and use an @apache.org email. There's no timeline or specific requirement to become a committer, but active contributors are strong candidates. As a committer, you shape the project's future by reviewing and merging code, testing release candidates, participating in discussions, and contributing in various ways. Active committers may be invited to join the PPMC.
-
-### Contributors
-A canonical list of contributors can be found in the [Apache Fluss GitHub repository](https://github.com/apache/fluss/graphs/contributors).


### PR DESCRIPTION
### Purpose

Linked issue: close https://github.com/apache/fluss/issues/1935

Per Issue https://github.com/apache/fluss/issues/1935, this pull request introduces a new "Fluss Team" section within the Community area of the website. This section includes relevant information for all of the PMC Members for Apache Fluss (e.g., Apache ID, GitHub Username, and Public Name) as well as a separate link to the available contributors to the project.

The primary goal of this effort is to increase visibility and transparency into the project while also recognizing members of the project and community.

### Brief change log

Added a new "Fluss Team" section under the Community area of the website which introduces:
- A link to the official Apache Committers By Project page (prefiltered to Fluss).
- A new table containing all members of the existing PMC for Apache Fluss, including their Apache ID, GitHub Username, and Public Name (with links where applicable).
- An additional section and link for the existing contributors to the project which links to the corresponding Contributors section of this repository.

### Tests

N/A

### API and Format

N/A

### Documentation

N/A; Although technically this introduces _new_ documentation, however it isn't related to any technical aspect of the project.
