### PR TITLE
[test] Support manually trigger and wait for KV snapshots for FlussClusterExtension

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/ClientToServerITCaseBase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/ClientToServerITCaseBase.java
@@ -113,8 +113,6 @@ public abstract class ClientToServerITCaseBase {
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
         conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
-        // set a shorter interval for testing purpose
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
         // set default datalake format for the cluster and enable datalake tables
         conf.set(ConfigOptions.DATALAKE_FORMAT, DataLakeFormat.PAIMON);
 

--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1001,8 +1001,8 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
             Map<Integer, CompletedSnapshot> expectedSnapshots = new HashMap<>();
             for (int bucket = 0; bucket < bucketNum; bucket++) {
                 CompletedSnapshot completedSnapshot =
-                        FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(
-                                new TableBucket(tableId, bucket), 0);
+                        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(
+                                new TableBucket(tableId, bucket));
                 expectedSnapshots.put(bucket, completedSnapshot);
             }
 
@@ -1018,7 +1018,7 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
             TableBucket tb = new TableBucket(snapshots.getTableId(), 0);
             // wait until the snapshot finish
             expectedSnapshots.put(
-                    tb.getBucket(), FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tb, 1));
+                    tb.getBucket(), FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tb));
 
             // check snapshot
             snapshots = admin.getLatestKvSnapshots(tablePath1).get();

--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -1023,8 +1023,6 @@ public class FlussAuthorizationITCase {
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
         conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
-        // set a shorter interval for testing purpose
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
         // set a shorter max lag time to make tests in FlussFailServerTableITCase faster
         conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(10));
         // set default datalake format for the cluster and enable datalake tables

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/batch/KvSnapshotBatchScannerITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/scanner/batch/KvSnapshotBatchScannerITCase.java
@@ -45,7 +45,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.apache.fluss.record.TestData.DATA1_ROW_TYPE;
 import static org.apache.fluss.testutils.DataTestUtils.compactedRow;
@@ -104,7 +103,7 @@ class KvSnapshotBatchScannerITCase extends ClientToServerITCaseBase {
         Map<TableBucket, List<InternalRow>> expectedRowByBuckets = putRows(tableId, tablePath, 10);
 
         // wait snapshot finish
-        waitUntilAllSnapshotFinished(expectedRowByBuckets.keySet(), 0);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(expectedRowByBuckets.keySet());
 
         // test read snapshot
         testSnapshotRead(tablePath, expectedRowByBuckets);
@@ -113,7 +112,7 @@ class KvSnapshotBatchScannerITCase extends ClientToServerITCaseBase {
         expectedRowByBuckets = putRows(tableId, tablePath, 20);
 
         // wait snapshot finish
-        waitUntilAllSnapshotFinished(expectedRowByBuckets.keySet(), 1);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(expectedRowByBuckets.keySet());
 
         // test read snapshot
         testSnapshotRead(tablePath, expectedRowByBuckets);
@@ -126,7 +125,7 @@ class KvSnapshotBatchScannerITCase extends ClientToServerITCaseBase {
 
         // put into values with old schema.
         Map<TableBucket, List<InternalRow>> oldSchemaRowByBuckets = putRows(tableId, tablePath, 10);
-        waitUntilAllSnapshotFinished(oldSchemaRowByBuckets.keySet(), 0);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(oldSchemaRowByBuckets.keySet());
 
         // add a new column and rename an existing column
         admin.alterTable(
@@ -175,7 +174,7 @@ class KvSnapshotBatchScannerITCase extends ClientToServerITCaseBase {
         }
 
         // wait snapshot finish
-        waitUntilAllSnapshotFinished(expectedRowByBuckets.keySet(), 1);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(expectedRowByBuckets.keySet());
 
         // test read snapshot with new Schema
         testSnapshotRead(tablePath, expectedRowByBuckets);
@@ -238,11 +237,5 @@ class KvSnapshotBatchScannerITCase extends ClientToServerITCaseBase {
         BucketingFunction function = BucketingFunction.of(DataLakeFormat.PAIMON);
         byte[] key = keyEncoder.encodeKey(row);
         return function.bucketing(key, DEFAULT_BUCKET_NUM);
-    }
-
-    private void waitUntilAllSnapshotFinished(Set<TableBucket> tableBuckets, long snapshotId) {
-        for (TableBucket tableBucket : tableBuckets) {
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
-        }
     }
 }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
@@ -50,7 +50,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
 
@@ -67,8 +66,6 @@ abstract class FlinkMetricsITCase {
             FlussClusterExtension.builder()
                     .setClusterConf(
                             new org.apache.fluss.config.Configuration()
-                                    // set snapshot interval to 1s for testing purposes
-                                    .set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
                                     // not to clean snapshots for test purpose
                                     .set(
                                             ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS,

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/procedure/FlinkProcedureITCase.java
@@ -782,8 +782,6 @@ public abstract class FlinkProcedureITCase {
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
         conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
-        // set a shorter interval for testing purpose
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
         // set a shorter max lag time to make tests in FlussFailServerTableITCase faster
         conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(10));
         // set default datalake format for the cluster and enable datalake tables

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/security/acl/FlinkAuthorizationITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/security/acl/FlinkAuthorizationITCase.java
@@ -456,8 +456,6 @@ abstract class FlinkAuthorizationITCase extends AbstractTestBase {
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
         conf.setInt(ConfigOptions.DEFAULT_REPLICATION_FACTOR, 3);
-        // set a shorter interval for testing purpose
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
         // set a shorter max lag time to make tests in FlussFailServerTableITCase faster
         conf.set(ConfigOptions.LOG_REPLICA_MAX_LAG_TIME, Duration.ofSeconds(10));
         // set default datalake format for the cluster and enable datalake tables

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFailOverITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/FlinkTableSourceFailOverITCase.java
@@ -49,7 +49,6 @@ import org.junit.jupiter.api.io.TempDir;
 import javax.annotation.Nullable;
 
 import java.io.File;
-import java.time.Duration;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -76,8 +75,6 @@ abstract class FlinkTableSourceFailOverITCase {
             FlussClusterExtension.builder()
                     .setClusterConf(
                             new org.apache.fluss.config.Configuration()
-                                    // set snapshot interval to 1s for testing purposes
-                                    .set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
                                     // not to clean snapshots for test purpose
                                     .set(
                                             ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS,

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/enumerator/FlinkSourceEnumeratorTest.java
@@ -146,7 +146,7 @@ class FlinkSourceEnumeratorTest extends FlinkTestBase {
         // write data and wait snapshot finish to make sure
         // we can hava snapshot split
         Map<Integer, Integer> bucketIdToNumRecords = putRows(DEFAULT_TABLE_PATH, 10);
-        waitUntilSnapshot(tableId, 0);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(DEFAULT_TABLE_PATH);
 
         try (MockSplitEnumeratorContext<SourceSplitBase> context =
                 new MockSplitEnumeratorContext<>(numSubtasks)) {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/reader/FlinkSourceSplitReaderTest.java
@@ -144,7 +144,7 @@ class FlinkSourceSplitReaderTest extends FlinkTestBase {
             Map<TableBucket, List<InternalRow>> rows = putRows(tableId, tablePath, 10);
 
             // check the expected records
-            waitUntilSnapshot(tableId, 0);
+            FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tablePath);
 
             hybridSnapshotLogSplits = getHybridSnapshotLogSplits(tablePath);
 
@@ -252,7 +252,7 @@ class FlinkSourceSplitReaderTest extends FlinkTestBase {
             Map<TableBucket, List<InternalRow>> rows = putRows(tableId, tablePath, 10);
 
             // check the expected records
-            waitUntilSnapshot(tableId, 0);
+            FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tablePath);
 
             List<SourceSplitBase> totalSplits =
                     new ArrayList<>(getHybridSnapshotLogSplits(tablePath));

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/FlinkTieringTestBase.java
@@ -67,8 +67,7 @@ class FlinkTieringTestBase {
 
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
-                .set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
+        conf.set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
 
         // Configure the tiering sink to be Lance
         conf.set(ConfigOptions.DATALAKE_FORMAT, DataLakeFormat.LANCE);
@@ -150,14 +149,6 @@ class FlinkTieringTestBase {
         }
     }
 
-    protected void waitUntilSnapshot(long tableId, int bucketNum, long snapshotId) {
-        for (int i = 0; i < bucketNum; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, i);
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
-        }
-    }
-
-    @SuppressWarnings("resource")
     public List<InternalRow> getValuesRecords(TablePath tablePath) {
         return TestingValuesLake.getResults(tablePath.toString());
     }

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/TieringFailoverITCase.java
@@ -84,7 +84,7 @@ class TieringFailoverITCase extends FlinkTieringTestBase {
         List<InternalRow> rows = Arrays.asList(row(1, "i1"), row(2, "i2"), row(3, "i3"));
         List<InternalRow> expectedRows = new ArrayList<>(rows);
         writeRows(t1, rows);
-        waitUntilSnapshot(t1Id, 1, 0);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(t1);
 
         // fail the first write to the pk table
         TestingValuesLake.failWhen(t1.toString()).failWriteOnce();

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringSplitReaderTest.java
@@ -103,7 +103,7 @@ class TieringSplitReaderTest extends FlinkTestBase {
             Map<TableBucket, List<InternalRow>> firstRows = putRows(tableId, tablePath, 10);
 
             // check the expected records
-            waitUntilSnapshot(tableId, 0);
+            FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tablePath);
 
             splitsAddition =
                     new SplitsAddition<>(
@@ -168,8 +168,8 @@ class TieringSplitReaderTest extends FlinkTestBase {
                         createTieringReader(connection)) {
             Map<TableBucket, List<InternalRow>> table0Rows = putRows(tableId0, tablePath0, 10);
             Map<TableBucket, List<InternalRow>> table1Rows = putRows(tableId1, tablePath1, 10);
-            waitUntilSnapshot(tableId0, 0);
-            waitUntilSnapshot(tableId1, 0);
+            FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tablePath0);
+            FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(tablePath1);
 
             // first add snapshot split of bucket 0, bucket 1 of table id 0
             SplitsAddition<TieringSplit> splitsAddition =

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
@@ -52,7 +52,9 @@ import javax.annotation.Nullable;
 
 import java.nio.file.Files;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.fluss.testutils.DataTestUtils.row;
@@ -179,8 +181,6 @@ public class TieringTestBase extends AbstractTestBase {
 
     private static Configuration flussClusterConfig() {
         Configuration conf = new Configuration();
-        // set snapshot interval to 1s for testing purposes
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1));
         // not to clean snapshots for test purpose
         conf.set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
 
@@ -219,25 +219,23 @@ public class TieringTestBase extends AbstractTestBase {
         return admin.getTableInfo(tablePath).get().getTableId();
     }
 
-    protected void waitUntilSnapshot(long tableId, long snapshotId) {
-        waitUntilSnapshot(tableId, null, snapshotId);
+    protected void triggerAndWaitSnapshot(long tableId) {
+        List<TableBucket> allBuckets = new ArrayList<>();
+        for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
+            allBuckets.add(new TableBucket(tableId, null, i));
+        }
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(allBuckets);
     }
 
-    protected void waitUntilPartitionTableSnapshot(
-            long tableId, Map<String, Long> partitionNameByIds, long snapshotId) {
+    protected void triggerAndWaitUntilPartitionTableSnapshot(
+            long tableId, Map<String, Long> partitionNameByIds) {
+        List<TableBucket> allBuckets = new ArrayList<>();
         for (Map.Entry<String, Long> entry : partitionNameByIds.entrySet()) {
             for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
-                TableBucket tableBucket = new TableBucket(tableId, entry.getValue(), i);
-                FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
+                allBuckets.add(new TableBucket(tableId, entry.getValue(), i));
             }
         }
-    }
-
-    protected void waitUntilSnapshot(long tableId, @Nullable Long partitionId, long snapshotId) {
-        for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, partitionId, i);
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
-        }
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots(allBuckets);
     }
 
     protected static Map<Long, Map<Integer, Long>> upsertRowForPartitionedTable(

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/enumerator/TieringSourceEnumeratorTest.java
@@ -111,8 +111,7 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
 
             Map<Integer, Long> bucketOffsetOfSecondWrite =
                     upsertRow(tablePath, DEFAULT_PK_TABLE_DESCRIPTOR, 0, 10);
-            long snapshotId = 0;
-            waitUntilSnapshot(tableId, snapshotId);
+            triggerAndWaitSnapshot(tableId);
 
             // request tiering table splits
             for (int subtaskId = 0; subtaskId < 3; subtaskId++) {
@@ -150,7 +149,7 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
         final Map<Integer, Long> bucketOffsetOfInitialWrite =
                 upsertRow(tablePath, DEFAULT_PK_TABLE_DESCRIPTOR, 0, 10);
         long snapshotId = 0;
-        waitUntilSnapshot(tableId, snapshotId);
+        triggerAndWaitSnapshot(tableId);
 
         int expectNumberOfSplits = 3;
 
@@ -203,8 +202,7 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
 
             Map<Integer, Long> bucketOffsetOfSecondWrite =
                     upsertRow(tablePath, DEFAULT_PK_TABLE_DESCRIPTOR, 10, 20);
-            snapshotId = 1;
-            waitUntilSnapshot(tableId, snapshotId);
+            triggerAndWaitSnapshot(tableId);
 
             // request tiering table splits
             for (int subtaskId = 0; subtaskId < 3; subtaskId++) {
@@ -392,7 +390,7 @@ class TieringSourceEnumeratorTest extends TieringTestBase {
             Map<Long, Map<Integer, Long>> bucketOffsetOfSecondWrite =
                     upsertRowForPartitionedTable(
                             tablePath, DEFAULT_PK_TABLE_DESCRIPTOR, partitionNameByIds, 10, 20);
-            waitUntilPartitionTableSnapshot(tableId, partitionNameByIds, 0);
+            triggerAndWaitUntilPartitionTableSnapshot(tableId, partitionNameByIds);
 
             // request tiering table splits
             for (int subtaskId = 0; subtaskId < numSubtasks; subtaskId++) {

--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/FlinkTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/utils/FlinkTestBase.java
@@ -30,7 +30,6 @@ import org.apache.fluss.config.ConfigOptions;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.metadata.DatabaseDescriptor;
 import org.apache.fluss.metadata.Schema;
-import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableDescriptor;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
@@ -70,8 +69,6 @@ public class FlinkTestBase extends AbstractTestBase {
             FlussClusterExtension.builder()
                     .setClusterConf(
                             new Configuration()
-                                    // set snapshot interval to 1s for testing purposes
-                                    .set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
                                     // not to clean snapshots for test purpose
                                     .set(
                                             ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS,
@@ -179,13 +176,6 @@ public class FlinkTestBase extends AbstractTestBase {
             throws Exception {
         admin.createTable(tablePath, tableDescriptor, true).get();
         return admin.getTableInfo(tablePath).get().getTableId();
-    }
-
-    protected void waitUntilSnapshot(long tableId, long snapshotId) {
-        for (int i = 0; i < DEFAULT_BUCKET_NUM; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, i);
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
-        }
     }
 
     /**

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/testutils/FlinkIcebergTieringTestBase.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/testutils/FlinkIcebergTieringTestBase.java
@@ -108,8 +108,7 @@ public class FlinkIcebergTieringTestBase {
 
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
-                .set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
+        conf.set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
 
         // Configure the tiering sink to be Iceberg
         conf.set(ConfigOptions.DATALAKE_FORMAT, DataLakeFormat.ICEBERG);
@@ -316,13 +315,6 @@ public class FlinkIcebergTieringTestBase {
                 }
             }
             tableWriter.flush();
-        }
-    }
-
-    protected void waitUntilSnapshot(long tableId, int bucketNum, long snapshotId) {
-        for (int i = 0; i < bucketNum; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, i);
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
         }
     }
 

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringITCase.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/tiering/IcebergTieringITCase.java
@@ -172,7 +172,7 @@ class IcebergTieringITCase extends FlinkIcebergTieringTestBase {
                                 BinaryString.fromString("abc"),
                                 new byte[] {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}));
         writeRows(t1, rows, false);
-        waitUntilSnapshot(t1Id, 1, 0);
+        FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot(t1);
 
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);

--- a/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/testutils/FlinkLanceTieringTestBase.java
+++ b/fluss-lake/fluss-lake-lance/src/test/java/org/apache/fluss/lake/lance/testutils/FlinkLanceTieringTestBase.java
@@ -78,9 +78,8 @@ public class FlinkLanceTieringTestBase {
 
     private static Configuration initConfig() {
         Configuration conf = new Configuration();
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
-                // not to clean snapshots for test purpose
-                .set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
+        // not to clean snapshots for test purpose
+        conf.set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
         conf.setString("datalake.format", "lance");
         try {
             warehousePath =
@@ -209,12 +208,5 @@ public class FlinkLanceTieringTestBase {
                         new Configuration(),
                         DataLakeFormat.LANCE.toString())
                 .build();
-    }
-
-    protected void waitUntilSnapshot(long tableId, int bucketNum, long snapshotId) {
-        for (int i = 0; i < bucketNum; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, i);
-            FLUSS_CLUSTER_EXTENSION.waitUntilSnapshotFinished(tableBucket, snapshotId);
-        }
     }
 }

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/testutils/FlinkPaimonTieringTestBase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/testutils/FlinkPaimonTieringTestBase.java
@@ -93,9 +93,8 @@ public abstract class FlinkPaimonTieringTestBase {
 
     protected static Configuration initConfig() {
         Configuration conf = new Configuration();
-        conf.set(ConfigOptions.KV_SNAPSHOT_INTERVAL, Duration.ofSeconds(1))
-                // not to clean snapshots for test purpose
-                .set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
+        // not to clean snapshots for test purpose
+        conf.set(ConfigOptions.KV_MAX_RETAINED_SNAPSHOTS, Integer.MAX_VALUE);
         conf.setString("datalake.format", "paimon");
         conf.setString("datalake.paimon.metastore", "filesystem");
         try {
@@ -163,11 +162,12 @@ public abstract class FlinkPaimonTieringTestBase {
         return admin.getTableInfo(tablePath).get().getTableId();
     }
 
-    protected void waitUntilSnapshot(long tableId, int bucketNum, long snapshotId) {
+    protected void triggerAndWaitSnapshot(long tableId, int bucketNum) {
+        List<TableBucket> allBuckets = new ArrayList<>();
         for (int i = 0; i < bucketNum; i++) {
-            TableBucket tableBucket = new TableBucket(tableId, i);
-            getFlussClusterExtension().waitUntilSnapshotFinished(tableBucket, snapshotId);
+            allBuckets.add(new TableBucket(tableId, i));
         }
+        getFlussClusterExtension().triggerAndWaitSnapshots(allBuckets);
     }
 
     protected void writeRows(TablePath tablePath, List<InternalRow> rows, boolean append)

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/PaimonTieringITCase.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/PaimonTieringITCase.java
@@ -104,7 +104,7 @@ class PaimonTieringITCase extends FlinkPaimonTieringTestBase {
         // write records
         List<InternalRow> rows = Arrays.asList(row(1, "v1"), row(2, "v2"), row(3, "v3"));
         writeRows(t1, rows, false);
-        waitUntilSnapshot(t1Id, 1, 0);
+        triggerAndWaitSnapshot(t1Id, 1);
 
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);
@@ -339,7 +339,7 @@ class PaimonTieringITCase extends FlinkPaimonTieringTestBase {
         // write records
         List<InternalRow> rows = Arrays.asList(row(1, "v1"), row(2, "v2"), row(3, "v3"));
         writeRows(t1, rows, false);
-        waitUntilSnapshot(t1Id, 1, 0);
+        triggerAndWaitSnapshot(t1Id, 1);
 
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);
@@ -445,7 +445,7 @@ class PaimonTieringITCase extends FlinkPaimonTieringTestBase {
         // write records
         List<InternalRow> rows = Arrays.asList(row(1, "v1"), row(2, "v2"), row(3, "v3"));
         writeRows(t1, rows, false);
-        waitUntilSnapshot(t1Id, 1, 0);
+        triggerAndWaitSnapshot(t1Id, 1);
 
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/ReCreateSameTableAfterTieringTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/tiering/ReCreateSameTableAfterTieringTest.java
@@ -66,7 +66,7 @@ class ReCreateSameTableAfterTieringTest extends FlinkPaimonTieringTestBase {
         // write records
         List<InternalRow> rows = Arrays.asList(row(1, "v1"), row(2, "v2"), row(3, "v3"));
         writeRows(t1, rows, false);
-        waitUntilSnapshot(t1Id, 1, 0);
+        triggerAndWaitSnapshot(t1Id, 1);
         // then start tiering job
         JobClient jobClient = buildTieringJob(execEnv);
 
@@ -84,7 +84,7 @@ class ReCreateSameTableAfterTieringTest extends FlinkPaimonTieringTestBase {
         List<InternalRow> newRows = Arrays.asList(row(4, "v4"), row(5, "v5"));
         writeRows(t1, newRows, false);
         // new table, so the snapshot id should be 0
-        waitUntilSnapshot(t2Id, 1, 0);
+        triggerAndWaitSnapshot(t2Id, 1);
         // check the status of replica after synced
         assertReplicaStatus(t2Bucket, 2);
         // check data in paimon

--- a/fluss-server/src/main/java/org/apache/fluss/server/SequenceIDCounter.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/SequenceIDCounter.java
@@ -20,6 +20,9 @@ package org.apache.fluss.server;
 /** A counter for generating unique sequence IDs. */
 public interface SequenceIDCounter {
 
+    /** Gets the current sequence ID without incrementing it. */
+    long getCurrent() throws Exception;
+
     /**
      * Atomically increments the sequence ID.
      *

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvTabletSnapshotTarget.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/KvTabletSnapshotTarget.java
@@ -19,6 +19,7 @@ package org.apache.fluss.server.kv.snapshot;
 
 import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.ConfigOptions;
+import org.apache.fluss.exception.FlussRuntimeException;
 import org.apache.fluss.fs.FileSystem;
 import org.apache.fluss.fs.FsPath;
 import org.apache.fluss.metadata.TableBucket;
@@ -153,6 +154,16 @@ public class KvTabletSnapshotTarget implements PeriodicSnapshotManager.SnapshotT
         this.ioExecutor = ioExecutor;
         this.snapshotRunner = createSnapshotRunner(cancelStreamRegistry);
         this.snapshotsCleaner = new SnapshotsCleaner();
+    }
+
+    @Override
+    public long currentSnapshotId() {
+        try {
+            return snapshotIdCounter.getCurrent();
+        } catch (Exception e) {
+            throw new FlussRuntimeException(
+                    "Failed to get current snapshot ID for TableBucket " + tableBucket + ".", e);
+        }
     }
 
     @Override

--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
@@ -168,6 +168,11 @@ public class PeriodicSnapshotManager implements Closeable {
         }
     }
 
+    @VisibleForTesting
+    public long currentSnapshotId() {
+        return target.currentSnapshotId();
+    }
+
     public void triggerSnapshot() {
         // todo: consider shrink the scope
         // of using guardedExecutor
@@ -229,8 +234,9 @@ public class PeriodicSnapshotManager implements Closeable {
                                             snapshotLocation,
                                             snapshotResult);
                                     LOG.info(
-                                            "TableBucket {} snapshot finished successfully, cost {} ms.",
+                                            "TableBucket {} snapshot {} finished successfully, cost {} ms.",
                                             tableBucket,
+                                            snapshotId,
                                             System.currentTimeMillis() - triggerTime);
                                 } catch (Throwable t) {
                                     LOG.warn(
@@ -312,6 +318,10 @@ public class PeriodicSnapshotManager implements Closeable {
     /** {@link SnapshotRunnable} provider and consumer. */
     @NotThreadSafe
     public interface SnapshotTarget {
+
+        /** Gets current snapshot id. */
+        long currentSnapshotId();
+
         /**
          * Initialize kv snapshot.
          *

--- a/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/replica/Replica.java
@@ -1932,4 +1932,10 @@ public final class Replica {
     public SchemaGetter getSchemaGetter() {
         return schemaGetter;
     }
+
+    @VisibleForTesting
+    @Nullable
+    public PeriodicSnapshotManager getKvSnapshotManager() {
+        return kvSnapshotManager;
+    }
 }

--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/ZkSequenceIDCounter.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/ZkSequenceIDCounter.java
@@ -47,6 +47,11 @@ public class ZkSequenceIDCounter implements SequenceIDCounter {
                                 BASE_SLEEP_MS, MAX_SLEEP_MS, RETRY_TIMES));
     }
 
+    @Override
+    public long getCurrent() throws Exception {
+        return sequenceIdCounter.get().postValue();
+    }
+
     /**
      * Atomically increments the current sequence ID.
      *

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/autoinc/TestingSequenceIDCounter.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/autoinc/TestingSequenceIDCounter.java
@@ -40,6 +40,11 @@ public class TestingSequenceIDCounter implements SequenceIDCounter {
     }
 
     @Override
+    public long getCurrent() {
+        return idGenerator.get();
+    }
+
+    @Override
     public long getAndIncrement() {
         return idGenerator.getAndIncrement();
     }

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/KvTabletSnapshotTargetTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/KvTabletSnapshotTargetTest.java
@@ -656,6 +656,11 @@ class KvTabletSnapshotTargetTest {
     private class TestingSnapshotIDCounter implements SequenceIDCounter {
 
         @Override
+        public long getCurrent() {
+            return snapshotIdGenerator.get();
+        }
+
+        @Override
         public long getAndIncrement() {
             return snapshotIdGenerator.getAndIncrement();
         }

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
@@ -158,6 +158,11 @@ class PeriodicSnapshotManagerTest {
         private static final NopSnapshotTarget INSTANCE = new NopSnapshotTarget();
 
         @Override
+        public long currentSnapshotId() {
+            return 0;
+        }
+
+        @Override
         public Optional<PeriodicSnapshotManager.SnapshotRunnable> initSnapshot() {
             return Optional.empty();
         }
@@ -203,6 +208,11 @@ class PeriodicSnapshotManagerTest {
             } catch (IOException e) {
                 throw new FlussRuntimeException(e);
             }
+        }
+
+        @Override
+        public long currentSnapshotId() {
+            return 0;
         }
 
         @Override


### PR DESCRIPTION

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx


This pull request refactors snapshot-related test utilities across multiple integration test cases to improve consistency and reliability. The main change is replacing manual snapshot waiting logic and configuration with standardized methods provided by `FLUSS_CLUSTER_EXTENSION`, and removing unnecessary configuration of snapshot intervals for testing purposes.

**Snapshot Triggering and Waiting Refactor:**

* Replaced calls to custom snapshot waiting methods (e.g., `waitUntilAllSnapshotFinished`, `waitUntilSnapshotFinished`, and `waitUntilAllBucketFinishSnapshot`) with standardized calls to `FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshot` and `FLUSS_CLUSTER_EXTENSION.triggerAndWaitSnapshots` in test cases such as `FlinkTableSourceITCase`, `KvSnapshotBatchScannerITCase`, and `FlussAdminITCase`. This improves test reliability and code maintainability. 

**Configuration Cleanup:**

* Removed test-specific configuration for snapshot intervals (`KV_SNAPSHOT_INTERVAL`) from cluster configuration initialization in several test classes, relying instead on default settings and explicit snapshot triggering. This reduces test configuration complexity and potential flakiness.


**Code Simplification:**

* Removed unused imports and redundant utility methods related to snapshot waiting, such as `waitUntilAllSnapshotFinished` and `waitUntilAllBucketFinishSnapshot`, further streamlining test code. 

Overall, these changes standardize snapshot handling in tests, reduce configuration overhead, and simplify the codebase, making the tests easier to maintain and less error-prone.
<!-- What is the purpose of the change -->

### Brief change log


<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
