### PR TITLE
Remove external google font to address apache podling website resource check

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -50,7 +50,7 @@
 }
 
 .hero__title {
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-family: var(--ifm-font-family-base);
   font-weight: 700;
   letter-spacing: -0.03em;
 }


### PR DESCRIPTION
### Purpose

Linked issue: close #2564

### Brief change log

- Remove external google font resource
- Use readily available system fonts

### Tests

- Compiled locally and observed no significant changes to website
- Viewed under different device (iOS and android) mode in chrome browser
- Inspected elements and found updated font/css
- Inspected network graph and verified no google font downloads
