### PR TITLE
[docs] Make README consistent with developer guide regarding minimum Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,15 +43,12 @@ Prerequisites for building Apache Fluss:
 - Unix-like environment (we use Linux, Mac OS X, Cygwin, WSL)
 - Git
 - Maven (we require version >= 3.8.6)
-- Java 8 or 11
+- Java 11
 
 ```bash
 git clone https://github.com/apache/fluss.git
 cd fluss
-# in case of java 11
 ./mvnw clean package -DskipTests
-# or in case of java 8
-./mvnw clean package -DskipTests -Pjava8
 ```
 
 Apache Fluss is now installed in `build-target`. The build command uses Maven Wrapper (`mvnw`) which ensures the correct Maven version is used.


### PR DESCRIPTION
Although we have the Java 8 profile in Maven, it is not advertised actively to users anymore in the [developer guide](fluss.apache.org/community/dev/building/). Thus, the README should also not actively advertise it.