### PR TITLE
[fluss] allow setting table.log.ttl to -1 for infinite retention

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/config/ConfigurationUtils.java
+++ b/fluss-common/src/main/java/org/apache/fluss/config/ConfigurationUtils.java
@@ -139,6 +139,10 @@ public class ConfigurationUtils {
             return (Duration) o;
         }
 
+        String s = o.toString().trim();
+        if ("-1".equals(s)) {
+            return Duration.ofMillis(-1);
+        }
         return TimeUtils.parseDuration(o.toString());
     }
 
@@ -155,6 +159,9 @@ public class ConfigurationUtils {
             return (String) o;
         } else if (o.getClass() == Duration.class) {
             Duration duration = (Duration) o;
+            if (duration.toMillis() == -1) {
+                return "-1";
+            }
             return TimeUtils.formatWithHighestUnit(duration);
         } else if (o instanceof List) {
             return ((List<?>) o)

--- a/fluss-common/src/test/java/org/apache/fluss/config/ConfigurationTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/config/ConfigurationTest.java
@@ -108,6 +108,8 @@ public class ConfigurationTest {
         assertThat(conf.get(DURATION_OPTION).toMillis()).isEqualTo(3);
         conf.setString(DURATION_OPTION.key(), "3 s");
         assertThat(conf.get(DURATION_OPTION).toMillis()).isEqualTo(3000);
+        conf.setString(DURATION_OPTION.key(), "-1");
+        assertThat(conf.get(DURATION_OPTION)).isEqualTo(Duration.ofMillis(-1));
 
         conf.setBytes("test-bytes-key", new byte[] {1, 2, 3, 4, 5});
         assertThat(conf.getBytes("test-bytes-key", new byte[0]).length).isEqualTo(5);
@@ -426,6 +428,20 @@ public class ConfigurationTest {
         assertThat(conf.toMap().get(LIST_STRING_OPTION.key())).isEqualTo(listValues);
         assertThat(conf.toMap().get(MAP_OPTION.key())).isEqualTo(mapValues);
         assertThat(conf.toMap().get(DURATION_OPTION.key())).isEqualTo("3 s");
+    }
+
+    @Test
+    void testTableLogTtlMinusOneParseAndRoundTrip() {
+        // Parse "-1" as Duration (e.g. table.log.ttl = -1 means never delete logs)
+        final Configuration conf = new Configuration();
+        conf.setString(ConfigOptions.TABLE_LOG_TTL.key(), "-1");
+        assertThat(conf.get(ConfigOptions.TABLE_LOG_TTL)).isEqualTo(Duration.ofMillis(-1));
+        assertThat(conf.get(ConfigOptions.TABLE_LOG_TTL).toMillis()).isEqualTo(-1L);
+
+        // Round-trip: Duration.ofMillis(-1) serializes back to "-1"
+        final Configuration conf2 = new Configuration();
+        conf2.set(ConfigOptions.TABLE_LOG_TTL, Duration.ofMillis(-1));
+        assertThat(conf2.toMap().get(ConfigOptions.TABLE_LOG_TTL.key())).isEqualTo("-1");
     }
 
     @Test


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

According to the documentation for  `table.log.ttl`:

https://github.com/apache/fluss/blob/main/website/docs/engine-flink/options.md

The configuration controls the maximum time we will retain a log before we will delete old segments to free up space. If set to -1, the log will not be deleted.

This PR implements it

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/fluss/issues/2653

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
