### PR TITLE
[iceberg] Use DataFileSet / DeleteFileSet instead of normal collections

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/maintenance/RewriteDataFileResult.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/maintenance/RewriteDataFileResult.java
@@ -18,10 +18,9 @@
 
 package org.apache.fluss.lake.iceberg.maintenance;
 
-import org.apache.iceberg.DataFile;
+import org.apache.iceberg.util.DataFileSet;
 
 import java.io.Serializable;
-import java.util.List;
 
 /** The result for rewrite iceberg data files. */
 public class RewriteDataFileResult implements Serializable {
@@ -29,21 +28,21 @@ public class RewriteDataFileResult implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private final long snapshotId;
-    private final List<DataFile> deletedDataFiles;
-    private final List<DataFile> addedDataFiles;
+    private final DataFileSet deletedDataFiles;
+    private final DataFileSet addedDataFiles;
 
     public RewriteDataFileResult(
-            long snapshotId, List<DataFile> deletedDataFiles, List<DataFile> addedDataFiles) {
+            long snapshotId, DataFileSet deletedDataFiles, DataFileSet addedDataFiles) {
         this.snapshotId = snapshotId;
         this.deletedDataFiles = deletedDataFiles;
         this.addedDataFiles = addedDataFiles;
     }
 
-    public List<DataFile> deletedDataFiles() {
+    public DataFileSet deletedDataFiles() {
         return deletedDataFiles;
     }
 
-    public List<DataFile> addedDataFiles() {
+    public DataFileSet addedDataFiles() {
         return addedDataFiles;
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergCommittable.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergCommittable.java
@@ -21,6 +21,8 @@ import org.apache.fluss.lake.iceberg.maintenance.RewriteDataFileResult;
 
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -31,25 +33,25 @@ public class IcebergCommittable implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private final List<DataFile> dataFiles;
-    private final List<DeleteFile> deleteFiles;
+    private final DataFileSet dataFiles;
+    private final DeleteFileSet deleteFiles;
 
     private final List<RewriteDataFileResult> rewriteDataFiles;
 
     private IcebergCommittable(
-            List<DataFile> dataFiles,
-            List<DeleteFile> deleteFiles,
+            DataFileSet dataFiles,
+            DeleteFileSet deleteFiles,
             List<RewriteDataFileResult> rewriteDataFiles) {
         this.dataFiles = dataFiles;
         this.deleteFiles = deleteFiles;
         this.rewriteDataFiles = rewriteDataFiles;
     }
 
-    public List<DataFile> getDataFiles() {
+    public DataFileSet getDataFiles() {
         return dataFiles;
     }
 
-    public List<DeleteFile> getDeleteFiles() {
+    public DeleteFileSet getDeleteFiles() {
         return deleteFiles;
     }
 
@@ -66,8 +68,8 @@ public class IcebergCommittable implements Serializable {
      * entries.
      */
     public static class Builder {
-        private final List<DataFile> dataFiles = new ArrayList<>();
-        private final List<DeleteFile> deleteFiles = new ArrayList<>();
+        private final DataFileSet dataFiles = DataFileSet.create();
+        private final DeleteFileSet deleteFiles = DeleteFileSet.create();
 
         private final List<RewriteDataFileResult> rewriteDataFileResults = new ArrayList<>();
 
@@ -87,10 +89,7 @@ public class IcebergCommittable implements Serializable {
         }
 
         public IcebergCommittable build() {
-            return new IcebergCommittable(
-                    new ArrayList<>(dataFiles),
-                    new ArrayList<>(deleteFiles),
-                    rewriteDataFileResults);
+            return new IcebergCommittable(dataFiles, deleteFiles, rewriteDataFileResults);
         }
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeCommitter.java
@@ -48,7 +48,6 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -115,9 +114,7 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
             if (committable.getDeleteFiles().isEmpty()) {
                 // Simple append-only case: only data files, no delete files or compaction
                 AppendFiles appendFiles = icebergTable.newAppend();
-                for (DataFile dataFile : committable.getDataFiles()) {
-                    appendFiles.appendFile(dataFile);
-                }
+                committable.getDataFiles().forEach(appendFiles::appendFile);
                 snapshotUpdate = appendFiles;
             } else {
                 /*
@@ -131,10 +128,8 @@ public class IcebergLakeCommitter implements LakeCommitter<IcebergWriteResult, I
                  being committed.
                 */
                 RowDelta rowDelta = icebergTable.newRowDelta();
-                Arrays.stream(committable.getDataFiles().stream().toArray(DataFile[]::new))
-                        .forEach(rowDelta::addRows);
-                Arrays.stream(committable.getDeleteFiles().stream().toArray(DeleteFile[]::new))
-                        .forEach(rowDelta::addDeletes);
+                committable.getDataFiles().forEach(rowDelta::addRows);
+                committable.getDeleteFiles().forEach(rowDelta::addDeletes);
                 snapshotUpdate = rowDelta;
             }
 

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteTest.java
@@ -41,14 +41,13 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.TaskWriter;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DataFileSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static org.apache.fluss.lake.iceberg.utils.IcebergConversions.toIceberg;
 import static org.apache.fluss.metadata.TableDescriptor.BUCKET_COLUMN_NAME;
@@ -232,7 +231,7 @@ class IcebergRewriteTest {
 
     private static void appendTinyFilesWithRowsAndBucket(
             Table table, int files, int rowsPerFile, int baseOffset, int bucket) throws Exception {
-        List<DataFile> toAppend = new ArrayList<>(files);
+        DataFileSet toAppend = DataFileSet.create();
         for (int i = 0; i < files; i++) {
             toAppend.add(
                     writeTinyDataFile(table, rowsPerFile, baseOffset + (i * rowsPerFile), bucket));

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergWriteResultSerializerTest.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergWriteResultSerializerTest.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DataFileSet;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -80,8 +81,8 @@ class IcebergWriteResultSerializerTest {
         RewriteDataFileResult rewriteDataFileResult =
                 new RewriteDataFileResult(
                         1L,
-                        Collections.singletonList(dataFile),
-                        Collections.singletonList(dataFile));
+                        DataFileSet.of(Collections.singletonList(dataFile)),
+                        DataFileSet.of(Collections.singletonList(dataFile)));
         originalResult = new IcebergWriteResult(writeResult, rewriteDataFileResult);
         serializedData = serializer.serialize(originalResult);
         deserializedResult = serializer.deserialize(serializer.getVersion(), serializedData);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

For Iceberg V3 with Deletion Vectors we introduced `DataFileSet` & `DeleteFileSet` in Iceberg so that a `DeleteFile` is correctly compared by looking at its `location` / `contentOffset` / `contentSizeInBytes` (https://github.com/apache/iceberg/blob/ec269ee3ec0de4184eb536a6ef4f3523dc91332a/api/src/main/java/org/apache/iceberg/util/DeleteFileSet.java#L100-L102). Using `DataFileSet` prevents duplicate data file instances in collections. Therefore we should switch using to `DataFileSet` / `DeleteFileSet` everywhere to be future-proof.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
