### PR TITLE
[Helm] ServiceAccount for TabletServer, CoordinatorServer

### DIFF
--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-{{- if .Values.serviceAccount.enabled }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -35,7 +35,7 @@ spec:
         {{- include "fluss.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: coordinator
     spec:
-      {{- if .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "fluss.fullname" .) }}
       {{- end }}
       containers:

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -35,7 +35,7 @@ spec:
         {{- include "fluss.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: tablet
     spec:
-      {{- if .Values.serviceAccount.enabled }}
+      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "fluss.fullname" .) }}
       {{- end }}
       containers:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -68,8 +68,9 @@ resources: {}
   #     memory: 128Mi
 
 serviceAccount:
-  enabled: false
+  create: false
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-  # Useful for IRSA: eks.amazonaws.com/role-arn: arn:aws:iam::ACCOUNT_ID:role/ROLE_NAME
+  # Additional annotations to apply to the ServiceAccount.
+  # These can be useful, for example, to support integrations like workload identity.
   annotations: {}


### PR DESCRIPTION
### Purpose

Support of IRSA [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is an important feature which helps in configuring the necessary access for the `tablet-server` and `coordinater-server` to interact with S3 for remote storage.

I see that helm chart for version `0.9.0-incubating` is still not released. Hence, not bumping the version with this change. Let me know if this is fine. 


Update: In my testing I figured that `coordinater-server` also tried to connect with S3 and failed to start if the authentication was missing.

Also it is important to note that we need to set few extra `configurationOverrides` to make it work


```
configurationOverrides:
    # Configure S3 as remote storage backend for snapshots
    # Format: s3://bucket-name/path-prefix
    remote.data.dir: s3://bucket-name/remote-data
    # S3 region (required for S3 access)
    # Update this to your actual AWS region (e.g., eu-west-1, ap-southeast-1)
    s3.region: ""
    # Workaround: Set dummy non-empty access key to bypass Fluss's delegation token mechanism
    # This prevents S3FileSystemPlugin.setCredentialProvider() from calling
    # S3DelegationTokenReceiver.updateHadoopConfig() which requires delegation tokens.
    # The credential provider chain below will then use IRSA credentials instead.
    # These dummy values will be ignored by Hadoop's credential provider chain.
    s3.access-key: "dummy"
    s3.secret-key: "dummy"
    # Configure S3A credential provider chain for IRSA
    # Fluss uses AWS SDK 1.12.319 and Hadoop 3.4.0
    # The chain will try WebIdentityTokenCredentialsProvider first (for IRSA),
    # then fall back to other providers if needed
    # IRSA credentials are read from environment variables set by EKS:
    # - AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
    # - AWS_ROLE_ARN=arn:aws:iam::ACCOUNT:role/IAM-ROLE
    # Note: The dummy access keys above prevent Fluss from using delegation tokens.
    # Hadoop S3A will use this credential provider chain which supports IRSA.
    fs.s3a.aws.credentials.provider: com.amazonaws.auth.WebIdentityTokenCredentialsProvider,com.amazonaws.auth.EnvironmentVariableCredentialsProvider,com.amazonaws.auth.InstanceProfileCredentialsProvider
```

Linked issue: close #2141

### Brief change log

ServiceAccount for TabletServer

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
