### PR TITLE
[docker] use gosu to start the coordinator-server and tablet-server

### DIFF
--- a/docker/fluss/Dockerfile
+++ b/docker/fluss/Dockerfile
@@ -25,7 +25,7 @@ FROM eclipse-temurin:17-jre-jammy AS builder
 # Install dependencies
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install gpg libsnappy1v5 gettext-base libjemalloc-dev; \
+  apt-get -y install gpg libsnappy1v5 gettext-base libjemalloc-dev gosu; \
   rm -rf /var/lib/apt/lists/*
 
 # Please copy build-target to the docker dictory first, then copy to the image.

--- a/docker/fluss/docker-entrypoint.sh
+++ b/docker/fluss/docker-entrypoint.sh
@@ -26,6 +26,7 @@ prepare_configuration() {
         echo "${FLUSS_PROPERTIES}" >> "${CONF_FILE}"
     fi
     envsubst < "${CONF_FILE}" > "${CONF_FILE}.tmp" && mv "${CONF_FILE}.tmp" "${CONF_FILE}"
+    chown fluss:fluss "${CONF_FILE}"
 }
 
 prepare_configuration
@@ -39,11 +40,11 @@ if [ "$1" = "help" ]; then
 elif [ "$1" = "coordinatorServer" ]; then
   args=("${args[@]:1}")
   echo "Starting Coordinator Server"
-  exec "$FLUSS_HOME/bin/coordinator-server.sh" start-foreground "${args[@]}"
+  exec gosu fluss "$FLUSS_HOME/bin/coordinator-server.sh" start-foreground "${args[@]}"
 elif [ "$1" = "tabletServer" ]; then
   args=("${args[@]:1}")
   echo "Starting Tablet Server"
-  exec "$FLUSS_HOME/bin/tablet-server.sh" start-foreground "${args[@]}"
+  exec gosu fluss "$FLUSS_HOME/bin/tablet-server.sh" start-foreground "${args[@]}"
 fi
 
 args=("${args[@]}")


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: https://github.com/apache/fluss/issues/1854

<!-- What is the purpose of the change -->

### Brief change log
1. add **gosu** in Dockerfile
2.  use "**gosu fluss**" to start the relevant processes in docker-entrypoint.sh

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
