### PR TITLE
[server] Close the DynamicConfigManager before closing the ZookeeperClient to prevent exceptions

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/authorizer/DefaultAuthorizer.java
@@ -159,10 +159,6 @@ public class DefaultAuthorizer extends AbstractAuthorizer implements FatalErrorH
 
     @Override
     public void close() {
-        if (zooKeeperClient != null) {
-            zooKeeperClient.close();
-        }
-
         if (aclChangeNotificationWatcher != null) {
             aclChangeNotificationWatcher.stop();
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/authorizer/ZkNodeChangeNotificationWatcher.java
@@ -91,7 +91,7 @@ public class ZkNodeChangeNotificationWatcher {
             return;
         }
         running = false;
-        LOG.info("Stopping TableChangeWatcher");
+        LOG.info("Stopping ZkNodeChangeNotificationWatcher");
         curatorCache.close();
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/tablet/TabletServer.java
@@ -382,10 +382,6 @@ public class TabletServer extends ServerBase {
             }
 
             try {
-                if (zkClient != null) {
-                    zkClient.close();
-                }
-
                 // TODO currently, rpc client don't have timeout logic. After implementing the
                 // timeout logic, we need to move the closure of rpc client to after the closure of
                 // replica manager.
@@ -431,6 +427,9 @@ public class TabletServer extends ServerBase {
                     lakeCatalogDynamicLoader.close();
                 }
 
+                if (zkClient != null) {
+                    zkClient.close();
+                }
             } catch (Throwable t) {
                 exception = ExceptionUtils.firstOrSuppressed(t, exception);
             }


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2017 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
