### PR TITLE
[flink] Union read support read partition data for the partition exists in the lake but not in Fluss

### DIFF
--- a/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSource.java
+++ b/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSource.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.source;
+
+import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
+import org.apache.fluss.metadata.PartitionInfo;
+import org.apache.fluss.predicate.Predicate;
+import org.apache.fluss.utils.CloseableIterator;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A testing implementation of {@link LakeSource}. */
+public class TestingLakeSource implements LakeSource<LakeSplit> {
+
+    // bucket num of source table
+    private final int bucketNum;
+
+    // partition infos of partitions contain lake splits
+    private final List<PartitionInfo> partitionInfos;
+
+    public TestingLakeSource() {
+        this.bucketNum = 0;
+        this.partitionInfos = null;
+    }
+
+    public TestingLakeSource(int bucketNum, List<PartitionInfo> partitionInfos) {
+        this.bucketNum = bucketNum;
+        this.partitionInfos = partitionInfos;
+    }
+
+    @Override
+    public void withProject(int[][] project) {}
+
+    @Override
+    public void withLimit(int limit) {}
+
+    @Override
+    public FilterPushDownResult withFilters(List<Predicate> predicates) {
+        return null;
+    }
+
+    @Override
+    public Planner<LakeSplit> createPlanner(PlannerContext context) throws IOException {
+        return new TestingPlanner(bucketNum, partitionInfos);
+    }
+
+    @Override
+    public RecordReader createRecordReader(ReaderContext<LakeSplit> context) throws IOException {
+        return CloseableIterator::emptyIterator;
+    }
+
+    @Override
+    public SimpleVersionedSerializer<LakeSplit> getSplitSerializer() {
+        return new SimpleVersionedSerializer<LakeSplit>() {
+
+            @Override
+            public int getVersion() {
+                return 0;
+            }
+
+            @Override
+            public byte[] serialize(LakeSplit split) throws IOException {
+                if (split instanceof TestingLakeSplit) {
+                    TestingLakeSplit testingSplit = (TestingLakeSplit) split;
+                    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                    try (DataOutputStream dos = new DataOutputStream(baos)) {
+                        // Serialize bucket
+                        dos.writeInt(testingSplit.bucket());
+
+                        // Serialize partition list
+                        List<String> partition = testingSplit.partition();
+                        if (partition == null) {
+                            dos.writeInt(-1);
+                        } else {
+                            dos.writeInt(partition.size());
+                            for (String part : partition) {
+                                // Write a boolean flag to indicate if the string is null
+                                dos.writeBoolean(part != null);
+                                if (part != null) {
+                                    dos.writeUTF(part);
+                                }
+                            }
+                        }
+                    }
+                    return baos.toByteArray();
+                }
+                throw new IOException("Unsupported split type: " + split.getClass().getName());
+            }
+
+            @Override
+            public LakeSplit deserialize(int version, byte[] serialized) throws IOException {
+                if (version != 0) {
+                    throw new IOException("Unsupported version: " + version);
+                }
+
+                try (DataInputStream dis =
+                        new DataInputStream(new ByteArrayInputStream(serialized))) {
+                    // Deserialize bucket
+                    int bucket = dis.readInt();
+
+                    // Deserialize partition list
+                    int partitionSize = dis.readInt();
+                    List<String> partition;
+                    if (partitionSize < 0) {
+                        partition = null;
+                    } else {
+                        partition = new ArrayList<>(partitionSize);
+                        for (int i = 0; i < partitionSize; i++) {
+                            // Read boolean flag to determine if the string is null
+                            boolean isNotNull = dis.readBoolean();
+                            String part = isNotNull ? dis.readUTF() : null;
+                            partition.add(part);
+                        }
+                    }
+
+                    return new TestingLakeSplit(bucket, partition);
+                }
+            }
+        };
+    }
+}

--- a/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSplit.java
+++ b/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingLakeSplit.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.source;
+
+import java.util.List;
+
+/** A testing implementation of {@link LakeSplit}. */
+public class TestingLakeSplit implements LakeSplit {
+
+    private final int bucket;
+    private final List<String> partition;
+
+    public TestingLakeSplit(int bucket, List<String> partition) {
+        this.bucket = bucket;
+        this.partition = partition;
+    }
+
+    @Override
+    public String toString() {
+        return "TestingLakeSplit{" + "bucket=" + bucket + ", partition=" + partition + '}';
+    }
+
+    @Override
+    public int bucket() {
+        return bucket;
+    }
+
+    @Override
+    public List<String> partition() {
+        return partition;
+    }
+}

--- a/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingPlanner.java
+++ b/fluss-common/src/test/java/org/apache/fluss/lake/source/TestingPlanner.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.lake.source;
+
+import org.apache.fluss.metadata.PartitionInfo;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/** A testing implementation of {@link Planner}. */
+public class TestingPlanner implements Planner<LakeSplit> {
+
+    private final int bucketNum;
+    private final List<PartitionInfo> partitionInfos;
+
+    public TestingPlanner(int bucketNum, List<PartitionInfo> partitionInfos) {
+        this.bucketNum = bucketNum;
+        this.partitionInfos = partitionInfos;
+    }
+
+    @Override
+    public List<LakeSplit> plan() throws IOException {
+        List<LakeSplit> splits = new ArrayList<>();
+
+        for (PartitionInfo partitionInfo : partitionInfos) {
+            for (int i = 0; i < bucketNum; i++) {
+                splits.add(
+                        new TestingLakeSplit(
+                                i, partitionInfo.getResolvedPartitionSpec().getPartitionValues()));
+            }
+        }
+
+        return splits;
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/event/PartitionsRemovedEvent.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/event/PartitionsRemovedEvent.java
@@ -20,6 +20,7 @@ package org.apache.fluss.flink.source.event;
 import org.apache.flink.api.connector.source.SourceEvent;
 
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * A source event to represent partitions is removed to send from enumerator to reader.
@@ -39,6 +40,20 @@ public class PartitionsRemovedEvent implements SourceEvent {
 
     public Map<Long, String> getRemovedPartitions() {
         return removedPartitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PartitionsRemovedEvent that = (PartitionsRemovedEvent) o;
+        return Objects.equals(removedPartitions, that.removedPartitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(removedPartitions);
     }
 
     @Override

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/lake/LakeSplitSerializerTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/lake/LakeSplitSerializerTest.java
@@ -23,6 +23,7 @@ import org.apache.fluss.flink.lake.split.LakeSnapshotSplit;
 import org.apache.fluss.flink.source.split.SourceSplitBase;
 import org.apache.fluss.lake.serializer.SimpleVersionedSerializer;
 import org.apache.fluss.lake.source.LakeSplit;
+import org.apache.fluss.lake.source.TestingLakeSplit;
 import org.apache.fluss.metadata.TableBucket;
 
 import org.apache.flink.core.memory.DataInputDeserializer;
@@ -31,7 +32,6 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.List;
 
 import static org.apache.fluss.client.table.scanner.log.LogScanner.EARLIEST_OFFSET;
 import static org.apache.fluss.flink.lake.split.LakeSnapshotAndFlussLogSplit.LAKE_SNAPSHOT_FLUSS_LOG_SPLIT_KIND;
@@ -47,7 +47,7 @@ class LakeSplitSerializerTest {
     private static final int STOPPING_OFFSET = 1024;
 
     private static final LakeSplit LAKE_SPLIT =
-            new TestLakeSplit(0, Collections.singletonList("2025-08-18"));
+            new TestingLakeSplit(0, Collections.singletonList("2025-08-18"));
 
     private final SimpleVersionedSerializer<LakeSplit> sourceSplitSerializer =
             new TestSimpleVersionedSerializer();
@@ -203,38 +203,12 @@ class LakeSplitSerializerTest {
             if (version < V2) {
                 return LAKE_SPLIT;
             }
-            return new TestLakeSplit(0, Collections.singletonList("2025-08-19"));
+            return new TestingLakeSplit(0, Collections.singletonList("2025-08-19"));
         }
 
         @Override
         public int getVersion() {
             return V2;
-        }
-    }
-
-    private static class TestLakeSplit implements LakeSplit {
-
-        private final int bucket;
-        private final List<String> partition;
-
-        public TestLakeSplit(int bucket, List<String> partition) {
-            this.bucket = bucket;
-            this.partition = partition;
-        }
-
-        @Override
-        public String toString() {
-            return "TestLakeSplit";
-        }
-
-        @Override
-        public int bucket() {
-            return bucket;
-        }
-
-        @Override
-        public List<String> partition() {
-            return partition;
         }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceReaderTest.java
@@ -26,6 +26,8 @@ import org.apache.fluss.flink.source.event.PartitionsRemovedEvent;
 import org.apache.fluss.flink.source.metrics.FlinkSourceReaderMetrics;
 import org.apache.fluss.flink.source.split.LogSplit;
 import org.apache.fluss.flink.utils.FlinkTestBase;
+import org.apache.fluss.lake.source.LakeSource;
+import org.apache.fluss.lake.source.LakeSplit;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TablePath;
@@ -85,7 +87,8 @@ class FlinkSourceReaderTest extends FlinkTestBase {
                         clientConf,
                         tablePath,
                         tableDescriptor.getSchema().getRowType(),
-                        readerContext)) {
+                        readerContext,
+                        null)) {
 
             // first of all, add all splits of all partitions to the reader
             Map<Long, Set<TableBucket>> assignedBuckets = new HashMap<>();
@@ -159,7 +162,8 @@ class FlinkSourceReaderTest extends FlinkTestBase {
             Configuration flussConf,
             TablePath tablePath,
             RowType sourceOutputType,
-            SourceReaderContext context)
+            SourceReaderContext context,
+            LakeSource<LakeSplit> lakeSource)
             throws Exception {
         FutureCompletingBlockingQueue<RecordsWithSplitIds<RecordAndPos>> elementsQueue =
                 new FutureCompletingBlockingQueue<>();
@@ -181,6 +185,6 @@ class FlinkSourceReaderTest extends FlinkTestBase {
                 null,
                 new FlinkSourceReaderMetrics(context.metricGroup()),
                 recordEmitter,
-                null);
+                lakeSource);
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonSplit.java
+++ b/fluss-lake/fluss-lake-paimon/src/main/java/org/apache/fluss/lake/paimon/source/PaimonSplit.java
@@ -72,4 +72,14 @@ public class PaimonSplit implements LakeSplit {
     public boolean isBucketUnAware() {
         return isBucketUnAware;
     }
+
+    @Override
+    public String toString() {
+        return "PaimonSplit{"
+                + "dataSplit="
+                + dataSplit
+                + ", isBucketUnAware="
+                + isBucketUnAware
+                + '}';
+    }
 }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2194 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
