### PR TITLE
[docs] Update configuration.md by removing Kafka section

### DIFF
--- a/website/docs/maintenance/configuration.md
+++ b/website/docs/maintenance/configuration.md
@@ -188,16 +188,3 @@ More metrics example could be found in [Observability - Metric Reporters](observ
 | Option          | Type | Default | Description                                                                                                                                                                                                                 |
 |-----------------|------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | datalake.format | Enum | (None)  | The datalake format used by of Fluss to be as lakehouse storage. Currently, supported formats are Paimon, Iceberg, and Lance. In the future, more kinds of data lake format will be supported, such as DeltaLake or Hudi.   |
-
-## Kafka
-
-:::warning
-Kafka protocol compatibility is still in development.
-:::
-
-| Option                         | Type     | Default | Description                                                                                                        |
-|--------------------------------|----------|---------|--------------------------------------------------------------------------------------------------------------------|
-| kafka.enabled                  | Boolean  | false   | Whether enable Fluss Kafka. Disabled by default. When this option is set to true, the Fluss Kafka will be enabled. |
-| kafka.listener.names           | String   | KAFKA   | The listener names for Kafka wire protocol communication. Support multiple listener names, separated by comma.     |
-| kafka.database                 | String   | kafka   | The database for Fluss Kafka. The default database is `kafka`.                                                     |
-| kafka.connection.max-idle-time | Duration | 60s     | Close kafka idle connections after the given time specified by this config.                                        |


### PR DESCRIPTION

### Purpose


Linked issue: close #XXX

Remove outdated Kafka-related documentation and warnings about compatibility. Kafka integration is no longer supported or maintained in this version of Fluss, and these references cause confusion for users.



### Brief change log


- Removed Kafka compatibility warning section from main documentation

### Tests

- No functional changes; documentation-only update


### API and Format

No API or format changes. Documentation update only.

### Documentation


No new features. This is a documentation cleanup to remove outdated references.