### PR TITLE
[hotfix] Add missing authentication for CoordinatorService RPC calls

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/RpcServiceBase.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/RpcServiceBase.java
@@ -20,6 +20,7 @@ package org.apache.fluss.server;
 import org.apache.fluss.cluster.ServerNode;
 import org.apache.fluss.cluster.ServerType;
 import org.apache.fluss.config.cluster.ConfigEntry;
+import org.apache.fluss.exception.AuthorizationException;
 import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.exception.KvSnapshotNotExistException;
 import org.apache.fluss.exception.LakeTableSnapshotNotExistException;
@@ -181,6 +182,18 @@ public abstract class RpcServiceBase extends RpcGatewayService implements AdminR
     public void authorizeTable(OperationType operationType, TablePath tablePath) {
         if (authorizer != null) {
             authorizer.authorize(currentSession(), operationType, Resource.table(tablePath));
+        }
+    }
+
+    public void authorizeCluster(OperationType operationType) {
+        if (authorizer != null) {
+            authorizer.authorize(currentSession(), operationType, Resource.cluster());
+        }
+    }
+
+    public void authorizeInternal() {
+        if (!currentSession().isInternal()) {
+            throw new AuthorizationException("Only internal requests are permitted.");
         }
     }
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/CoordinatorService.java
@@ -596,6 +596,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     }
 
     public CompletableFuture<AdjustIsrResponse> adjustIsr(AdjustIsrRequest request) {
+        authorizeInternal();
+
         CompletableFuture<AdjustIsrResponse> response = new CompletableFuture<>();
         eventManagerSupplier
                 .get()
@@ -606,6 +608,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitKvSnapshotResponse> commitKvSnapshot(
             CommitKvSnapshotRequest request) {
+        authorizeInternal();
+
         CompletableFuture<CommitKvSnapshotResponse> response = new CompletableFuture<>();
         // parse completed snapshot from request
         byte[] completedSnapshotBytes = request.getCompletedSnapshot();
@@ -623,6 +627,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitRemoteLogManifestResponse> commitRemoteLogManifest(
             CommitRemoteLogManifestRequest request) {
+        authorizeInternal();
+
         CompletableFuture<CommitRemoteLogManifestResponse> response = new CompletableFuture<>();
         eventManagerSupplier
                 .get()
@@ -655,6 +661,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<PrepareLakeTableSnapshotResponse> prepareLakeTableSnapshot(
             PrepareLakeTableSnapshotRequest request) {
+        authorizeCluster(OperationType.WRITE);
+
         CompletableFuture<PrepareLakeTableSnapshotResponse> future = new CompletableFuture<>();
         ioExecutor.submit(
                 () -> {
@@ -701,6 +709,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CommitLakeTableSnapshotResponse> commitLakeTableSnapshot(
             CommitLakeTableSnapshotRequest request) {
+        authorizeCluster(OperationType.WRITE);
+
         CompletableFuture<CommitLakeTableSnapshotResponse> response = new CompletableFuture<>();
         eventManagerSupplier
                 .get()
@@ -713,6 +723,8 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<LakeTieringHeartbeatResponse> lakeTieringHeartbeat(
             LakeTieringHeartbeatRequest request) {
+        authorizeCluster(OperationType.READ);
+
         LakeTieringHeartbeatResponse heartbeatResponse = new LakeTieringHeartbeatResponse();
         int currentCoordinatorEpoch = coordinatorEpochSupplier.get();
         heartbeatResponse.setCoordinatorEpoch(currentCoordinatorEpoch);
@@ -772,9 +784,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<ControlledShutdownResponse> controlledShutdown(
             ControlledShutdownRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.ALTER, Resource.cluster());
-        }
+        authorizeInternal();
 
         CompletableFuture<ControlledShutdownResponse> response = new CompletableFuture<>();
         eventManagerSupplier
@@ -796,9 +806,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
             return CompletableFuture.completedFuture(new AlterClusterConfigsResponse());
         }
 
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.ALTER, Resource.cluster());
-        }
+        authorizeCluster(OperationType.ALTER);
 
         List<AlterConfig> serverConfigChanges =
                 infos.stream()
@@ -828,9 +836,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<AddServerTagResponse> addServerTag(AddServerTagRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.ALTER, Resource.cluster());
-        }
+        authorizeCluster(OperationType.ALTER);
 
         CompletableFuture<AddServerTagResponse> response = new CompletableFuture<>();
         eventManagerSupplier
@@ -848,9 +854,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<RemoveServerTagResponse> removeServerTag(
             RemoveServerTagRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.ALTER, Resource.cluster());
-        }
+        authorizeCluster(OperationType.ALTER);
 
         CompletableFuture<RemoveServerTagResponse> response = new CompletableFuture<>();
         eventManagerSupplier
@@ -867,9 +871,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
 
     @Override
     public CompletableFuture<RebalanceResponse> rebalance(RebalanceRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.WRITE, Resource.cluster());
-        }
+        authorizeCluster(OperationType.WRITE);
 
         List<Goal> goalsByPriority = new ArrayList<>();
         Arrays.stream(request.getGoals())
@@ -883,9 +885,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<ListRebalanceProgressResponse> listRebalanceProgress(
             ListRebalanceProgressRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.DESCRIBE, Resource.cluster());
-        }
+        authorizeCluster(OperationType.DESCRIBE);
 
         CompletableFuture<ListRebalanceProgressResponse> response = new CompletableFuture<>();
         eventManagerSupplier
@@ -900,9 +900,7 @@ public final class CoordinatorService extends RpcServiceBase implements Coordina
     @Override
     public CompletableFuture<CancelRebalanceResponse> cancelRebalance(
             CancelRebalanceRequest request) {
-        if (authorizer != null) {
-            authorizer.authorize(currentSession(), OperationType.WRITE, Resource.cluster());
-        }
+        authorizeCluster(OperationType.WRITE);
 
         CompletableFuture<CancelRebalanceResponse> response = new CompletableFuture<>();
         eventManagerSupplier


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Add missing authentication for RPC calls in `CoordinatorService`. Mainly for lake related RPC calls and simplify the rebalance authentication.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
