### PR TITLE
[FLUSS-2137][docs] Added Recent Conference Talks and Sessions to Videos Area

### DIFF
--- a/website/learn/talks.md
+++ b/website/learn/talks.md
@@ -8,6 +8,51 @@ Talks and presentations about Apache Fluss from conferences, meetups, and commun
 
 ---
 
+### Fluss: A Streaming Storage for Real-Time Lakehouse
+**Jark Wu** • Carnegie Mellon Future Data Systems Seminar Series 2025 • December 2025
+
+This seminar session explores Fluss as the foundation of a Streaming Lakehouse model, where real-time data in Fluss and historical data in Lakehouse (Iceberg) are seamlessly unified for truly real-time analytics. Built on Apache Arrow, Fluss provides the columnar streaming storage and sub-second ingestion that make this unified model possible.
+
+[📹 Watch on YouTube](https://www.youtube.com/watch?v=mcFHZFb1CAo) | [Slides](https://speakerdeck.com/jark/cmu-db-2025fall-apache-fluss-a-streaming-storage-for-real-time-lakehouse)
+
+---
+
+### The Seven Deadly Sins of Streaming
+**Giannis Polyzos** • Big Data Conference Europe 2025 • December 2025
+
+Exploring the Streaming Lakehouse model—powered by Fluss’s columnar streaming storage—addresses the “Seven Deadly Sins of Streaming,” from redundant data copies and unqueryable streams to stale lakehouse data and costly architectures. By unifying streaming and lakehouse systems through streaming tables, Fluss enables real-time dashboards, streaming ETL, and Customer 360 use cases within a single, modern architecture that delivers fresher, more efficient real-time analytics.
+
+[📹 Watch on YouTube](https://www.youtube.com/watch?v=ZOh9XH4zGLM)
+
+---
+
+### Streaming Down the Fluss: Taming CDC Streams with Fluss, Fluss, and Paimon
+**Dominik Žnidaršič** • Flink Forward 2025 • November 2025
+
+This session explores how real-time data processing extends far beyond ingestion, focusing on what happens after the CDC stream lands. It offers a practical look at building a real-time lakehouse pipeline by integrating Flink, Fluss, and Paimon to deliver fast, efficient, and usable end-to-end analytics.
+
+[📹 Watch on YouTube](https://www.youtube.com/watch?v=ushwjnXmi2A)
+
+---
+
+### Fluss: Making Your Lakehouse Truly Real Time
+**Jark Wu** • Flink Forward 2025 • November 2025
+
+Exploring how Fluss bridges data streaming and the Lakehouse (Iceberg) by serving real-time data directly on top of it, enabling powerful analytics on streams while delivering low-latency updates to Iceberg—effectively transforming it into a Real-Time Lakehouse. We’ll close with real-world use cases that showcase how Fluss powers Real-Time Lakehouses and fuels the next generation of AI-driven applications.
+
+[📹 Watch on YouTube](https://www.youtube.com/watch?v=pnrW5r-4mIQ)
+
+---
+
+### Apache Fluss and The Seven Deadly Sins of Streaming
+**Giannis Polyzos** • Flink Forward 2025 • November 2025
+
+Exploring how Apache Fluss addresses the “seven deadly sins” of streaming by introducing streams-as-tables that unify streaming and lakehouse systems, unlocking modern real-time analytics use cases such as real-time dashboards, streaming ETL, and Customer 360—all within a single, cohesive architecture.
+
+[📹 Watch on YouTube](https://www.youtube.com/watch?v=3c5RgJFTsMM)
+
+---
+
 ### Fluss: Redefining Streaming Storage for Real-Time Data Analytics and AI
 **Jark Wu** • Flink Forward Asia 2025 • July 2025
 


### PR DESCRIPTION
### Purpose

Linked issue: close https://github.com/apache/fluss/issues/2137

Per Issue https://github.com/apache/fluss/issues/2137, this pull request adds a series of Fluss-related seminar sessions, conference talks, and other informative videos.

### Brief change log

- Added five new Fluss-related videos to the existing Talks page of the website with associated links, speaker notes (where applicable), etc.

### Tests

N/A

### API and Format

N/A

### Documentation

N/A
