### PR TITLE
[kv/auto increment column]: Add an implementation of AutoIncIDBuffer

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/AutoIncIDBuffer.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/AutoIncIDBuffer.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv;
+
+import org.apache.fluss.annotation.VisibleForTesting;
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.server.zk.data.ZkData;
+import org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.fluss.shaded.curator5.org.apache.curator.framework.recipes.atomic.AtomicValue;
+import org.apache.fluss.shaded.curator5.org.apache.curator.framework.recipes.atomic.DistributedAtomicLong;
+import org.apache.fluss.shaded.curator5.org.apache.curator.retry.BoundedExponentialBackoffRetry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.concurrent.ThreadSafe;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.fluss.utils.Preconditions.checkArgument;
+
+/**
+ * A buffer for auto-increment IDs. It buffers a range of IDs from ZooKeeper to
+ * reduce the overhead
+ * of accessing ZooKeeper.
+ */
+@ThreadSafe
+public class AutoIncIDBuffer {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AutoIncIDBuffer.class);
+
+    private static final int RETRY_TIMES = 10;
+    private static final int BASE_SLEEP_MS = 100;
+    private static final int MAX_SLEEP_MS = 1000;
+
+    private final DistributedAtomicLong distAtomicLong;
+    private final long batchSize;
+
+    // The current available range [localCurrent, localEnd)
+    private final AtomicLong localCurrent;
+    private final AtomicLong localEnd;
+
+    public AutoIncIDBuffer(
+            CuratorFramework zkClient, TablePath tablePath, int columnIdx, long batchSize) {
+        this(
+                new DistributedAtomicLong(
+                        zkClient,
+                        ZkData.AutoIncZNode.path(tablePath, columnIdx),
+                        new BoundedExponentialBackoffRetry(
+                                BASE_SLEEP_MS, MAX_SLEEP_MS, RETRY_TIMES)),
+                batchSize);
+    }
+
+    @VisibleForTesting
+    AutoIncIDBuffer(DistributedAtomicLong distAtomicLong, long batchSize) {
+        checkArgument(batchSize > 0, "Batch size must be greater than 0.");
+        this.distAtomicLong = distAtomicLong;
+        this.batchSize = batchSize;
+        this.localCurrent = new AtomicLong(0);
+        this.localEnd = new AtomicLong(0);
+    }
+
+    /**
+     * Get a unique ID. If the buffer is empty, it will fetch a new batch of IDs
+     * from ZooKeeper.
+     *
+     * @return a unique ID.
+     */
+    public synchronized long getAndIncrement() throws Exception {
+        if (localCurrent.get() >= localEnd.get()) {
+            // buffer is empty, fetch new batch
+            fetchBatch();
+        }
+
+        return localCurrent.getAndIncrement();
+    }
+
+    private void fetchBatch() throws Exception {
+        AtomicValue<Long> value = distAtomicLong.add(batchSize);
+        if (value.succeeded()) {
+            // value.preValue() is the value BEFORE addition.
+            // value.postValue() is the value AFTER addition.
+            // Example:
+            // Initial ZK value = 0.
+            // add(100). pre=0, post=100.
+            // We own range: 1 to 100 (inclusive).
+            // So logic:
+            // start = preValue + 1
+            // end = postValue + 1 (exclusive) -> so valid is < end
+
+            long preValue = value.preValue();
+            long postValue = value.postValue();
+
+            localCurrent.set(preValue + 1);
+            localEnd.set(postValue + 1);
+
+            LOG.info("Fetched new batch of IDs: [{}, {}).", localCurrent.get(), localEnd.get());
+        } else {
+            throw new Exception("Failed to allocate ID range from ZooKeeper.");
+        }
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/ZkData.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/ZkData.java
@@ -138,6 +138,17 @@ public final class ZkData {
     }
 
     /**
+     * The znode for auto increment column of a table. The znode path is:
+     *
+     * <p>/metadata/databases/[databaseName]/tables/[tableName]/auto_inc/col_[columnIdx]
+     */
+    public static final class AutoIncZNode {
+        public static String path(TablePath tablePath, int columnIdx) {
+            return TableZNode.path(tablePath) + "/auto_inc/col_" + columnIdx;
+        }
+    }
+
+    /**
      * The znode for a table which stores the schema information of a specific schema. The znode
      * path is:
      *

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/AutoIncIDBufferTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/AutoIncIDBufferTest.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.kv;
+
+import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.server.zk.ZooKeeperExtension;
+import org.apache.fluss.shaded.curator5.org.apache.curator.framework.CuratorFramework;
+import org.apache.fluss.server.zk.NOPErrorHandler;
+import org.apache.fluss.testutils.common.AllCallbackWrapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AutoIncIDBufferTest {
+
+    @RegisterExtension
+    public static final AllCallbackWrapper<ZooKeeperExtension> ZOO_KEEPER_EXTENSION_WRAPPER = new AllCallbackWrapper<>(
+            new ZooKeeperExtension());
+
+    private CuratorFramework zkClient;
+
+    @BeforeEach
+    void setUp() {
+        zkClient = ZOO_KEEPER_EXTENSION_WRAPPER.getCustomExtension().getZooKeeperClient(NOPErrorHandler.INSTANCE)
+                .getCuratorClient();
+    }
+
+    @Test
+    void testGetAndIncrement() throws Exception {
+        TablePath tablePath = TablePath.of("db", "t1");
+        int columnIdx = 0;
+        int batchSize = 10;
+        AutoIncIDBuffer buffer = new AutoIncIDBuffer(zkClient, tablePath, columnIdx, batchSize);
+
+        // buffer is empty, should fetch from ZK
+        // ZK initial value is 0.
+        // First batch: [1, 10]
+        assertThat(buffer.getAndIncrement()).isEqualTo(1L);
+        assertThat(buffer.getAndIncrement()).isEqualTo(2L);
+
+        // Consume all remaining
+        for (int i = 0; i < 8; i++) {
+            buffer.getAndIncrement();
+        }
+        // now buffer should be empty (current=11, end=11)
+
+        // checking internal state via side effect or just call again
+        // Next batch: [11, 20]
+        assertThat(buffer.getAndIncrement()).isEqualTo(11L);
+    }
+
+    @Test
+    void testMultipleBuffers() throws Exception {
+        TablePath tablePath = TablePath.of("db", "t2");
+        int columnIdx = 0;
+        int batchSize = 10;
+        AutoIncIDBuffer buffer1 = new AutoIncIDBuffer(zkClient, tablePath, columnIdx, batchSize);
+        AutoIncIDBuffer buffer2 = new AutoIncIDBuffer(zkClient, tablePath, columnIdx, batchSize);
+
+        // buffer1 takes [1, 10]
+        assertThat(buffer1.getAndIncrement()).isEqualTo(1L);
+
+        // buffer2 sees buffer1 took range, so it takes [11, 20]
+        assertThat(buffer2.getAndIncrement()).isEqualTo(11L);
+
+        // buffer1 continues
+        assertThat(buffer1.getAndIncrement()).isEqualTo(2L);
+    }
+
+    @Test
+    void testConcurrentFetch() throws Exception {
+        TablePath tablePath = TablePath.of("db", "t3");
+        int columnIdx = 0;
+        int batchSize = 100;
+        int numThreads = 5;
+        int fetchesPerThread = 50;
+
+        java.util.concurrent.ExecutorService executor = java.util.concurrent.Executors.newFixedThreadPool(numThreads);
+        java.util.List<java.util.concurrent.Future<java.util.Set<Long>>> futures = new java.util.ArrayList<>();
+
+        for (int i = 0; i < numThreads; i++) {
+            futures.add(executor.submit(() -> {
+                AutoIncIDBuffer buffer = new AutoIncIDBuffer(zkClient, tablePath, columnIdx, batchSize);
+                java.util.Set<Long> ids = new java.util.HashSet<>();
+                for (int j = 0; j < fetchesPerThread; j++) {
+                    ids.add(buffer.getAndIncrement());
+                }
+                return ids;
+            }));
+        }
+
+        java.util.Set<Long> allIds = new java.util.HashSet<>();
+        for (java.util.concurrent.Future<java.util.Set<Long>> future : futures) {
+            allIds.addAll(future.get());
+        }
+
+        // Check if we got expected number of unique IDs
+        assertThat(allIds).hasSize(numThreads * fetchesPerThread);
+
+        executor.shutdown();
+    }
+}


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2111

<!-- What is the purpose of the change -->

### Brief change log

Adding code for AutoIncIDBuffer in fluss-server as described in [FIP-16](https://cwiki.apache.org/confluence/display/FLUSS/FIP-16%3A+Auto-Increment+Column). This just adds changes for the buffer, integration may happen in a subsequent PR.

### Tests

Added some Unit tests to test some of the scenarios.

### API and Format

No.

### Documentation

If is related to [FIP-16](https://cwiki.apache.org/confluence/display/FLUSS/FIP-16%3A+Auto-Increment+Column)
