### PR TITLE
[kv] include hidden potential internal flush time in KV flush latency

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/rocksdb/RocksDBKv.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/rocksdb/RocksDBKv.java
@@ -18,6 +18,8 @@
 package org.apache.fluss.server.kv.rocksdb;
 
 import org.apache.fluss.exception.FlussRuntimeException;
+import org.apache.fluss.metrics.Counter;
+import org.apache.fluss.metrics.Histogram;
 import org.apache.fluss.rocksdb.RocksDBOperationUtils;
 import org.apache.fluss.server.utils.ResourceGuard;
 import org.apache.fluss.utils.BytesUtils;
@@ -89,8 +91,9 @@ public class RocksDBKv implements AutoCloseable {
         return rocksDBResourceGuard;
     }
 
-    public RocksDBWriteBatchWrapper newWriteBatch(long writeBatchSize) {
-        return new RocksDBWriteBatchWrapper(db, writeBatchSize);
+    public RocksDBWriteBatchWrapper newWriteBatch(
+            long writeBatchSize, Counter flushCount, Histogram flushLatencyHistogram) {
+        return new RocksDBWriteBatchWrapper(db, writeBatchSize, flushCount, flushLatencyHistogram);
     }
 
     public @Nullable byte[] get(byte[] key) throws IOException {


### PR DESCRIPTION
### Purpose

This change includes the hidden internal flush time during KV flushing.
`RocksDBWriteBatchWrapper` may trigger a flush implicitly when performing put or delete operations, which caused the previous latency measurement to be incomplete.

### Brief change log

Move startTime to the first line of the method.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
