### PR TITLE
[rpc] Fixed the issue about ServerConnection retry authentication tasks were not canceled

### DIFF
--- a/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
+++ b/fluss-rpc/src/main/java/org/apache/fluss/rpc/netty/client/ServerConnection.java
@@ -59,6 +59,7 @@ import java.nio.channels.ClosedChannelException;
 import java.util.ArrayDeque;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 
@@ -100,6 +101,9 @@ final class ServerConnection {
 
     @GuardedBy("lock")
     private int retryAuthCount = 0;
+
+    @GuardedBy("lock")
+    private ScheduledFuture<?> authRetryTask = null;
 
     ServerConnection(
             Bootstrap bootstrap,
@@ -182,6 +186,12 @@ final class ServerConnection {
             if (channel != null) {
                 // Close the channel directly, without waiting for the channel to close properly.
                 channel.close();
+            }
+
+            // Cancel any pending authentication retry task
+            if (authRetryTask != null) {
+                authRetryTask.cancel(false);
+                authRetryTask = null;
             }
 
             // TODO all return completeExceptionally will let some test cases blocked, so we
@@ -452,11 +462,16 @@ final class ServerConnection {
             if (cause != null) {
                 if (cause instanceof RetriableAuthenticationException) {
                     LOG.warn("Authentication failed, retrying {} times", retryAuthCount, cause);
-                    channel.eventLoop()
-                            .schedule(
-                                    this::sendInitialToken,
-                                    backoff.backoff(retryAuthCount++),
-                                    TimeUnit.MILLISECONDS);
+                    // Cancel any existing auth retry task before scheduling a new one
+                    if (authRetryTask != null) {
+                        authRetryTask.cancel(false);
+                    }
+                    authRetryTask =
+                            channel.eventLoop()
+                                    .schedule(
+                                            this::sendInitialToken,
+                                            backoff.backoff(retryAuthCount++),
+                                            TimeUnit.MILLISECONDS);
                 } else {
                     close(cause);
                 }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Issue: Scheduled tasks are created using ```channel.eventLoop().schedule()``` for authentication retries, but these tasks are not canceled when the connection is closed.

Impact: Scheduled tasks continue to execute even when the connection is closed, which is unreasonable.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
