### PR TITLE
[server] Set the waiting time of executing server shutdown hook to 120s to avoid an unclean server shutdown

### DIFF
--- a/fluss-dist/src/main/resources/bin/fluss-daemon.sh
+++ b/fluss-dist/src/main/resources/bin/fluss-daemon.sh
@@ -89,8 +89,10 @@ function guaranteed_kill {
   kill $to_stop_pid
   # if timeout exists, use it
   if command -v timeout &> /dev/null ; then
-    # wait 10 seconds for process to stop. By default, Fluss kills the JVM 5 seconds after sigterm.
-    timeout 10 tail --pid=$to_stop_pid -f /dev/null &> /dev/null
+    # wait 120 seconds for process to stop.This timeout shouldn't be set too small; if it is, the server close
+    # logic within the shutdown hook won't have enough time to complete properly, which would cause the server to
+    # enter an unclean shutdown state.
+    timeout 120 tail --pid=$to_stop_pid -f /dev/null &> /dev/null
     if [ "$?" -eq 124 ]; then
       echo "Daemon $daemon didn't stop within 10 seconds. Killing it."
       # send sigkill


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2025 

Set the waiting time of executing server shutdown hook to 120s to avoid an unclean server shutdown.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
