### PR TITLE
Add BucketingFunctionTest, this allows rust client side to also run the same test and ensures consistency.

### DIFF
--- a/fluss-common/src/test/java/org/apache/fluss/bucketing/BucketingFunctionTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/bucketing/BucketingFunctionTest.java
@@ -25,14 +25,7 @@ import java.nio.charset.StandardCharsets;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-/**
- /**
- * Unit tests for {@link BucketingFunction}.
- * * <p>Maintains parity with Rust client tests to guarantee cross-client 
- * hashing consistency.
- */
- * consistency
- */
+/** Maintains parity with Rust client tests to guarantee cross-client hashing consistency. */
 class BucketingFunctionTest {
     @Test
     void testDefaultBucketing() {


### PR DESCRIPTION
### Purpose

See related issue https://github.com/apache/fluss-rust/pull/117


### Brief change log

Add BucketingFunctionTest, this allows rust client side to also run the same test and ensures consistency.

### Tests

Added tests for default, Paimon, Lance and Datalake BucketingFunctions.
