### PR TITLE
[FLUSS-2262][lake/iceberg] Improved IcebergRewriteITCase.testLogTableCompaction Reliability

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteITCase.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteITCase.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import static org.apache.fluss.testutils.DataTestUtils.row;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -167,7 +168,7 @@ class IcebergRewriteITCase extends FlinkIcebergTieringTestBase {
     void testLogTableCompaction() throws Exception {
         JobClient jobClient = buildTieringJob(execEnv);
         try {
-            TablePath t1 = TablePath.of(DEFAULT_DB, "log_table");
+            TablePath t1 = TablePath.of(DEFAULT_DB, "log_table_" + UUID.randomUUID());
             long t1Id = createLogTable(t1, 1, true, logSchema);
             TableBucket t1Bucket = new TableBucket(t1Id, 0);
 
@@ -210,6 +211,7 @@ class IcebergRewriteITCase extends FlinkIcebergTieringTestBase {
             List<InternalRow> rows)
             throws Exception {
         writeRows(tablePath, rows, append);
+        waitForIcebergSnapshotOffset(tablePath, tableBucket, expectedLogEndOffset);
         assertReplicaStatus(tableBucket, expectedLogEndOffset);
         return rows;
     }


### PR DESCRIPTION
### Purpose

Linked issue: close #2262  

Per Issue https://github.com/apache/fluss/issues/2262, this pull request addresses a potential asynchronous time-gap issue during the commit notification flow that could result in the `IcebergRewriteITCase.testLogTableCompaction` test case failing (particularly during CI builds). 

### Brief change log

This change improves the reliability of `IcebergRewriteITCase.testLogTableCompaction` by introducing a two-phase verification process for tiering completion. It adds `waitForIcebergSnapshotOffset()` to first verify commits at the source of truth (i.e. Iceberg), then uses an updated `assertReplicaStatus()` to wait for the async replica notification.

#### Verification

After significant exploration within [the previously proposed solution](https://github.com/apache/fluss/pull/2265) and within separate out-of-band conversations with @luoyuxia during investigation, a root cause along with related evidence was found to justify the time-gap issue. 

##### Diagnostics Gist
A reproducible test can be found within [this gist here](https://gist.github.com/rionmonster/364ee6639a6aa267210e644bd9c12500) which introduces a `LakeTableOffsetAsyncGapTest` purely for diagnostics purposes.

##### Diagnostics Logs
The above gist provides a series of logs to verify the timing issues (between actual values and expectations):
```
1784 [ForkJoinPool-1-worker-19] INFO  org.apache.fluss.server.replica.LakeTableOffsetAsyncGapTest [] - [TEST] Cycle 10: Gap observed! Commit took 5 ms, notification delay was 1 ms
1784 [ForkJoinPool-1-worker-19] INFO  org.apache.fluss.server.replica.LakeTableOffsetAsyncGapTest [] - [TEST] Summary: Gap observed in 10/10 cycles
1785 [ForkJoinPool-1-worker-19] INFO  org.apache.fluss.server.replica.LakeTableOffsetAsyncGapTest [] - [TEST] Gap timings (ms): min=1, max=3, avg=1.2
...
1928 [ForkJoinPool-1-worker-19] INFO  org.apache.fluss.server.replica.LakeTableOffsetAsyncGapTest [] - [TEST] Immediate check after commit: lakeLogEndOffset=-1 (expected: -1 if async gap exists, 25 if sync)
1928 [ForkJoinPool-1-worker-19] INFO  org.apache.fluss.server.replica.LakeTableOffsetAsyncGapTest [] - [TEST] Rapid samples of lakeLogEndOffset: [-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1]
```

### Tests

Updates commit and status verifications for existing `FlinkIcebergTieringTestBase.assertReplicaStatus` and `FlinkIcebergTieringTestBase.waitForIcebergSnapshotOffset` to address the underlying flaky test itself.

### API and Format

N/A

### Documentation

N/A

### Reviewer(s) Requested

@luoyuxia 
