### PR TITLE
[tests] Cleanup ZK state in TableChangeWatcherTest to not let current tests be impacted by leftover events from previous tests.

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
@@ -91,11 +91,18 @@ class TableChangeWatcherTest {
                         zookeeperClient,
                         new Configuration(),
                         new LakeCatalogDynamicLoader(new Configuration(), null, true));
-        metadataManager.createDatabase(DEFAULT_DB, DatabaseDescriptor.builder().build(), false);
     }
 
     @BeforeEach
     void before() {
+        // Clean up ZK state from previous tests to prevent CuratorCache initial sync
+        // from picking up leftover data
+        try {
+            metadataManager.dropDatabase(DEFAULT_DB, true, true);
+        } catch (Exception ignored) {
+        }
+        metadataManager.createDatabase(DEFAULT_DB, DatabaseDescriptor.builder().build(), false);
+
         eventManager = new TestingEventManager();
         tableChangeWatcher = new TableChangeWatcher(zookeeperClient, eventManager);
         tableChangeWatcher.start();
@@ -106,7 +113,6 @@ class TableChangeWatcherTest {
         if (tableChangeWatcher != null) {
             tableChangeWatcher.stop();
         }
-        eventManager.clearEvents();
     }
 
     @Test


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2237

<!-- What is the purpose of the change -->

### Brief change log

As described in #2237 , the events from one test can impact the assert of another test. This PR clears the state of ZK before every test so that the events asserted by the current test belong only to that test and no leftover events from previous tests.
