### PR TITLE
[hotfix] Fix unstable tiering source enumerator test

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/tiering/source/TieringTestBase.java
@@ -89,7 +89,7 @@ public class TieringTestBase extends AbstractTestBase {
                     .schema(DEFAULT_PK_TABLE_SCHEMA)
                     .distributedBy(DEFAULT_BUCKET_NUM, "id")
                     .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
-                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(200))
+                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(10))
                     .build();
 
     protected static final TableDescriptor DEFAULT_LOG_TABLE_DESCRIPTOR =
@@ -98,7 +98,7 @@ public class TieringTestBase extends AbstractTestBase {
                     .distributedBy(DEFAULT_BUCKET_NUM, "id")
                     .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
                     .property(ConfigOptions.TABLE_DATALAKE_FORMAT, DataLakeFormat.PAIMON)
-                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(200))
+                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(10))
                     .build();
 
     protected static final TableDescriptor DEFAULT_AUTO_PARTITIONED_LOG_TABLE_DESCRIPTOR =
@@ -117,7 +117,7 @@ public class TieringTestBase extends AbstractTestBase {
                             AutoPartitionTimeUnit.YEAR)
                     .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
                     .property(ConfigOptions.TABLE_DATALAKE_FORMAT, DataLakeFormat.PAIMON)
-                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(500))
+                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(10))
                     .build();
 
     protected static final TableDescriptor DEFAULT_AUTO_PARTITIONED_PK_TABLE_DESCRIPTOR =
@@ -137,7 +137,7 @@ public class TieringTestBase extends AbstractTestBase {
                             AutoPartitionTimeUnit.YEAR)
                     .property(ConfigOptions.TABLE_DATALAKE_ENABLED, true)
                     .property(ConfigOptions.TABLE_DATALAKE_FORMAT, DataLakeFormat.PAIMON)
-                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(500))
+                    .property(ConfigOptions.TABLE_DATALAKE_FRESHNESS, Duration.ofMillis(10))
                     .build();
 
     protected static final String DEFAULT_DB = "test-tiering-db";


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #xxx
Fix unstable test
 https://github.com/apache/fluss/actions/runs/21382698242/job/61552666939

<!-- What is the purpose of the change -->

### Brief change log
testHandleFailedTieringTableEvent have two tables, table1, table2, whose freshness is 100ms,
it may happen that table1 already add to pending queue, and mark it as fail, the table2 is still not added to the queue.
So, the next request will still get table1 which cause test fails.

I can reproduce it with repeat 100 tests.


I change table freshness to 10ms, then repeat 100 tests. The test won't fail.

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
