### PR TITLE
[client] Add another queue for re-enqueue operation only in LookupSender to avoid deadlocks during re-enqueue

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupSender.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/lookup/LookupSender.java
@@ -157,6 +157,9 @@ class LookupSender implements Runnable {
             // lookup the leader node
             TableBucket tb = lookup.tableBucket();
             try {
+                // TODO Metadata requests are being sent too frequently here. consider first
+                // collecting the tables that need to be updated and then sending them together in
+                // one request.
                 leader = metadataUpdater.leaderFor(lookup.tablePath(), tb);
             } catch (Exception e) {
                 // if leader is not found, re-enqueue the lookup to send again.
@@ -423,7 +426,7 @@ class LookupSender implements Runnable {
     }
 
     private void reEnqueueLookup(AbstractLookupQuery<?> lookup) {
-        lookupQueue.appendLookup(lookup);
+        lookupQueue.reEnqueue(lookup);
     }
 
     private boolean canRetry(AbstractLookupQuery<?> lookup, Exception exception) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2110 

Add another queue for re-enqueue operation only in LookupSender to avoid deadlocks during re-enqueue

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
