### PR TITLE
[docs] Use the `docker compose ps` to show the running containers

### DIFF
--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -131,7 +131,7 @@ This command automatically starts all the containers defined in the Docker Compo
 
 Run 
 ```shell
-docker container ls -a
+docker compose ps
 ```
 to check whether all containers are running properly.
 

--- a/website/docs/quickstart/lakehouse.md
+++ b/website/docs/quickstart/lakehouse.md
@@ -128,7 +128,7 @@ This command automatically starts all the containers defined in the Docker Compo
 
 Run 
 ```shell
-docker container ls -a
+docker compose ps
 ```
 to check whether all containers are running properly.
 


### PR DESCRIPTION

### Purpose

Use `docker compose ps` to show only the containers created by the Fluss quick-start, rather than all containers on the machine.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
