### PR TITLE
[mvnw script] fix mvnw script error on macos

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -217,18 +217,13 @@ elif set_java_home; then
   verbose " - Running Downloader.java ..."
   "$(native_path "$JAVACMD")" -cp "$(native_path "$TMP_DOWNLOAD_DIR")" Downloader "$distributionUrl" "$(native_path "$targetZip")"
 fi
-#  setup proper sha256 command
-if command -v sha256sum >/dev/null; then 
-  SHA_CMD="sha256sum -c" 
-elif command -v shasum >/dev/null; then 
-  SHA_CMD="shasum -a 256 -c"
-fi
+
+# darwin sha command behavior requires "-"" as suffix to read from stdin
+SHA_CMD_SUFFIX=""
 case "$(uname -s)" in
   Darwin*)
-    if [ "$SHA_CMD" != "" ]; then
-      SHA_CMD="$SHA_CMD -"
-      echo "Using sha256 command on mac os: $SHA_CMD"
-    fi
+      SHA_CMD_SUFFIX=" -"
+      echo "Using sha command on mac os with suffix : $SHA_CMD_SUFFIX"
     ;;
 esac
 # If specified, validate the SHA-256 sum of the Maven distribution zip file
@@ -239,11 +234,11 @@ if [ -n "${distributionSha256Sum-}" ]; then
     echo "Please disable validation by removing 'distributionSha256Sum' from your maven-wrapper.properties." >&2
     exit 1
   elif command -v sha256sum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | ${SHA_CMD} >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | sha256sum -c $SHA_CMD_SUFFIX >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   elif command -v shasum >/dev/null; then
-    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | ${SHA_CMD} >/dev/null 2>&1; then
+    if echo "$distributionSha256Sum  $TMP_DOWNLOAD_DIR/$distributionUrlName" | shasum -a 256 -c $SHA_CMD_SUFFIX >/dev/null 2>&1; then
       distributionSha256Result=true
     fi
   else


### PR DESCRIPTION

## Contribution Checklist

≈

### Purpose
https://github.com/apache/fluss/issues/1965

Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

bug fix on shell script 
### Tests

local run pass test on 
Darwin Kernel Version 25.0.0: Wed Sep 17 21:42:08 PDT 2025; root:xnu-12377.1.9~141/RELEASE_ARM64_T8132 arm64
```
❯ ./mvnw --version 2>&1 | head -20
Using sha256 command on mac os: sha256sum -c -
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: ~/.m2/wrapper/dists/apache-maven-3.8.6/fa5e371
Java version: 17.0.5, vendor: Oracle Corporation, runtime: /Library/Java/JavaVirtualMachines/jdk-17.0.5.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "26.0.1", arch: "aarch64", family: "Mac"
```
### API and Format

n/a

### Documentation

n/a