### PR TITLE
[FLUSS-2062][docs] Added Redirect for Latest Stable Version Docs

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -124,6 +124,32 @@ const config: Config = {
           ],
       },
     ],
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+          // Create redirects from the available routes that have already been created
+          createRedirects(existingPath) {
+            // Only evaluate paths related to documentation
+            if (!existingPath.startsWith('/docs/')) {
+              return undefined;
+            }
+            
+            // Extract the relative path after /docs/
+            const relativeDocsPath = existingPath.substring(6); 
+            const firstSegment = relativeDocsPath.split('/')[0];
+            
+            // Exclude any known version identifiers aligned with existing routes
+            const existingVersionedRoutes = ['next', ...Object.keys(versionsMap)];
+            if (existingVersionedRoutes.includes(firstSegment)) {
+              return undefined;
+            }
+            
+            // Redirect the explicit versioned path to the implicit unversioned path
+            return [`/docs/${latestVersion}${existingPath.replace('/docs', '')}`];
+        },
+      },
+    ],
+
   ],
   themeConfig: {
     image: 'img/logo/png/colored_logo.png',

--- a/website/package.json
+++ b/website/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.9.2",
     "@docusaurus/plugin-pwa": "^3.9.2",
+    "@docusaurus/plugin-client-redirects": "^3.9.2",
     "@docusaurus/preset-classic": "^3.9.2",
     "@mdx-js/react": "^3.0.0",
     "algoliasearch": "^5.10.2",


### PR DESCRIPTION
### Purpose

Linked issue: close https://github.com/apache/fluss/issues/2062

Per Issue https://github.com/apache/fluss/issues/2062, this pull request adds redirect support for the latest stable version documentation (e.g. `docs/0.8/engine-flink/getting-started/` → `docs/engine-flink/getting-started/`). This change will ensure that both implicit and explicit references to the latest stable version are resolved correctly, avoiding broken links.

### Brief change log

- Added a dependency on the `@docusaurus/plugin-client-redirects` plugin to support performing client-side redirects.
- Added a new `createRedirects` redirect rule that applies only to the docs area, which will handle ensuring that the existing routes are evaluated and redirect routes are defined for those that are considered "unversioned" (e.g. "next", non-existant versions, etc.)
  - Note: The `createRedirects` function is not at all intuitive and I [highly recommend reviewing over the documentation here](https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects#CreateRedirectsFn) to help make sense of things.

### Tests

These changes were tested locally and require an explicit `npm run build` and `npm run serve` as redirect rules are _only_ applied for production builds (so an `npm run start` will _not_ apply them). You can see an example of this running locally and successfully navigating through the available versions _and_ redirecting routes that explicitly use the latest, stable version (0.8) below:

https://github.com/user-attachments/assets/7aafa9c5-aec6-4d60-a3e4-73f6b3b5eb35

### API and Format

N/A

### Documentation

N/A
