### PR TITLE
docs: update local cluster warning

### DIFF
--- a/website/docs/install-deploy/deploying-local-cluster.md
+++ b/website/docs/install-deploy/deploying-local-cluster.md
@@ -7,7 +7,7 @@ sidebar_position: 2
 :::warning
 **This setup deploys Fluss to a single machine only.**
 
-By default, the Fluss endpoint is **accessible only locally** (e.g., via `localhost`). To allow external access to your local cluster, configure an externally reachable hostname or IP address in the `bind.listeners` field of `server.yaml`. When this is set, all services—including TabletServers—will bind to that address, making their ports accessible from remote clients.
+By default, the local cluster endpoint is **accessible only locally** (e.g., via `localhost`). To allow external access to your local cluster, configure an externally reachable hostname or IP address of this machine in the `bind.listeners` field of `server.yaml`. When this is set, all services—including TabletServers—will bind to that address, making their ports accessible from remote clients.
 
 If you require full control over network exposure or plan to deploy Fluss across multiple machines, refer to the [Deploying Distributed Cluster](install-deploy/deploying-distributed-cluster.md) guide. That guide explains how to deploy each `CoordinatorServer` and `TabletServer` with explicitly configured, externally accessible hostnames and ports.
 :::


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2534

<!-- What is the purpose of the change -->

### Brief change log

- Updated the warning note in the "Deploying Local Cluster" documentation.
- Clarified the default local-only access behavior.
- Documented how configuring `bind.listeners` enables external access.
- Added guidance directing users to the Distributed Cluster documentation for multi-machine deployments.

### Tests

No. documentation-only change.

### API and Format

No. this change does not affect any API or storage format.

### Documentation

Yes. this change updates existing documentation to align with current behavior.
