### PR TITLE
[hotfix][server] KvSnapshotLeaseMetadataJsonSerde serialize kv snapshot path use toString() instead of getPath()

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lease/KvSnapshotLeaseMetadataJsonSerde.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/zk/data/lease/KvSnapshotLeaseMetadataJsonSerde.java
@@ -56,7 +56,7 @@ public class KvSnapshotLeaseMetadataJsonSerde
                 kvSnapshotLeaseMetadata.getTableIdToRemoteMetadataFilePath().entrySet()) {
             generator.writeStartObject();
             generator.writeNumberField(TABLE_ID, entry.getKey());
-            generator.writeStringField(KV_SNAPSHOT_PATH, entry.getValue().getPath());
+            generator.writeStringField(KV_SNAPSHOT_PATH, entry.getValue().toString());
             generator.writeEndObject();
         }
         // end tables

--- a/fluss-server/src/test/java/org/apache/fluss/server/zk/data/lease/KvSnapshotLeaseMetadataJsonSerdeTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/zk/data/lease/KvSnapshotLeaseMetadataJsonSerdeTest.java
@@ -36,8 +36,8 @@ public class KvSnapshotLeaseMetadataJsonSerdeTest
     protected KvSnapshotLeaseMetadata[] createObjects() {
         KvSnapshotLeaseMetadata[] kvSnapshotLeaseMetadata = new KvSnapshotLeaseMetadata[2];
         Map<Long, FsPath> tableIdToRemoteMetadataFilePath = new HashMap<>();
-        tableIdToRemoteMetadataFilePath.put(1L, new FsPath("/path/to/metadata1"));
-        tableIdToRemoteMetadataFilePath.put(2L, new FsPath("/path/to/metadata2"));
+        tableIdToRemoteMetadataFilePath.put(1L, new FsPath("oss://path/to/metadata1"));
+        tableIdToRemoteMetadataFilePath.put(2L, new FsPath("s3://path/to/metadata2"));
         kvSnapshotLeaseMetadata[0] =
                 new KvSnapshotLeaseMetadata(1735538268L, tableIdToRemoteMetadataFilePath);
         kvSnapshotLeaseMetadata[1] =
@@ -49,8 +49,8 @@ public class KvSnapshotLeaseMetadataJsonSerdeTest
     protected String[] expectedJsons() {
         return new String[] {
             "{\"version\":1,\"expiration_time\":1735538268,\"tables\":"
-                    + "[{\"table_id\":1,\"lease_metadata_path\":\"/path/to/metadata1\"},"
-                    + "{\"table_id\":2,\"lease_metadata_path\":\"/path/to/metadata2\"}]}",
+                    + "[{\"table_id\":1,\"lease_metadata_path\":\"oss://path/to/metadata1\"},"
+                    + "{\"table_id\":2,\"lease_metadata_path\":\"s3://path/to/metadata2\"}]}",
             "{\"version\":1,\"expiration_time\":1735538268,\"tables\":[]}"
         };
     }


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->

`KvSnapshotLeaseMetadataJsonSerde` serialize kv snapshot path use `toString()` instead of `getPath()`. This can avoid the path cannot find when download file.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
