### PR TITLE
[hotfix] Catalog related options should overwrite table lake related options

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeFlinkCatalog.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeFlinkCatalog.java
@@ -30,6 +30,7 @@ import org.apache.paimon.flink.FlinkFileIOLoader;
 import org.apache.paimon.options.Options;
 
 import java.lang.reflect.Method;
+import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.fluss.metadata.DataLakeFormat.ICEBERG;
@@ -72,11 +73,11 @@ public class LakeFlinkCatalog implements AutoCloseable {
                                         + "' is set.");
                     }
                     Map<String, String> catalogProperties =
-                            PropertiesUtils.extractAndRemovePrefix(
-                                    lakeCatalogProperties, lakeFormat + ".");
-
+                            new HashMap<>(DataLakeUtils.extractLakeCatalogProperties(tableOptions));
+                    // properties in catalog are preferred
                     catalogProperties.putAll(
-                            DataLakeUtils.extractLakeCatalogProperties(tableOptions));
+                            PropertiesUtils.extractAndRemovePrefix(
+                                    lakeCatalogProperties, lakeFormat + "."));
                     if (lakeFormat == PAIMON) {
                         catalog =
                                 PaimonCatalogFactory.create(


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
#1937 doesn't use catalog related options to overwrite table options in table witth `$lake` cause catalog related options don't work.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
