### PR TITLE
[feat] Handle individual table failures without failing the entire job

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/committer/TieringCommitOperator.java
@@ -124,6 +124,29 @@ public class TieringCommitOperator<WriteResult, Committable>
     public void processElement(StreamRecord<TableBucketWriteResult<WriteResult>> streamRecord)
             throws Exception {
         TableBucketWriteResult<WriteResult> tableBucketWriteResult = streamRecord.getValue();
+
+        // Check if this is a failure marker from upstream Reader
+        if (tableBucketWriteResult.isFailedMarker()) {
+            long failedTableId = tableBucketWriteResult.tableBucket().getTableId();
+            String failReason = tableBucketWriteResult.failReason();
+            LOG.info(
+                    "Received failure marker for table {}. Reason: {}. "
+                            + "Cleaning up collected write results for this table.",
+                    failedTableId,
+                    failReason);
+
+            // Clean up any partially collected write results for the failed table
+            List<TableBucketWriteResult<WriteResult>> removedResults =
+                    collectedTableBucketWriteResults.remove(failedTableId);
+            if (removedResults != null) {
+                LOG.info(
+                        "Cleaned up {} collected write results for failed table {}.",
+                        removedResults.size(),
+                        failedTableId);
+            }
+            return;
+        }
+
         TableBucket tableBucket = tableBucketWriteResult.tableBucket();
         long tableId = tableBucket.getTableId();
         registerTableBucketWriteResult(tableId, tableBucketWriteResult);

--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/event/FailedTieringEvent.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/tiering/event/FailedTieringEvent.java
@@ -40,4 +40,15 @@ public class FailedTieringEvent implements SourceEvent {
     public String failReason() {
         return failReason;
     }
+
+    @Override
+    public String toString() {
+        return "FailedTieringEvent{"
+                + "tableId="
+                + tableId
+                + ", failReason='"
+                + failReason
+                + '\''
+                + '}';
+    }
 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2360 

<!-- What is the purpose of the change -->

### Brief change log

1. Add exception handling in TieringSplitReader to catch tiering task failures and queue failure information instead of crashing the entire job.
2. Add FailedTableInfo inner class to store failed table ID and failure reason.
3. Add TableTieringFailedEvent event class for Enumerator to broadcast table tiering failure notifications to all Readers.
4. In TieringSourceReader, add processFailedTables() method to detect failed tables and send FailedTieringEvent to Enumerator. And add handleSourceEvents() to process TableTieringFailedEvent from Enumerator and generate failure markers to downstream Committer.
5. In TieringSourceEnumerator, add broadcastTableTieringFailedEvent() method to broadcast failure events to all other Readers upon receiving a failure event.
6. In TableBucketWriteResult, add failedMarker and failReason fields, and add failedMarker() static factory method to create failure markers.
7. In TieringCommitOperator, add failure marker handling logic: when a failure marker is detected, clean up collected write results for the failed table.
8. Update TableBucketWriteResultSerializer to support serialization/deserialization of the new failedMarker and failReason fields.

### Tests

TieringCommitOperatorTest
TableBucketWriteResultSerializerTest
TieringSourceEnumeratorTest

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
