### PR TITLE
[hotfix][client] Retry to initial cluster when encounter TimeoutException

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/metadata/MetadataUpdater.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/metadata/MetadataUpdater.java
@@ -336,7 +336,9 @@ public class MetadataUpdater {
             } catch (Exception e) {
                 Throwable cause = stripExecutionException(e);
                 // in case of bootstrap is recovering, we should retry to connect.
-                if (!(cause instanceof StaleMetadataException || cause instanceof NetworkException)
+                if (!(cause instanceof StaleMetadataException
+                                || cause instanceof NetworkException
+                                || cause instanceof TimeoutException)
                         || retryCount >= maxRetryTimes) {
                     throw e;
                 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

```
java.lang.IllegalStateException: Failed to initialize fluss client connection to bootstrap servers: [xxx..com/xxx:80]. 
Reason: null
	at org.apache.fluss.client.metadata.MetadataUpdater.initializeCluster(MetadataUpdater.java:319)
	at org.apache.fluss.client.metadata.MetadataUpdater.<init>(MetadataUpdater.java:72)
	at org.apache.fluss.client.FlussConnection.<init>(FlussConnection.java:85)
	at org.apache.fluss.client.ConnectionFactory.createConnection(ConnectionFactory.java:66)
	at org.apache.fluss.flink.source.reader.FlinkSourceSplitReader.<init>(FlinkSourceSplitReader.java:127)
	at org.apache.fluss.flink.source.reader.FlinkSourceReader.lambda$new$0(FlinkSourceReader.java:69)
	at org.apache.flink.connector.base.source.reader.fetcher.SplitFetcherManager.createSplitFetcher(SplitFetcherManager.java:196)
	at org.apache.flink.connector.base.source.reader.fetcher.SingleThreadFetcherManager.addSplits(SingleThreadFetcherManager.java:107)
	at org.apache.flink.connector.base.source.reader.SourceReaderBase.addSplits(SourceReaderBase.java:258)
	at org.apache.flink.streaming.api.operators.SourceOperator.open(SourceOperator.java:380)
	at org.apache.flink.streaming.runtime.tasks.RegularOperatorChain.initializeStateAndOpenOperators(RegularOperatorChain.java:107)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreGates(StreamTask.java:842)
	at org.apache.flink.streaming.runtime.tasks.StreamTaskActionExecutor$1.call(StreamTaskActionExecutor.java:55)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restoreInternal(StreamTask.java:789)
	at org.apache.flink.streaming.runtime.tasks.StreamTask.restore(StreamTask.java:746)
	at org.apache.flink.runtime.taskmanager.Task.runWithSystemExitMonitoring(Task.java:968)
	at org.apache.flink.runtime.taskmanager.Task.restoreAndInvoke(Task.java:937)
	at org.apache.flink.runtime.taskmanager.Task.doRun(Task.java:754)
	at org.apache.flink.runtime.taskmanager.Task.run(Task.java:569)
	at java.lang.Thread.run(Thread.java:879)
Caused by: java.util.concurrent.TimeoutException
	at java.util.concurrent.CompletableFuture.timedGet(CompletableFuture.java:1784)
	at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:1928)
	at org.apache.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster(MetadataUtils.java:163)
	at org.apache.fluss.client.utils.MetadataUtils.sendMetadataRequestAndRebuildCluster(MetadataUtils.java:68)
	at org.apache.fluss.client.metadata.MetadataUpdater.tryToInitializeCluster(MetadataUpdater.java:372)
	at org.apache.fluss.client.metadata.MetadataUpdater.tryToInitializeClusterWithRetries(MetadataUpdater.java:335)
	at org.apache.fluss.client.metadata.MetadataUpdater.initializeCluster(MetadataUpdater.java:292)
	... 19 more
```

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
