### PR TITLE
[test][kv] ensure ordered inserts for auto-increment ID tests

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/sink/FlinkTableSinkITCase.java
@@ -1688,9 +1688,9 @@ abstract class FlinkTableSinkITCase extends AbstractTestBase {
                                 + ") with ('auto-increment.fields'='auto_increment_id')",
                         tableName));
 
-        // Insert initial data one by one to ensure auto increment ID ordering.
-        // Auto increment IDs are assigned server-side in arrival order, so concurrent
-        // multi-value INSERTs may receive IDs out of SQL statement order.
+        // Insert rows one by one to preserve auto-increment ID ordering.
+        // Partial-column INSERT ... VALUES is rewritten into a UNION ALL of Value Sources
+        // by Flink, whose runtime does not guarantee UNION ALL input ordering.
         List<Tuple2<Integer, Integer>> inserts =
                 Arrays.asList(
                         Tuple2.of(1, 100), Tuple2.of(2, 200), Tuple2.of(3, 150), Tuple2.of(4, 250));
@@ -1784,9 +1784,9 @@ abstract class FlinkTableSinkITCase extends AbstractTestBase {
                                 + ") with ('table.changelog.image' = 'wal', 'auto-increment.fields'='auto_increment_id')",
                         tableName));
 
-        // Insert initial data one by one to ensure auto increment ID ordering.
-        // Auto increment IDs are assigned server-side in arrival order, so concurrent
-        // multi-value INSERTs may receive IDs out of SQL statement order.
+        // Insert rows one by one to preserve auto-increment ID ordering.
+        // Partial-column INSERT ... VALUES is rewritten into a UNION ALL of Value Sources
+        // by Flink, whose runtime does not guarantee UNION ALL input ordering.
         List<Tuple2<Integer, Integer>> inserts =
                 Arrays.asList(
                         Tuple2.of(1, 100), Tuple2.of(2, 200), Tuple2.of(3, 150), Tuple2.of(4, 250));


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Fix flaky tests testAutoIncrementWithTargetColumns and testWalModeWithAutoIncrement where multi-value INSERT statements caused non-deterministic auto-increment ID assignment, leading to test failures.
```
java.lang.AssertionError: 
[Expected 6 records in exact order but got 6 after waiting. Query: SELECT _change_type, id, auto_increment_id, amount FROM wal_mode_pk_table$changelog /*+ OPTIONS('scan.startup.mode' = 'earliest') */, Actual results: [+I[insert, 2, 1, 200], +I[insert, 3, 2, 150], +I[insert, 4, 3, 250], +I[insert, 1, 4, 100], +I[update_after, 1, 4, 120], +I[update_after, 3, 2, 180]]] 
Expecting actual:
  ["+I[insert, 2, 1, 200]",
    "+I[insert, 3, 2, 150]",
    "+I[insert, 4, 3, 250]",
    "+I[insert, 1, 4, 100]",
    "+I[update_after, 1, 4, 120]",
    "+I[update_after, 3, 2, 180]"]
to contain exactly (and in same order):
  ["+I[insert, 1, 1, 100]",
    "+I[insert, 2, 2, 200]",
    "+I[insert, 3, 3, 150]",
    "+I[insert, 4, 4, 250]",
    "+I[update_after, 1, 1, 120]",
    "+I[update_after, 3, 3, 180]"]
but some elements were not found:
  ["+I[insert, 1, 1, 100]",
    "+I[insert, 2, 2, 200]",
    "+I[insert, 3, 3, 150]",
    "+I[insert, 4, 4, 250]",
    "+I[update_after, 1, 1, 120]",
    "+I[update_after, 3, 3, 180]"]
and others were not expected:
  ["+I[insert, 2, 1, 200]",
    "+I[insert, 3, 2, 150]",
    "+I[insert, 4, 3, 250]",
    "+I[insert, 1, 4, 100]",
    "+I[update_after, 1, 4, 120]",
    "+I[update_after, 3, 2, 180]"]

	at org.apache.fluss.flink.source.testutils.FlinkRowAssertionsUtils.assertQueryResultExactOrder(FlinkRowAssertionsUtils.java:87)
	at org.apache.fluss.flink.sink.FlinkTableSinkITCase.testWalModeWithAutoIncrement(FlinkTableSinkITCase.java:1815)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:82)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
