### PR TITLE
[docs] Add documentation for complex type mapping

### DIFF
--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -203,6 +203,9 @@ Fluss's integration for Flink automatically converts between Flink and Fluss typ
 | TIMESTAMP     | TIMESTAMP     |
 | TIMESTAMP_LTZ | TIMESTAMP_LTZ |
 | BYTES         | BYTES         |
+| ARRAY         | ARRAY         |
+| MAP           | MAP           |
+| ROW           | ROW           |
 
 ### Apache Flink -> Fluss
 
@@ -222,11 +225,11 @@ Fluss's integration for Flink automatically converts between Flink and Fluss typ
 | TIMESTAMP     | TIMESTAMP                                     |
 | TIMESTAMP_LTZ | TIMESTAMP_LTZ                                 |
 | BYTES         | BYTES                                         |
+| ARRAY         | ARRAY                                         |
+| MAP           | MAP                                           |
+| ROW           | ROW                                           |
 | VARCHAR       | Not supported, suggest to use STRING instead. |
 | VARBINARY     | Not supported, suggest to use BYTES instead.  |
 | INTERVAL      | Not supported                                 |
-| ARRAY         | Not supported                                 |
-| MAP           | Not supported                                 |
 | MULTISET      | Not supported                                 |
-| ROW           | Not supported                                 |
 | RAW           | Not supported                                 |


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2483

<!-- What is the purpose of the change -->
This PR adds documentation for the newly supported complex data types (ARRAY, MAP, and ROW) in the Flink-Fluss integration. These types are now fully supported but were not reflected in the documentation.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
- Updated the type conversion tables in `website/docs/engine-flink/getting-started.md`
- Added ARRAY, MAP, and ROW to the `Fluss -> Apache Flink` type mapping table
- Moved ARRAY, MAP, and ROW from "Not supported" to supported status in the `Apache Flink -> Fluss` type mapping table
- These types are now listed alongside other supported types instead of in the unsupported section

### Tests

<!-- List UT and IT cases to verify this change -->
- No tests required as this is a documentation-only change
- Verified that the markdown table formatting is correct
- Confirmed the changes align with the actual implementation support

### API and Format

<!-- Does this change affect API or storage format -->
No. This is a documentation-only change and does not affect any API or storage format.

### Documentation

<!-- Does this change introduce a new feature -->
Yes. This change documents existing features (ARRAY, MAP, and ROW type support) that were previously undocumented in the Flink integration guide.
