### PR TITLE
Forbid aggregate merge engine with WAL changelog image

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/admin/FlussAdminITCase.java
@@ -1740,8 +1740,10 @@ class FlussAdminITCase extends ClientToServerITCaseBase {
         assertThatThrownBy(() -> admin.createTable(tablePath1, tableDescriptor1, false).get())
                 .cause()
                 .isInstanceOf(InvalidConfigException.class)
-                .hasMessageContaining(ConfigOptions.TABLE_MERGE_ENGINE.key())
-                .hasMessageContaining(ConfigOptions.TABLE_CHANGELOG_IMAGE.key());
+                .hasMessageContaining(
+                        "Table with 'AGGREGATION' merge engine does not support 'WAL' changelog image mode. "
+                                + "Aggregation merge engine tables require FULL changelog image mode for correct UNDO recovery. "
+                                + "Please set 'table.changelog.image' to 'FULL' or remove the setting.");
 
         // Test 2: Aggregate + FULL should be allowed
         TablePath tablePath2 = TablePath.of("fluss", "test_aggregate_full_changelog_allowed");

--- a/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/utils/TableDescriptorValidation.java
@@ -308,11 +308,9 @@ public class TableDescriptorValidation {
                 if (changelogImage == ChangelogImage.WAL) {
                     throw new InvalidConfigException(
                             String.format(
-                                    "Table with '%s' merge engine does not support '%s' changelog image mode. "
-                                            + "Aggregate merge engine tables require FULL changelog image mode "
+                                    "Table with 'AGGREGATION' merge engine does not support 'WAL' changelog image mode. "
+                                            + "Aggregation merge engine tables require FULL changelog image mode "
                                             + "for correct UNDO recovery. Please set '%s' to 'FULL' or remove the setting.",
-                                    ConfigOptions.TABLE_MERGE_ENGINE.key(),
-                                    ConfigOptions.TABLE_CHANGELOG_IMAGE.key(),
                                     ConfigOptions.TABLE_CHANGELOG_IMAGE.key()));
                 }
                 // Validate aggregation function parameters for aggregation merge engine


### PR DESCRIPTION
WAL mode lacks UPDATE_BEFORE records needed for UNDO recovery in aggregate tables. Add validation to reject this invalid combination.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2608 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
