### PR TITLE
[helm] correct the internal listening address configuration for coordinator-server

### DIFF
--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -68,7 +68,7 @@ spec:
 
               echo "" >> $FLUSS_HOME/conf/server.yaml && \
               echo "tablet-server.id: ${FLUSS_SERVER_ID}" >> $FLUSS_HOME/conf/server.yaml && \
-              echo "bind.listeners: INTERNAL://0.0.0.0:{{ .Values.appConfig.internalPort }}, CLIENT://0.0.0.0:{{ .Values.appConfig.externalPort }}" >> $FLUSS_HOME/conf/server.yaml && \
+              echo "bind.listeners: INTERNAL://${POD_IP}:{{ .Values.appConfig.internalPort }}, CLIENT://0.0.0.0:{{ .Values.appConfig.externalPort }}" >> $FLUSS_HOME/conf/server.yaml && \
               echo "advertised.listeners: CLIENT://${POD_NAME}.coordinator-server-hs.${POD_NAMESPACE}.svc.cluster.local:{{ .Values.appConfig.externalPort }}" >> $FLUSS_HOME/conf/server.yaml && \
 
               bin/coordinator-server.sh start-foreground


### PR DESCRIPTION
### Purpose

The purpose of this change is to fix a connectivity issue between clients and the coordinator-server when Fluss is deployed via Helm. Previously, the `INTERNAL` listener was bound to `0.0.0.0`, which caused the server to register itself with an ambiguous address. This prevented clients from correctly resolving the coordinator-server location during the `CREATE CATALOG` process via `bootstrap.servers`.

### Brief change log

- Modified `helm/templates/sts-coordinator.yaml` to change the `INTERNAL` listener bind address from `0.0.0.0` to `${POD_IP}`.
- This ensures that the coordinator-server registers its specific Pod IP for internal cluster communication, allowing metadata requests and bootstrap connections (e.g., `coordinator-server-hs.fluss:9123`) to succeed:
`CREATE CATALOG fluss_catalog WITH (
    'type' = 'fluss',
    'bootstrap.servers' = 'coordinator-server-hs.fluss:9123'
);`

### Tests

- Verified by deploying Fluss in a Kubernetes cluster using the updated Helm chart.
- Confirmed that Flink SQL `CREATE CATALOG` commands now succeed without errors.
- Manual verification of `$FLUSS_HOME/conf/server.yaml` inside the coordinator pod to ensure the `bind.listeners` property is correctly rendered with the Pod's IP.

### API and Format

- This change does not affect public APIs or storage formats. It only modifies the network binding configuration in the Kubernetes deployment template.

### Documentation

- No changes to formal documentation are required as this is a bug fix for the deployment configuration.