### PR TITLE
[FLUSS-2473][server][test] Fix flaky test FlussAuthorizationITCase.testRebalance

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/rebalance/RebalanceManager.java
@@ -365,6 +365,11 @@ public class RebalanceManager {
             checkArgument(bucketLeaderAndIsrOpt.isPresent(), "Bucket leader and isr is empty.");
             LeaderAndIsr isr = bucketLeaderAndIsrOpt.get();
             int leader = isr.leader();
+            // Skip the bucket if it is in a transient state (e.g., during table creation)
+            // where the leader is elected but not yet present in the assignment list.
+            if (leader == -1 || !assignment.contains(leader)) {
+                continue;
+            }
             for (int i = 0; i < assignment.size(); i++) {
                 int replica = assignment.get(i);
                 clusterModel.createReplica(replica, tableBucket, i, leader == replica);


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2473

<!-- What is the purpose of the change -->

### Brief change log

This PR fixes the flaky test `FlussAuthorizationITCase.testRebalance`.

The error happens because of a race condition between creating a table and the rebalance operation. Sometimes, `RebalanceManager` tries to build a cluster model while a table is still being created. In this specific moment, the table has a Leader elected, but the replica list is not updated yet. This caused the error `RebalanceFailureException: Leader replica is not in the bucket`.

### Tests

- Added `testRebalanceDuringConcurrentTableCreation` in `FlussAuthorizationITCase`.
- I ran the new test locally more than 50 times and it passed. Before the fix, it failed consistently.
- I also ran the full Maven build locally and all tests passed.

### API and Format
no

### Documentation

no
