### PR TITLE
[helm] Add `tabletServer.count` configuration option

### DIFF
--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -96,11 +96,11 @@ spec:
         - name: fluss-conf
           configMap:
             name: fluss-conf-file
-        {{- if not .Values.persistence.enabled }}
+        {{- if not .Values.coordinator.storage.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
-  {{- if .Values.persistence.enabled }}
+  {{- if .Values.coordinator.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -108,6 +108,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
-            storage: {{ .Values.persistence.size }}
-        storageClassName: {{ .Values.persistence.storageClass }}
+            storage: {{ .Values.coordinator.storage.size }}
+        storageClassName: {{ .Values.coordinator.storage.storageClass }}
   {{- end}}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -92,11 +92,11 @@ spec:
         - name: fluss-conf
           configMap:
             name: fluss-conf-file
-        {{- if not .Values.persistence.enabled }}
+        {{- if not .Values.tablet.storage.enabled }}
         - name: data
           emptyDir: {}
         {{- end }}
-  {{- if .Values.persistence.enabled }}
+  {{- if .Values.tablet.storage.enabled }}
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -104,6 +104,6 @@ spec:
         accessModes: [ "ReadWriteOnce" ]
         resources:
           requests:
-            storage: {{ .Values.persistence.size }}
-        storageClassName: {{ .Values.persistence.storageClass }}
+            storage: {{ .Values.tablet.storage.size }}
+        storageClassName: {{ .Values.tablet.storage.storageClass }}
   {{- end}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -42,16 +42,19 @@ configurationOverrides:
   data.dir: /tmp/fluss/data
   internal.listener.name: INTERNAL
 
-persistence:
-  enabled: false
-  size: 1Gi
-  storageClass:
-
 tablet:
   numberOfReplicas: 3
+  storage:
+    enabled: false
+    size: 1Gi
+    storageClass:
 
 coordinator:
   numberOfReplicas: 1
+  storage:
+    enabled: false
+    size: 1Gi
+    storageClass:
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -141,10 +141,6 @@ The Fluss Helm chart deploys the following Kubernetes resources:
 - **ConfigMap**: Configuration management for `server.yaml` settings
 - **Services**: Headless services providing stable pod DNS names
 
-### Optional Components
-- **PersistentVolumes**: Data persistence when `persistence.enabled=true`
-
-
 ### Step 3: Verify Installation
 
 ```bash
@@ -205,13 +201,16 @@ The following table lists the configurable parameters of the Fluss chart and the
 |-----------|-------------|---------|
 | `tablet.numberOfReplicas` | Number of TabletServer replicas to deploy | `3` |
 
-### Persistence Parameters
+### Storage Parameters
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
-| `persistence.enabled` | Enable persistent volume claims | `false` |
-| `persistence.size` | Persistent volume size | `1Gi` |
-| `persistence.storageClass` | Storage class name | `nil` (uses default) |
+| `coordinator.storage.enabled` | Enable persistent volume claims for CoordinatorServer | `false` |
+| `coordinator.storage.size` | Coordinator persistent volume size | `1Gi` |
+| `coordinator.storage.storageClass` | Coordinator storage class name | `nil` (uses default) |
+| `tablet.storage.enabled` | Enable persistent volume claims for TabletServer | `false` |
+| `tablet.storage.size` | Tablet persistent volume size | `1Gi` |
+| `tablet.storage.storageClass` | Tablet storage class name | `nil` (uses default) |
 
 ### Resource Parameters
 
@@ -260,7 +259,23 @@ configurationOverrides:
 
 ### Storage Configuration
 
-Configure different storage backends:
+Configure different storage volumes for coordinator or tablet pods:
+
+```yaml
+coordinator:
+  storage:
+    enabled: true
+    size: 5Gi
+    storageClass: fast-ssd
+
+tablet:
+  storage:
+    enabled: true
+    size: 20Gi
+    storageClass: fast-ssd
+```
+
+Configure remote storage:
 
 ```yaml
 configurationOverrides:
@@ -411,4 +426,3 @@ kubectl get configmap fluss-conf-file -o yaml
 # Get detailed pod information
 kubectl get pods -o wide -l app.kubernetes.io/name=fluss
 ```
-


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2455 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Enable setting the number tablet servers when deploying with helm charts.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
Added parameter section in the helm deployment documentation.
