### PR TITLE
[hotfix] Fix union read fail when from timestamp and projection enabled

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeSplitGenerator.java
@@ -119,7 +119,7 @@ public class LakeSplitGenerator {
                     lakeSplits, isLogTable, tableBucketsOffset, partitionNameById);
         } else {
             Map<Integer, List<LakeSplit>> nonPartitionLakeSplits =
-                    lakeSplits.values().iterator().next();
+                    lakeSplits.isEmpty() ? null : lakeSplits.values().iterator().next();
             // non-partitioned table
             return generateNoPartitionedTableSplit(
                     nonPartitionLakeSplits, isLogTable, tableBucketsOffset);
@@ -307,7 +307,7 @@ public class LakeSplitGenerator {
     }
 
     private List<SourceSplitBase> generateNoPartitionedTableSplit(
-            Map<Integer, List<LakeSplit>> lakeSplits,
+            @Nullable Map<Integer, List<LakeSplit>> lakeSplits,
             boolean isLogTable,
             Map<TableBucket, Long> tableBucketSnapshotLogOffset) {
         // iterate all bucket

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/FlinkTableSource.java
@@ -331,8 +331,7 @@ public class FlinkTableSource
                     enableLakeSource = false;
                 } else {
                     if (enableLakeSource) {
-                        enableLakeSource =
-                                pushTimeStampFilterToLakeSource(lakeSource, flussRowType);
+                        enableLakeSource = pushTimeStampFilterToLakeSource(lakeSource);
                     }
                 }
                 break;
@@ -385,12 +384,11 @@ public class FlinkTableSource
         }
     }
 
-    private boolean pushTimeStampFilterToLakeSource(
-            LakeSource<?> lakeSource, RowType flussRowType) {
+    private boolean pushTimeStampFilterToLakeSource(LakeSource<?> lakeSource) {
         // will push timestamp to lake
         // we will have three additional system columns, __bucket, __offset, __timestamp
         // in lake, get the  __timestamp index in lake table
-        final int timestampFieldIndex = flussRowType.getFieldCount() + 2;
+        final int timestampFieldIndex = tableOutputType.getFieldCount() + 2;
         Predicate timestampFilter =
                 new LeafPredicate(
                         GreaterOrEqual.INSTANCE,

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumerator.java
@@ -770,16 +770,6 @@ public class FlinkSourceEnumerator
                             TableBucket tableBucket = split.getTableBucket();
                             assignedTableBuckets.add(tableBucket);
 
-                            if (pendingHybridLakeFlussSplits != null) {
-                                // removed from the pendingHybridLakeFlussSplits
-                                // since this split already be assigned
-                                pendingHybridLakeFlussSplits.removeIf(
-                                        hybridLakeFlussSplit ->
-                                                hybridLakeFlussSplit
-                                                        .splitId()
-                                                        .equals(split.splitId()));
-                            }
-
                             if (isPartitioned) {
                                 long partitionId =
                                         checkNotNull(
@@ -792,6 +782,17 @@ public class FlinkSourceEnumerator
                                 assignedPartitions.put(partitionId, partitionName);
                             }
                         });
+
+                if (pendingHybridLakeFlussSplits != null) {
+                    Set<String> splitIdsToRemove =
+                            pendingAssignmentForReader.stream()
+                                    .map(SourceSplitBase::splitId)
+                                    .collect(Collectors.toSet());
+                    // removed from the pendingHybridLakeFlussSplits
+                    // since this split already be assigned
+                    pendingHybridLakeFlussSplits.removeIf(
+                            split -> splitIdsToRemove.contains(split.splitId()));
+                }
             }
         }
 

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadFromTimestampITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/flink/FlinkUnionReadFromTimestampITCase.java
@@ -140,12 +140,16 @@ class FlinkUnionReadFromTimestampITCase extends FlinkPaimonTieringTestBase {
             CloseableIterator<Row> actualRows =
                     streamTEnv
                             .executeSql(
-                                    "select * from "
+                                    "select b from "
                                             + tableName
                                             + " /*+ OPTIONS('scan.startup.mode' = 'timestamp',\n"
                                             + "'scan.startup.timestamp' = '2000') */")
                             .collect();
-            List<Row> expectedRows = rows.stream().skip(2 * 3).collect(Collectors.toList());
+            List<Row> expectedRows =
+                    rows.stream()
+                            .skip(2 * 3)
+                            .map(row -> Row.of(row.getField(1)))
+                            .collect(Collectors.toList());
             assertRowResultsIgnoreOrder(actualRows, expectedRows, true);
 
             // verify scan from earliest


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Fix when union read from lake table, and projectinn is enabled, the `__timestamp` in paimon will not match which cause cast exception 

<!-- What is the purpose of the change -->

### Brief change log
Use table origin row type instead of projected row type.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->
Adjust the test to use enable projection

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
