### PR TITLE
[lake] Fix zk lake snapshot node compatible issue

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/FlussTableLakeSnapshotCommitterTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/committer/FlussTableLakeSnapshotCommitterTest.java
@@ -21,18 +21,25 @@ import org.apache.fluss.client.metadata.LakeSnapshot;
 import org.apache.fluss.flink.utils.FlinkTestBase;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TablePath;
+import org.apache.fluss.server.zk.ZooKeeperClient;
+import org.apache.fluss.server.zk.data.ZkData;
+import org.apache.fluss.server.zk.data.lake.LakeTableSnapshot;
+import org.apache.fluss.server.zk.data.lake.LakeTableSnapshotJsonSerde;
+import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
+import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.fluss.utils.types.Tuple2;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import static org.apache.fluss.flink.tiering.committer.FlussTableLakeSnapshotCommitter.toCommitLakeTableSnapshotRequest;
 import static org.apache.fluss.record.TestData.DATA1_PARTITIONED_TABLE_DESCRIPTOR;
 import static org.apache.fluss.record.TestData.DATA1_TABLE_DESCRIPTOR;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,35 +68,11 @@ class FlussTableLakeSnapshotCommitterTest extends FlinkTestBase {
     void testCommit(boolean isPartitioned) throws Exception {
         TablePath tablePath =
                 TablePath.of("fluss", "test_commit" + (isPartitioned ? "_partitioned" : ""));
-        long tableId =
-                createTable(
-                        tablePath,
-                        isPartitioned
-                                ? DATA1_PARTITIONED_TABLE_DESCRIPTOR
-                                : DATA1_TABLE_DESCRIPTOR);
+        Tuple2<Long, Collection<Long>> tableIdAndPartitions = createTable(tablePath, isPartitioned);
+        long tableId = tableIdAndPartitions.f0;
+        Collection<Long> partitions = tableIdAndPartitions.f1;
 
-        List<String> partitions;
-        Map<String, Long> partitionNameAndIds = new HashMap<>();
-        if (!isPartitioned) {
-            FLUSS_CLUSTER_EXTENSION.waitUntilTableReady(tableId);
-            partitions = Collections.singletonList(null);
-        } else {
-            partitionNameAndIds = FLUSS_CLUSTER_EXTENSION.waitUntilPartitionAllReady(tablePath);
-            partitions = new ArrayList<>(partitionNameAndIds.keySet());
-        }
-
-        Map<TableBucket, Long> logEndOffsets = new HashMap<>();
-        for (int bucket = 0; bucket < 3; bucket++) {
-            long bucketOffset = bucket * bucket;
-            for (String partitionName : partitions) {
-                if (partitionName == null) {
-                    logEndOffsets.put(new TableBucket(tableId, bucket), bucketOffset);
-                } else {
-                    long partitionId = partitionNameAndIds.get(partitionName);
-                    logEndOffsets.put(new TableBucket(tableId, partitionId, bucket), bucketOffset);
-                }
-            }
-        }
+        Map<TableBucket, Long> logEndOffsets = mockLogEndOffsets(tableId, partitions);
 
         long snapshotId = 3;
         // commit offsets
@@ -100,5 +83,79 @@ class FlussTableLakeSnapshotCommitterTest extends FlinkTestBase {
         // get and check the offsets
         Map<TableBucket, Long> bucketLogOffsets = lakeSnapshot.getTableBucketsOffset();
         assertThat(bucketLogOffsets).isEqualTo(logEndOffsets);
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    void testCompatibilityWithoutSerializationVersion(boolean isPartitioned) throws Exception {
+        TablePath tablePath =
+                TablePath.of(
+                        "fluss",
+                        "test_legacy_version_commit" + (isPartitioned ? "_partitioned" : ""));
+        Tuple2<Long, Collection<Long>> tableIdAndPartitions = createTable(tablePath, isPartitioned);
+        long tableId = tableIdAndPartitions.f0;
+        Collection<Long> partitions = tableIdAndPartitions.f1;
+
+        Map<TableBucket, Long> logEndOffsets = mockLogEndOffsets(tableId, partitions);
+
+        long snapshotId = 3;
+        // commit offsets
+        FlussTableLakeSnapshot flussTableLakeSnapshot =
+                new FlussTableLakeSnapshot(tableId, snapshotId);
+        for (Map.Entry<TableBucket, Long> entry : logEndOffsets.entrySet()) {
+            flussTableLakeSnapshot.addBucketOffset(entry.getKey(), entry.getValue());
+        }
+
+        // not set commit lake snapshot version to mock old version behavior
+        flussTableLakeSnapshotCommitter
+                .getCoordinatorGateway()
+                .commitLakeTableSnapshot(toCommitLakeTableSnapshotRequest(flussTableLakeSnapshot))
+                .get();
+
+        // test deserialize with old version deserializer
+        ZooKeeperClient zkClient = FLUSS_CLUSTER_EXTENSION.getZooKeeperClient();
+        // read the the json node from lake table node
+        JsonNode jsonNode =
+                new ObjectMapper()
+                        .readTree(zkClient.getOrEmpty(ZkData.LakeTableZNode.path(tableId)).get());
+        LakeTableSnapshot lakeTableSnapshot =
+                LakeTableSnapshotJsonSerde.INSTANCE.deserializeVersion1(jsonNode);
+
+        // verify the deserialized lakeTableSnapshot
+        assertThat(lakeTableSnapshot.getSnapshotId()).isEqualTo(3);
+        assertThat(lakeTableSnapshot.getBucketLogEndOffset()).isEqualTo(logEndOffsets);
+    }
+
+    private Map<TableBucket, Long> mockLogEndOffsets(long tableId, Collection<Long> partitionsIds) {
+        Map<TableBucket, Long> logEndOffsets = new HashMap<>();
+        for (int bucket = 0; bucket < 3; bucket++) {
+            long bucketOffset = bucket * bucket;
+            for (Long partitionId : partitionsIds) {
+                if (partitionId == null) {
+                    logEndOffsets.put(new TableBucket(tableId, bucket), bucketOffset);
+                } else {
+                    logEndOffsets.put(new TableBucket(tableId, partitionId, bucket), bucketOffset);
+                }
+            }
+        }
+        return logEndOffsets;
+    }
+
+    private Tuple2<Long, Collection<Long>> createTable(TablePath tablePath, boolean isPartitioned)
+            throws Exception {
+        long tableId =
+                createTable(
+                        tablePath,
+                        isPartitioned
+                                ? DATA1_PARTITIONED_TABLE_DESCRIPTOR
+                                : DATA1_TABLE_DESCRIPTOR);
+        Collection<Long> partitions;
+        if (!isPartitioned) {
+            partitions = Collections.singletonList(null);
+            FLUSS_CLUSTER_EXTENSION.waitUntilTableReady(tableId);
+        } else {
+            partitions = FLUSS_CLUSTER_EXTENSION.waitUntilPartitionAllReady(tablePath).values();
+        }
+        return new Tuple2<>(tableId, partitions);
     }
 }

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -451,6 +451,19 @@ message NotifyRemoteLogOffsetsResponse {
 
 message CommitLakeTableSnapshotRequest {
   repeated PbLakeTableSnapshotInfo tables_req = 1;
+  // The version number for serializing lake_snapshot. This field tells the coordinator server
+  // which version to use when serializing the lake snapshot data.
+  //
+  // Legacy tiering services (before this field was introduced) do not set this field. This field
+  // is primarily used to handle compatibility during Fluss upgrades:
+  //
+  // - During upgrade: Fluss may use a new serialization format, but some tablet servers may not
+  //   have been upgraded yet and cannot deserialize the new format. The coordinator server can
+  //   check this field to determine which serialization format to use.
+  // - After upgrade: Once all Fluss components are upgraded, tiering services can be updated to
+  //   use the new format. The coordinator server will recognize this field and use the new
+  //   serialization method, and all tablet servers will be able to deserialize the new format.
+  optional int32 lake_snapshot_serialization_version = 2;
 }
 
 message PbLakeTableSnapshotInfo {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorEventProcessor.java
@@ -1260,10 +1260,14 @@ public class CoordinatorEventProcessor implements EventProcessor {
                                                     + tableId
                                                     + " not found in coordinator context.");
                                 }
-
-                                // this involves IO operation (ZK), so we do it in ioExecutor
-                                lakeTableHelper.upsertLakeTable(
-                                        tableId, tablePath, lakeTableSnapshotEntry.getValue());
+                                if (commitLakeTableSnapshotData.getSerializationVersion() == null) {
+                                    lakeTableHelper.upsertLakeTableV1(
+                                            tableId, lakeTableSnapshotEntry.getValue());
+                                } else {
+                                    // this involves IO operation (ZK), so we do it in ioExecutor
+                                    lakeTableHelper.upsertLakeTable(
+                                            tableId, tablePath, lakeTableSnapshotEntry.getValue());
+                                }
                             } catch (Exception e) {
                                 ApiError error = ApiError.fromThrowable(e);
                                 tableResp.setError(error.error().code(), error.message());

--- a/fluss-server/src/main/java/org/apache/fluss/server/entity/CommitLakeTableSnapshotData.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/entity/CommitLakeTableSnapshotData.java
@@ -21,6 +21,8 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.rpc.messages.CommitLakeTableSnapshotRequest;
 import org.apache.fluss.server.zk.data.lake.LakeTableSnapshot;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 import java.util.Objects;
 
@@ -30,11 +32,17 @@ public class CommitLakeTableSnapshotData {
     private final Map<Long, LakeTableSnapshot> lakeTableSnapshots;
     private final Map<TableBucket, Long> tableBucketsMaxTieredTimestamp;
 
+    // the serialization version for lake table snapshot, will be null
+    // before 0.8
+    private final Integer serializationVersion;
+
     public CommitLakeTableSnapshotData(
             Map<Long, LakeTableSnapshot> lakeTableSnapshots,
-            Map<TableBucket, Long> tableBucketsMaxTieredTimestamp) {
+            Map<TableBucket, Long> tableBucketsMaxTieredTimestamp,
+            @Nullable Integer serializationVersion) {
         this.lakeTableSnapshots = lakeTableSnapshots;
         this.tableBucketsMaxTieredTimestamp = tableBucketsMaxTieredTimestamp;
+        this.serializationVersion = serializationVersion;
     }
 
     public Map<Long, LakeTableSnapshot> getLakeTableSnapshot() {
@@ -43,6 +51,10 @@ public class CommitLakeTableSnapshotData {
 
     public Map<TableBucket, Long> getTableBucketsMaxTieredTimestamp() {
         return tableBucketsMaxTieredTimestamp;
+    }
+
+    public Integer getSerializationVersion() {
+        return serializationVersion;
     }
 
     @Override
@@ -56,12 +68,14 @@ public class CommitLakeTableSnapshotData {
         CommitLakeTableSnapshotData that = (CommitLakeTableSnapshotData) o;
         return Objects.equals(lakeTableSnapshots, that.lakeTableSnapshots)
                 && Objects.equals(
-                        tableBucketsMaxTieredTimestamp, that.tableBucketsMaxTieredTimestamp);
+                        tableBucketsMaxTieredTimestamp, that.tableBucketsMaxTieredTimestamp)
+                && Objects.equals(serializationVersion, that.serializationVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(lakeTableSnapshots, tableBucketsMaxTieredTimestamp);
+        return Objects.hash(
+                lakeTableSnapshots, tableBucketsMaxTieredTimestamp, serializationVersion);
     }
 
     @Override
@@ -71,6 +85,8 @@ public class CommitLakeTableSnapshotData {
                 + lakeTableSnapshots
                 + ", tableBucketsMaxTieredTimestamp="
                 + tableBucketsMaxTieredTimestamp
+                + ", serializationVersion="
+                + serializationVersion
                 + '}';
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
@@ -1574,7 +1574,13 @@ public class ServerRpcMessageUtils {
             lakeTableInfoByTableId.put(
                     tableId, new LakeTableSnapshot(snapshotId, bucketLogEndOffset));
         }
-        return new CommitLakeTableSnapshotData(lakeTableInfoByTableId, tableBucketsMaxTimestamp);
+
+        Integer serializationVersion =
+                request.hasLakeSnapshotSerializationVersion()
+                        ? request.getLakeSnapshotSerializationVersion()
+                        : null;
+        return new CommitLakeTableSnapshotData(
+                lakeTableInfoByTableId, tableBucketsMaxTimestamp, serializationVersion);
     }
 
     public static PbNotifyLakeTableOffsetReqForBucket makeNotifyLakeTableOffsetForBucket(

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/ZooKeeperClient.java
@@ -1027,9 +1027,15 @@ public class ZooKeeperClient implements AutoCloseable {
     }
 
     /** Upsert the {@link LakeTable} to Zk Node. */
-    public void upsertLakeTable(long tableId, LakeTable lakeTable, boolean isUpdate)
+    public void upsertLakeTable(
+            long tableId, LakeTable lakeTable, boolean isUpdate, boolean isLegacyVersion)
             throws Exception {
-        byte[] zkData = LakeTableZNode.encode(lakeTable);
+        byte[] zkData;
+        if (isLegacyVersion) {
+            zkData = LakeTableZNode.encodeV1(tableId, lakeTable);
+        } else {
+            zkData = LakeTableZNode.encode(lakeTable);
+        }
         String zkPath = LakeTableZNode.path(tableId);
         if (isUpdate) {
             zkClient.setData().forPath(zkPath, zkData);

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/ZkData.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/ZkData.java
@@ -31,6 +31,7 @@ import org.apache.fluss.utils.types.Tuple2;
 
 import javax.annotation.Nullable;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -587,6 +588,14 @@ public final class ZkData {
          */
         public static String path(long tableId) {
             return TableIdZNode.path(tableId) + "/laketable";
+        }
+
+        /**
+         * Encodes a {@link LakeTable} to JSON bytes using Version 1 format (legacy) for storage in
+         * ZooKeeper.
+         */
+        public static byte[] encodeV1(long tableId, LakeTable lakeTable) throws IOException {
+            return LakeTableJsonSerde.serializeV1(tableId, lakeTable);
         }
 
         /**

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTable.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTable.java
@@ -112,7 +112,7 @@ public class LakeTable {
      *
      * @return the LakeTableSnapshot
      */
-    public LakeTableSnapshot getLatestTableSnapshot() throws Exception {
+    public LakeTableSnapshot getLatestTableSnapshot() throws IOException {
         if (lakeTableSnapshot != null) {
             return lakeTableSnapshot;
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTableJsonSerde.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTableJsonSerde.java
@@ -85,6 +85,17 @@ public class LakeTableJsonSerde implements JsonSerializer<LakeTable>, JsonDeseri
         generator.writeEndObject();
     }
 
+    /**
+     * Serializes a {@link LakeTable} to JSON bytes using Version 1 format (legacy).
+     *
+     * <p>This method is used for backward compatibility when the coordinator receives a commit
+     * request without a serialization version (from legacy tiering services).
+     */
+    public static byte[] serializeV1(long tableId, LakeTable lakeTable) throws IOException {
+        return LakeTableSnapshotJsonSerde.toJsonVersion1(
+                lakeTable.getLatestTableSnapshot(), tableId);
+    }
+
     @Override
     public LakeTable deserialize(JsonNode node) {
         int version = node.get(VERSION_KEY).asInt();

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTableSnapshotJsonSerde.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lake/LakeTableSnapshotJsonSerde.java
@@ -18,7 +18,6 @@
 
 package org.apache.fluss.server.zk.data.lake;
 
-import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.core.JsonGenerator;
 import org.apache.fluss.shaded.jackson2.com.fasterxml.jackson.databind.JsonNode;
@@ -173,7 +172,7 @@ public class LakeTableSnapshotJsonSerde
     }
 
     /** Deserialize Version 1 format (legacy). */
-    private LakeTableSnapshot deserializeVersion1(JsonNode node) {
+    public LakeTableSnapshot deserializeVersion1(JsonNode node) {
         long snapshotId = node.get(SNAPSHOT_ID).asLong();
         long tableId = node.get(TABLE_ID).asLong();
         Iterator<JsonNode> buckets = node.get(BUCKETS).elements();
@@ -263,7 +262,6 @@ public class LakeTableSnapshotJsonSerde
     }
 
     /** Serialize the {@link LakeTableSnapshot} to json bytes using Version 1 format. */
-    @VisibleForTesting
     public static byte[] toJsonVersion1(LakeTableSnapshot lakeTableSnapshot, long tableId) {
         return JsonSerdeUtils.writeValueAsBytes(lakeTableSnapshot, new Version1Serializer(tableId));
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/zk/data/lake/LakeTableHelperTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/zk/data/lake/LakeTableHelperTest.java
@@ -30,7 +30,6 @@ import org.apache.fluss.server.zk.ZooKeeperClient;
 import org.apache.fluss.server.zk.ZooKeeperExtension;
 import org.apache.fluss.server.zk.ZooKeeperUtils;
 import org.apache.fluss.server.zk.data.TableRegistration;
-import org.apache.fluss.server.zk.data.ZkData;
 import org.apache.fluss.testutils.common.AllCallbackWrapper;
 
 import org.junit.jupiter.api.AfterAll;
@@ -110,16 +109,9 @@ class LakeTableHelperTest {
 
             LakeTableSnapshot lakeTableSnapshot =
                     new LakeTableSnapshot(snapshotId, bucketLogEndOffset);
-            // Write version 1 format data directly to ZK (simulating old system behavior)
-            String zkPath = ZkData.LakeTableZNode.path(tableId);
-            byte[] version1Data =
-                    LakeTableSnapshotJsonSerde.toJsonVersion1(lakeTableSnapshot, tableId);
-            zooKeeperClient
-                    .getCuratorClient()
-                    .create()
-                    .creatingParentsIfNeeded()
-                    .forPath(zkPath, version1Data);
 
+            // Write version 1 format (simulating old system behavior)
+            lakeTableHelper.upsertLakeTableV1(tableId, lakeTableSnapshot);
             // Verify version 1 data can be read
             Optional<LakeTable> optionalLakeTable = zooKeeperClient.getLakeTable(tableId);
             assertThat(optionalLakeTable).isPresent();


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
This fix the compatible issue introduced by #2037
After #2037, when upgrade coordinator server firstly, the coordinator server will write zk node with v2 version, but the tablet server which is still not upgraded can't regconize v2 which casue the exception.

<!-- What is the purpose of the change -->

### Brief change log
- introduce a version in commit lake snapshot request, new tiering service should set the version to 2, if the coordinator server received version is v2, use the v2 version to write zk node.

So, the upgrade process can be: 
- upgrade coordinator server 
- upgrade tablet server
- upgrade tiering service

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
