### PR TITLE
[server] Support projection pushdown with field id in server side.

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchTest.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/log/DefaultCompletedFetchTest.java
@@ -427,7 +427,8 @@ public class DefaultCompletedFetchTest {
                 DATA2_TABLE_ID,
                 testingSchemaGetter,
                 DEFAULT_COMPRESSION,
-                projection.getProjectionInOrder());
+                projection.getProjectionInOrder(),
+                false);
         ByteBuffer buffer =
                 toByteBuffer(
                         fileLogProjection

--- a/fluss-common/src/main/java/org/apache/fluss/record/ProjectionPushdownCache.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/ProjectionPushdownCache.java
@@ -50,26 +50,33 @@ public class ProjectionPushdownCache {
 
     @Nullable
     public ProjectionInfo getProjectionInfo(
-            long tableId, short schemaId, int[] selectedFieldPositions) {
-        ProjectionKey key = new ProjectionKey(tableId, schemaId, selectedFieldPositions);
+            long tableId, short schemaId, int[] selectedColumns, boolean isSelectedByIds) {
+        ProjectionKey key = new ProjectionKey(tableId, schemaId, selectedColumns, isSelectedByIds);
         return projectionCache.getIfPresent(key);
     }
 
     public void setProjectionInfo(
-            long tableId, short schemaId, int[] selectedColumnIds, ProjectionInfo projectionInfo) {
-        ProjectionKey key = new ProjectionKey(tableId, schemaId, selectedColumnIds);
+            long tableId,
+            short schemaId,
+            int[] selectedColumns,
+            boolean isSelectedByIds,
+            ProjectionInfo projectionInfo) {
+        ProjectionKey key = new ProjectionKey(tableId, schemaId, selectedColumns, isSelectedByIds);
         projectionCache.put(key, projectionInfo);
     }
 
     static final class ProjectionKey {
         private final long tableId;
         private final short schemaId;
-        private final int[] selectedColumnIds;
+        private final int[] selectedColumns;
+        private final boolean isSelectedByIds;
 
-        ProjectionKey(long tableId, short schemaId, int[] selectedColumnIds) {
+        ProjectionKey(
+                long tableId, short schemaId, int[] selectedColumns, boolean isSelectedByIds) {
             this.tableId = tableId;
             this.schemaId = schemaId;
-            this.selectedColumnIds = selectedColumnIds;
+            this.selectedColumns = selectedColumns;
+            this.isSelectedByIds = isSelectedByIds;
         }
 
         @Override
@@ -80,12 +87,14 @@ public class ProjectionPushdownCache {
             ProjectionKey that = (ProjectionKey) o;
             return tableId == that.tableId
                     && schemaId == that.schemaId
-                    && Arrays.equals(selectedColumnIds, that.selectedColumnIds);
+                    && Arrays.equals(selectedColumns, that.selectedColumns)
+                    && isSelectedByIds == that.isSelectedByIds;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(tableId, schemaId, Arrays.hashCode(selectedColumnIds));
+            return Objects.hash(
+                    tableId, schemaId, Arrays.hashCode(selectedColumns), isSelectedByIds);
         }
     }
 }

--- a/fluss-rpc/src/main/proto/FlussApi.proto
+++ b/fluss-rpc/src/main/proto/FlussApi.proto
@@ -702,6 +702,8 @@ message PbFetchLogReqForTable {
   required bool projection_pushdown_enabled = 2;
   repeated int32 projected_fields = 3 [packed = true];
   repeated PbFetchLogReqForBucket buckets_req = 4;
+  // If true, projected_fields are interpreted as field IDs; if false, they are field positions.
+  optional bool project_by_ids = 5;
 }
 
 message PbFetchLogReqForBucket {

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/SchemaUpdate.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/SchemaUpdate.java
@@ -63,9 +63,7 @@ public class SchemaUpdate {
 
     public Schema getSchema() {
         Schema.Builder builder =
-                Schema.newBuilder()
-                        .fromColumns(columns)
-                        .highestFieldId((short) highestFieldId.get());
+                Schema.newBuilder().fromColumns(columns).highestFieldId(highestFieldId.get());
         if (!primaryKeys.isEmpty()) {
             builder.primaryKey(primaryKeys);
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/entity/FetchReqInfo.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/entity/FetchReqInfo.java
@@ -30,19 +30,25 @@ public final class FetchReqInfo {
     private final long tableId;
     private final long fetchOffset;
     @Nullable private final int[] projectFields;
+    private final boolean isProjectByIds;
 
-    private int maxBytes;
+    private final int maxBytes;
 
     public FetchReqInfo(long tableId, long fetchOffset, int maxBytes) {
-        this(tableId, fetchOffset, maxBytes, null);
+        this(tableId, fetchOffset, maxBytes, null, false);
     }
 
     public FetchReqInfo(
-            long tableId, long fetchOffset, int maxBytes, @Nullable int[] projectFields) {
+            long tableId,
+            long fetchOffset,
+            int maxBytes,
+            @Nullable int[] projectFields,
+            boolean isProjectByIds) {
         this.tableId = tableId;
         this.fetchOffset = fetchOffset;
         this.maxBytes = maxBytes;
         this.projectFields = projectFields;
+        this.isProjectByIds = isProjectByIds;
     }
 
     public long getTableId() {
@@ -53,12 +59,12 @@ public final class FetchReqInfo {
         return fetchOffset;
     }
 
-    public void setFetchMaxBytes(int maxBytes) {
-        this.maxBytes = maxBytes;
-    }
-
     public int getMaxBytes() {
         return maxBytes;
+    }
+
+    public boolean isProjectByIds() {
+        return isProjectByIds;
     }
 
     @Nullable
@@ -77,6 +83,8 @@ public final class FetchReqInfo {
                 + maxBytes
                 + ", projectionFields="
                 + Arrays.toString(projectFields)
+                + ", isProjectByIds="
+                + isProjectByIds
                 + '}';
     }
 
@@ -97,11 +105,14 @@ public final class FetchReqInfo {
             return false;
         }
 
-        return fetchOffset == fetchReqInfo.fetchOffset && maxBytes == fetchReqInfo.maxBytes;
+        return fetchOffset == fetchReqInfo.fetchOffset
+                && maxBytes == fetchReqInfo.maxBytes
+                && isProjectByIds == fetchReqInfo.isProjectByIds;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(tableId, fetchOffset, maxBytes, Arrays.hashCode(projectFields));
+        return Objects.hash(
+                tableId, fetchOffset, maxBytes, Arrays.hashCode(projectFields), isProjectByIds);
     }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParams.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/FetchParams.java
@@ -101,6 +101,7 @@ public final class FetchParams {
             SchemaGetter schemaGetter,
             ArrowCompressionInfo compressionInfo,
             @Nullable int[] projectedFields,
+            boolean isSelectedByIds,
             ProjectionPushdownCache projectionCache) {
         this.fetchOffset = fetchOffset;
         this.maxFetchBytes = maxFetchBytes;
@@ -111,7 +112,7 @@ public final class FetchParams {
             }
 
             fileLogProjection.setCurrentProjection(
-                    tableId, schemaGetter, compressionInfo, projectedFields);
+                    tableId, schemaGetter, compressionInfo, projectedFields, isSelectedByIds);
         } else {
             projectionEnabled = false;
         }

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/ReplicaManager.java
@@ -153,7 +153,6 @@ public class ReplicaManager {
     private final Map<TableBucket, HostedReplica> allReplicas = MapUtils.newConcurrentHashMap();
 
     private final TabletServerMetadataCache metadataCache;
-    private final ExecutorService ioExecutor;
     private final ProjectionPushdownCache projectionsCache = new ProjectionPushdownCache();
     private final Lock replicaStateChangeLock = new ReentrantLock();
 
@@ -292,7 +291,6 @@ public class ReplicaManager {
         this.serverMetricGroup = serverMetricGroup;
         this.userMetrics = userMetrics;
         this.clock = clock;
-        this.ioExecutor = ioExecutor;
         registerMetrics();
     }
 
@@ -1113,6 +1111,7 @@ public class ReplicaManager {
                         replica.getSchemaGetter(),
                         replica.getArrowCompressionInfo(),
                         fetchReqInfo.getProjectFields(),
+                        fetchReqInfo.isProjectByIds(),
                         projectionsCache);
                 LogReadInfo readInfo = replica.fetchRecords(fetchParams);
 

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/ServerRpcMessageUtils.java
@@ -822,6 +822,13 @@ public class ServerRpcMessageUtils {
                 projectionFields = null;
             }
 
+            final boolean isSelectedByIds;
+            if (fetchLogReqForTable.hasProjectByIds()) {
+                isSelectedByIds = fetchLogReqForTable.isProjectByIds();
+            } else {
+                isSelectedByIds = false;
+            }
+
             List<PbFetchLogReqForBucket> bucketsReqsList = fetchLogReqForTable.getBucketsReqsList();
             for (PbFetchLogReqForBucket fetchLogReqForBucket : bucketsReqsList) {
                 int bucketId = fetchLogReqForBucket.getBucketId();
@@ -836,7 +843,8 @@ public class ServerRpcMessageUtils {
                                 tableId,
                                 fetchLogReqForBucket.getFetchOffset(),
                                 fetchLogReqForBucket.getMaxFetchBytes(),
-                                projectionFields));
+                                projectionFields,
+                                isSelectedByIds));
             }
         }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/KvTabletTest.java
@@ -732,7 +732,7 @@ class KvTabletTest {
         if (doProjection) {
             logProjection = new FileLogProjection(projectionCache);
             logProjection.setCurrentProjection(
-                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0});
+                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0}, true);
         }
 
         RowType readLogRowType = doProjection ? rowType.project(new int[] {0}) : rowType;
@@ -828,7 +828,7 @@ class KvTabletTest {
         if (doProjection) {
             logProjection = new FileLogProjection(projectionCache);
             logProjection.setCurrentProjection(
-                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0});
+                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0}, true);
         }
 
         // schema evolution case 1 :insert with data with schema 2
@@ -916,7 +916,7 @@ class KvTabletTest {
         if (doProjection) {
             logProjection = new FileLogProjection(projectionCache);
             logProjection.setCurrentProjection(
-                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0});
+                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0}, true);
         }
         RowType readLogRowType = doProjection ? rowType.project(new int[] {0}) : rowType;
 
@@ -1036,7 +1036,7 @@ class KvTabletTest {
         if (doProjection) {
             logProjection = new FileLogProjection(projectionCache);
             logProjection.setCurrentProjection(
-                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0});
+                    0L, schemaGetter, DEFAULT_COMPRESSION, new int[] {0}, true);
         }
 
         // schema evolution case 1 :insert with data with new schema

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/FetchParamsTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/FetchParamsTest.java
@@ -42,6 +42,7 @@ class FetchParamsTest {
                 new TestingSchemaGetter(new SchemaInfo(TestData.DATA1_SCHEMA, (short) 1)),
                 DEFAULT_COMPRESSION,
                 null,
+                false,
                 projectionCache);
         assertThat(fetchParams.fetchOffset()).isEqualTo(20L);
         assertThat(fetchParams.maxFetchBytes()).isEqualTo(1024);
@@ -54,6 +55,7 @@ class FetchParamsTest {
                 new TestingSchemaGetter(new SchemaInfo(TestData.DATA2_SCHEMA, (short) 1)),
                 DEFAULT_COMPRESSION,
                 new int[] {0, 2},
+                false,
                 projectionCache);
         assertThat(fetchParams.fetchOffset()).isEqualTo(30L);
         assertThat(fetchParams.maxFetchBytes()).isEqualTo(512);
@@ -68,6 +70,7 @@ class FetchParamsTest {
                 new TestingSchemaGetter(new SchemaInfo(TestData.DATA1_SCHEMA, (short) 1)),
                 DEFAULT_COMPRESSION,
                 null,
+                false,
                 projectionCache);
         assertThat(fetchParams.projection()).isNull();
 
@@ -78,6 +81,7 @@ class FetchParamsTest {
                 new TestingSchemaGetter(new SchemaInfo(TestData.DATA2_SCHEMA, (short) 1)),
                 DEFAULT_COMPRESSION,
                 new int[] {0, 2},
+                false,
                 projectionCache);
         // the FileLogProjection should be cached
         assertThat(fetchParams.projection()).isNotNull().isSameAs(prevProjection);

--- a/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/replica/ReplicaTest.java
@@ -146,6 +146,7 @@ final class ReplicaTest extends ReplicaTestBase {
                 schemaGetter,
                 DEFAULT_COMPRESSION,
                 null,
+                true,
                 projectionCache);
         LogReadInfo logReadInfo = logReplica.fetchRecords(fetchParams);
         assertLogRecordsEquals(
@@ -172,6 +173,7 @@ final class ReplicaTest extends ReplicaTestBase {
                 schemaGetter,
                 DEFAULT_COMPRESSION,
                 null,
+                true,
                 projectionCache);
         logReadInfo = logReplica.fetchRecords(fetchParams);
         assertLogRecordsEquals(
@@ -818,6 +820,7 @@ final class ReplicaTest extends ReplicaTestBase {
                 replica.getSchemaGetter(),
                 DEFAULT_COMPRESSION,
                 null,
+                true,
                 new ProjectionPushdownCache());
         LogReadInfo logReadInfo = replica.fetchRecords(fetchParams);
         return logReadInfo.getFetchedData().getRecords();

--- a/fluss-server/src/test/java/org/apache/fluss/server/testutils/RpcMessageTestUtils.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/testutils/RpcMessageTestUtils.java
@@ -215,11 +215,23 @@ public class RpcMessageTestUtils {
     public static FetchLogRequest newFetchLogRequest(
             int followerId, long tableId, int bucketId, long fetchOffset, int[] selectedFields) {
         return newFetchLogRequest(
+                followerId, tableId, bucketId, fetchOffset, selectedFields, false);
+    }
+
+    public static FetchLogRequest newFetchLogRequest(
+            int followerId,
+            long tableId,
+            int bucketId,
+            long fetchOffset,
+            int[] selectedFields,
+            boolean isProjectByIds) {
+        return newFetchLogRequest(
                 followerId,
                 tableId,
                 bucketId,
                 fetchOffset,
                 selectedFields,
+                isProjectByIds,
                 -1,
                 Integer.MAX_VALUE,
                 -1);
@@ -231,6 +243,7 @@ public class RpcMessageTestUtils {
             int bucketId,
             long fetchOffset,
             int[] selectedFields,
+            boolean isProjectByIds,
             int minFetchBytes,
             int maxFetchBytes,
             int maxWaitMs) {
@@ -241,6 +254,7 @@ public class RpcMessageTestUtils {
         }
 
         PbFetchLogReqForTable fetchLogReqForTable = new PbFetchLogReqForTable().setTableId(tableId);
+        fetchLogReqForTable.setProjectByIds(isProjectByIds);
         if (selectedFields != null) {
             fetchLogReqForTable
                     .setProjectionPushdownEnabled(true)
@@ -248,6 +262,7 @@ public class RpcMessageTestUtils {
         } else {
             fetchLogReqForTable.setProjectionPushdownEnabled(false);
         }
+
         // TODO make the max fetch bytes configurable.
         PbFetchLogReqForBucket fetchLogReqForBucket =
                 new PbFetchLogReqForBucket()


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2311 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

org.apache.fluss.server.tablet.TabletServiceITCase#testFetchLogWithNestedRowProjectionPushdown

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
