### PR TITLE
Add assertions in CompactedKeyEncoderTest to maintain parity with Rust client test

### DIFF
--- a/fluss-common/src/test/java/org/apache/fluss/row/encode/CompactedKeyEncoderTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/row/encode/CompactedKeyEncoderTest.java
@@ -231,7 +231,8 @@ class CompactedKeyEncoderTest {
             expectedHexString.append("00 00 00 00 00 31 00 00 00 00 ");
             expectedHexString.append("00 00 81 32 00 00 00 00 00 00 ");
             expectedHexString.append("81");
-            byte[] expected = BaseEncoding.base16().decode(expectedHexString.toString().replace(" ", ""));
+            byte[] expected =
+                    BaseEncoding.base16().decode(expectedHexString.toString().replace(" ", ""));
 
             assertThat(keyBytes).isEqualTo(expected);
 


### PR DESCRIPTION
### Purpose

Add assertions in CompactedKeyEncoderTest to maintain parity with Rust client test to guarantee cross-client encoding (and consequently hashing) consistency.

Related to: https://github.com/apache/fluss-rust/pull/124

### Brief change log

- Added assertions on byte[] arrays returned by CompactedKeyEncoder 
- Added test resource file containing the encoded bytes of all test data field
