### PR TITLE
[lake] Optimize TableLookup finder creation

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/lookup/PrimaryKeyLookuper.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/lookup/PrimaryKeyLookuper.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.fluss.client.utils.ClientUtils.getPartitionId;
-import static org.apache.fluss.utils.Preconditions.checkArgument;
 
 /** An implementation of {@link Lookuper} that lookups by primary key. */
 @NotThreadSafe
@@ -62,10 +61,6 @@ class PrimaryKeyLookuper extends AbstractLookuper implements Lookuper {
             MetadataUpdater metadataUpdater,
             LookupClient lookupClient) {
         super(tableInfo, metadataUpdater, lookupClient, schemaGetter);
-        checkArgument(
-                tableInfo.hasPrimaryKey(),
-                "Log table %s doesn't support lookup",
-                tableInfo.getTablePath());
         this.numBuckets = tableInfo.getNumBuckets();
 
         // the row type of the input lookup row

--- a/fluss-client/src/test/java/org/apache/fluss/client/table/FlussLakeTableITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/table/FlussLakeTableITCase.java
@@ -199,7 +199,9 @@ class FlussLakeTableITCase {
             List<String> lookUpColumns =
                     isDefaultBucketKey
                             ? Arrays.asList("a", "c", "d")
-                            : isPartitioned ? Arrays.asList("a", "d") : Collections.singletonList("a");
+                            : isPartitioned
+                                    ? Arrays.asList("a", "d")
+                                    : Collections.singletonList("a");
             Lookuper lookuper = table.newLookup().lookupBy(lookUpColumns).createLookuper();
             List<InternalRow.FieldGetter> lookUpFieldGetter = new ArrayList<>(lookUpColumns.size());
             for (int columnIndex : pkTableSchema.getColumnIndexes(lookUpColumns)) {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2521

<!-- What is the purpose of the change -->

### Brief change log
- Enhance TableLookup.createLookuper() to intelligently route lookup requests:
  * Create PrimaryKeyLookuper when lookup columns match primary key
  * Create PrefixKeyLookuper when lookup columns are valid prefix key
  * Fail-fast with clear error message for invalid lookup columns
<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests
- Add TableLookupTest with 10 test cases covering:
  * Primary key lookup (with/without lookupBy, partitioned/non-partitioned)
  * Prefix key lookup (single/multiple columns, partitioned/non-partitioned)
  * Invalid inputs (out-of-order, empty, non-primary/non-prefix columns)
  * Log table rejection
<!-- List UT and IT cases to verify this change -->

### API and Format
None
<!-- Does this change affect API or storage format -->

### Documentation
None
<!-- Does this change introduce a new feature -->
