### PR TITLE
[hotfix] Use CatalogTableAdapter rather than CatalogTable.newBuilder in flink catalog.

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/catalog/FlinkCatalog.java
@@ -23,6 +23,7 @@ import org.apache.fluss.client.admin.Admin;
 import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.exception.InvalidTableException;
+import org.apache.fluss.flink.adapter.CatalogTableAdapter;
 import org.apache.fluss.flink.lake.LakeFlinkCatalog;
 import org.apache.fluss.flink.procedure.ProcedureManager;
 import org.apache.fluss.flink.utils.CatalogExceptionUtils;
@@ -842,14 +843,11 @@ public class FlinkCatalog extends AbstractCatalog {
         if (!indexKeys.isEmpty()) {
             indexes.add(indexKeys);
         }
-        return CatalogTable.newBuilder()
-                .schema(withIndex(table.getUnresolvedSchema(), indexes))
-                .comment(table.getComment())
-                .partitionKeys(table.getPartitionKeys())
-                .options(table.getOptions())
-                .snapshot(table.getSnapshot().orElse(null))
-                .distribution(table.getDistribution().orElse(null))
-                .build();
+        return CatalogTableAdapter.toCatalogTable(
+                withIndex(table.getUnresolvedSchema(), indexes),
+                table.getComment(),
+                table.getPartitionKeys(),
+                table.getOptions());
     }
 
     private static boolean isPrefixList(List<String> fullList, List<String> prefixList) {


### PR DESCRIPTION
…i

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Use CatalogTableAdapter rather than CatalogTable.newBuilder in flink catalog to avoid imcompatibility

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
