### PR TITLE
[hotfix] remove kafka compatibility from the roadmap

### DIFF
--- a/website/src/pages/roadmap.md
+++ b/website/src/pages/roadmap.md
@@ -1,7 +1,5 @@
 # Fluss Roadmap
 This roadmap means to provide users and contributors with a high-level summary of ongoing efforts in the Fluss community. The roadmap contains both efforts working in process as well as completed efforts, so that users may get a better impression of the overall status and direction of those developments.
-## Kafka Protocol Compatibility
-Fluss will support the Kafka network protocol to enable users to use Fluss as a drop-in replacement for Kafka. This will allow users to leverage Fluss's real-time storage capabilities while maintaining compatibility with existing Kafka applications.
 ## Flink Integration
 Fluss will provide deep integration with Apache Flink, enabling users a single engine experience for building real-time analytics applications. The integration will include:
 - Upgrade Flink version to 2.x


### PR DESCRIPTION
Removing the Kafka compatibility from the roadmap, as it might be confusing to users. As we discussed on our community sync Kafka compatibility is always welcomed as part of contributions, however it won't be on our direct plans because we want Fluss to set the way **beyond Kafka**. Moreover:
1. Providing a kafka-compatible api means using Fluss as a drop-in replacement for Kafka. Fluss provides way much functionality though, so users won't see benefits, by just using the kafka api.

2. After discussions with people supporting the kafka-api, seems like its lot of work, and the result is not the best one.. So we will have to put too much effort and then there is also lots of maintenance effort.