### PR TITLE
[server] Get table.datalake.format from dynamic configs when get table info.

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/MetadataManager.java
@@ -562,10 +562,14 @@ public class MetadataManager {
         }
         TableRegistration tableReg = optionalTable.get();
         SchemaInfo schemaInfo = getLatestSchema(tablePath);
-        Map<String, String> tableLakeOptions =
-                lakeCatalogDynamicLoader.getLakeCatalogContainer().getDefaultTableLakeOptions();
-        removeSensitiveTableOptions(tableLakeOptions);
-        return tableReg.toTableInfo(tablePath, schemaInfo, tableLakeOptions);
+        LakeCatalogDynamicLoader.LakeCatalogContainer lakeCatalogContainer =
+                lakeCatalogDynamicLoader.getLakeCatalogContainer();
+        removeSensitiveTableOptions(lakeCatalogContainer.getDefaultTableLakeOptions());
+        return tableReg.toTableInfo(
+                tablePath,
+                schemaInfo,
+                lakeCatalogContainer.getDefaultTableLakeOptions(),
+                lakeCatalogContainer.getDataLakeFormat());
     }
 
     public Map<TablePath, TableInfo> getTables(Collection<TablePath> tablePaths)
@@ -587,15 +591,16 @@ public class MetadataManager {
                 }
                 TableRegistration tableReg = tablePath2TableRegistrations.get(tablePath);
                 SchemaInfo schemaInfo = tablePath2SchemaInfos.get(tablePath);
+                LakeCatalogDynamicLoader.LakeCatalogContainer lakeCatalogContainer =
+                        lakeCatalogDynamicLoader.getLakeCatalogContainer();
 
                 result.put(
                         tablePath,
                         tableReg.toTableInfo(
                                 tablePath,
                                 schemaInfo,
-                                lakeCatalogDynamicLoader
-                                        .getLakeCatalogContainer()
-                                        .getDefaultTableLakeOptions()));
+                                lakeCatalogContainer.getDefaultTableLakeOptions(),
+                                lakeCatalogContainer.getDataLakeFormat()));
             }
         } catch (Exception e) {
             throw new FlussRuntimeException(


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2072 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
