### PR TITLE
[client] Clear VectorSchemaRoot to release buffer as soon as possible after a batch read finished.

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatch.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatch.java
@@ -187,9 +187,13 @@ public interface LogRecordBatch {
          * <p>The schema root is used to read the Arrow records in the batch, if this is a {@link
          * LogFormat#ARROW} record batch.
          *
-         * <p>Note: DO NOT close the vector schema root because it is shared across multiple
-         * batches. Use {@link VectorSchemaRoot#slice(int)} to cache the root and close it after
-         * use.
+         * <p><b>Lifecycle:</b> DO NOT close the returned {@link VectorSchemaRoot} because it is
+         * shared across multiple batches. Each new batch load replaces the old buffers inside the
+         * same root. To avoid temporary buffer duplication (old and new buffers coexisting during
+         * the load), callers should call {@link VectorSchemaRoot#clear()} after finishing each
+         * batch to release old buffers immediately before the next batch is loaded. If you need to
+         * retain the data beyond the current batch, use {@link VectorSchemaRoot#slice(int)} to
+         * create an independent copy and close it after use.
          *
          * @param schemaId The schema id of the record batch.
          * @return The (maybe projected) schema root of the record batch.


### PR DESCRIPTION


<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2726 

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
