### PR TITLE
[hotfix] Remove unstable "latest" scan startup mode test in ChangelogVirtualTableITCase

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/source/ChangelogVirtualTableITCase.java
@@ -349,20 +349,7 @@ abstract class ChangelogVirtualTableITCase extends AbstractTestBase {
             assertThat(result).startsWith("+I[+I,");
         }
 
-        // 2. Test scan.startup.mode='latest' - should only read new records after subscription
-        String optionsLatest = " /*+ OPTIONS('scan.startup.mode' = 'latest') */";
-        String queryLatest =
-                "SELECT _change_type, id, name FROM startup_mode_test$changelog" + optionsLatest;
-        CloseableIterator<Row> rowIterLatest = tEnv.executeSql(queryLatest).collect();
-
-        // Write new data after subscribing with 'latest'
-        CLOCK.advanceTime(Duration.ofMillis(100));
-        writeRows(conn, tablePath, Arrays.asList(row(6, "v6")), false);
-        List<String> latestResults = collectRowsWithTimeout(rowIterLatest, 1, true);
-        assertThat(latestResults).hasSize(1);
-        assertThat(latestResults.get(0)).isEqualTo("+I[+I, 6, v6]");
-
-        // 3. Test scan.startup.mode='timestamp' - should read records from specific timestamp
+        // 2. Test scan.startup.mode='timestamp' - should read records from specific timestamp
         // read between batch1 and batch2
         String optionsTimestamp =
                 " /*+ OPTIONS('scan.startup.mode' = 'timestamp', 'scan.startup.timestamp' = '150') */";


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

This test is quite unstable, and we can remove it temporarily and fix it in https://github.com/apache/fluss/pull/2467/files#r2724324458 in a more elegant way. 
<!-- Linking this pull request to the issue -->
Linked issue: close #xxx

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
