### PR TITLE
[hotfix][helm] Update image repository to use `apache/fluss` instead of `fluss`

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -22,7 +22,7 @@
 
 image:
   registry: ""
-  repository: fluss
+  repository: apache/fluss
   tag: "0.9.0-incubating"
   pullPolicy: IfNotPresent
   pullSecrets: []


### PR DESCRIPTION
### Purpose

Linked issue: close  #2339

### Brief change log

Fix the Helm docker image repository, update it to `apache/fluss` instead of current `fluss`.

### Tests

NA

### API and Format

NA

### Documentation

NA
