### PR TITLE
[CP-0.8][flink] Fix MultipleParameterTool ClassNotFoundException in tiering service

### DIFF
--- a/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/adapter/Flink118MultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-1.18/src/test/java/org/apache/fluss/flink/adapter/Flink118MultipleParameterToolTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+/** Test for {@link MultipleParameterToolAdapter} in flink 1.18. */
+public class Flink118MultipleParameterToolTest extends FlinkMultipleParameterToolTest {}

--- a/fluss-flink/fluss-flink-1.19/src/test/java/org/apache/fluss/flink/adapter/Flink119MultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-1.19/src/test/java/org/apache/fluss/flink/adapter/Flink119MultipleParameterToolTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+/** Test for {@link MultipleParameterToolAdapter} in flink 1.19. */
+public class Flink119MultipleParameterToolTest extends FlinkMultipleParameterToolTest {}

--- a/fluss-flink/fluss-flink-1.20/src/test/java/org/apache/fluss/flink/adapter/Flink120MultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-1.20/src/test/java/org/apache/fluss/flink/adapter/Flink120MultipleParameterToolTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+/** Test for {@link MultipleParameterToolAdapter} in flink 1.20. */
+public class Flink120MultipleParameterToolTest extends FlinkMultipleParameterToolTest {}

--- a/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/adapter/MultipleParameterToolAdapter.java
+++ b/fluss-flink/fluss-flink-2.1/src/main/java/org/apache/fluss/flink/adapter/MultipleParameterToolAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+import org.apache.flink.util.MultipleParameterTool;
+
+import java.util.Map;
+
+/**
+ * An adapter for Flink {@link MultipleParameterTool} class. The {@link MultipleParameterTool} is
+ * moved to a new package since Flink 2.x, so this adapter helps to bridge compatibility for
+ * different Flink versions.
+ *
+ * <p>TODO: remove this class when no longer support all the Flink 1.x series.
+ */
+public class MultipleParameterToolAdapter {
+
+    private MultipleParameterToolAdapter() {}
+
+    private MultipleParameterTool multipleParameterTool;
+
+    public static MultipleParameterToolAdapter fromArgs(String[] args) {
+        MultipleParameterToolAdapter adapter = new MultipleParameterToolAdapter();
+        adapter.multipleParameterTool = MultipleParameterTool.fromArgs(args);
+        return adapter;
+    }
+
+    public Map<String, String> toMap() {
+        return this.multipleParameterTool.toMap();
+    }
+}

--- a/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/adapter/Flink21MultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-2.1/src/test/java/org/apache/fluss/flink/adapter/Flink21MultipleParameterToolTest.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+/** Test for {@link MultipleParameterToolAdapter} in flink 2.1. */
+public class Flink21MultipleParameterToolTest extends FlinkMultipleParameterToolTest {}

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/adapter/MultipleParameterToolAdapter.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/adapter/MultipleParameterToolAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+import org.apache.flink.api.java.utils.MultipleParameterTool;
+
+import java.util.Map;
+
+/**
+ * An adapter for Flink {@link MultipleParameterTool} class. The {@link MultipleParameterTool} is
+ * moved to a new package since Flink 2.x, so this adapter helps to bridge compatibility for
+ * different Flink versions.
+ *
+ * <p>TODO: remove this class when no longer support all the Flink 1.x series.
+ */
+public class MultipleParameterToolAdapter {
+
+    private MultipleParameterToolAdapter() {}
+
+    private MultipleParameterTool multipleParameterTool;
+
+    public static MultipleParameterToolAdapter fromArgs(String[] args) {
+        MultipleParameterToolAdapter adapter = new MultipleParameterToolAdapter();
+        adapter.multipleParameterTool = MultipleParameterTool.fromArgs(args);
+        return adapter;
+    }
+
+    public Map<String, String> toMap() {
+        return this.multipleParameterTool.toMap();
+    }
+}

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkMultipleParameterToolTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/adapter/FlinkMultipleParameterToolTest.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.flink.adapter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Test for {@link MultipleParameterToolAdapter}. */
+abstract class FlinkMultipleParameterToolTest {
+
+    @Test
+    public void testToMap() {
+        String[] args =
+                new String[] {
+                    "--multi1", "multiValue1", "--multi2", "multiValue2", "--multi1", "multiValue3"
+                };
+
+        MultipleParameterToolAdapter adapter = MultipleParameterToolAdapter.fromArgs(args);
+
+        // The last value is used.
+        assertThat(adapter.toMap()).containsEntry("multi1", "multiValue3");
+        assertThat(adapter.toMap()).containsEntry("multi2", "multiValue2");
+    }
+}

--- a/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTieringEntrypoint.java
+++ b/fluss-flink/fluss-flink-tiering/src/main/java/org/apache/fluss/flink/tiering/FlussLakeTieringEntrypoint.java
@@ -19,8 +19,8 @@ package org.apache.fluss.flink.tiering;
 
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
+import org.apache.fluss.flink.adapter.MultipleParameterToolAdapter;
 
-import org.apache.flink.api.java.utils.MultipleParameterTool;
 import org.apache.flink.configuration.JobManagerOptions;
 import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -39,7 +39,7 @@ public class FlussLakeTieringEntrypoint {
     public static void main(String[] args) throws Exception {
 
         // parse params
-        final MultipleParameterTool params = MultipleParameterTool.fromArgs(args);
+        final MultipleParameterToolAdapter params = MultipleParameterToolAdapter.fromArgs(args);
         Map<String, String> paramsMap = params.toMap();
 
         // extract fluss config


### PR DESCRIPTION


(cherry picked from commit 6dd9776627ec63836b344cf0824c454a49966f89)

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
