### PR TITLE
[flink][test] Fix OOM when startTaskManager in FlinkMetricsITCase

### DIFF
--- a/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
+++ b/fluss-flink/fluss-flink-common/src/test/java/org/apache/fluss/flink/metrics/FlinkMetricsITCase.java
@@ -81,7 +81,7 @@ abstract class FlinkMetricsITCase {
                     new MiniClusterResourceConfiguration.Builder()
                             .setNumberTaskManagers(1)
                             .setNumberSlotsPerTaskManager(DEFAULT_PARALLELISM)
-                            .setConfiguration(reporter.addToConfiguration(new Configuration()))
+                            .setConfiguration(reporter.addToConfiguration(buildTestConfig()))
                             .build());
 
     private static final String CATALOG_NAME = "testcatalog";
@@ -93,6 +93,21 @@ abstract class FlinkMetricsITCase {
 
     private TableEnvironment tEnv;
 
+    /**
+     * Builds a minimal Flink {@link Configuration} for use in tests.
+     *
+     * <p>The network buffer pool size is intentionally reduced from the default 64MB to 32MB to
+     * lower JVM direct memory pressure when multiple IT cases run sequentially in the same JVM
+     * fork. The default size is not needed for these tests, which do not exercise high-throughput
+     * network paths.
+     */
+    private static Configuration buildTestConfig() {
+        Configuration config = new Configuration();
+        config.setString("taskmanager.memory.network.min", "32mb");
+        config.setString("taskmanager.memory.network.max", "32mb");
+        return config;
+    }
+
     @BeforeAll
     protected static void beforeAll() {
         clientConf = FLUSS_CLUSTER_EXTENSION.getClientConfig();
@@ -102,6 +117,11 @@ abstract class FlinkMetricsITCase {
         try {
             MINI_CLUSTER_EXTENSION.before();
         } catch (Exception e) {
+            // JUnit 5 does not invoke @AfterAll when @BeforeAll throws, so we must explicitly
+            // call after() here to release any direct memory that was partially allocated by
+            // the NetworkBufferPool before the failure. Leaving it unreleased would exhaust
+            // JVM direct memory for subsequent test classes in the same JVM fork.
+            MINI_CLUSTER_EXTENSION.after();
             throw new FlussRuntimeException("Fail to init Flink mini cluster", e);
         }
     }
@@ -129,17 +149,22 @@ abstract class FlinkMetricsITCase {
 
     @AfterAll
     static void afterAll() throws Exception {
-        if (admin != null) {
-            admin.close();
-            admin = null;
+        // Use try/finally to guarantee MINI_CLUSTER_EXTENSION.after() is always called,
+        // even if admin or conn cleanup throws. An unreleased MiniCluster holds JVM direct
+        // memory (NetworkBufferPool) that would cause OOM errors in subsequent test classes
+        // running in the same JVM fork.
+        try {
+            if (admin != null) {
+                admin.close();
+                admin = null;
+            }
+            if (conn != null) {
+                conn.close();
+                conn = null;
+            }
+        } finally {
+            MINI_CLUSTER_EXTENSION.after();
         }
-
-        if (conn != null) {
-            conn.close();
-            conn = null;
-        }
-
-        MINI_CLUSTER_EXTENSION.after();
     }
 
     protected long createTable(TablePath tablePath, TableDescriptor tableDescriptor)


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2744

<!-- What is the purpose of the change -->
Fixes an OutOfMemoryError: Could not allocate enough memory segments for NetworkBufferPool that occurred when TaskManagerRunner.startTaskManager was called in FlinkMetricsITCase (and its Flink-version subclasses Flink119MetricsITCase, Flink120MetricsITCase, etc.) during sequential IT case execution in the same JVM fork.

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
The root cause is that MiniClusterWithClientResource allocates JVM direct memory via NetworkBufferPool during before(), and this memory was not reliably released between test classes, exhausting the JVM direct memory budget for subsequent classes.
Three changes were made to FlinkMetricsITCase:

beforeAll: Wrap MINI_CLUSTER_EXTENSION.before() in a try/catch that explicitly calls MINI_CLUSTER_EXTENSION.after() on failure. JUnit 5 does not invoke @AfterAll when @BeforeAll throws, so without this, any direct memory partially allocated before the failure would never be freed.
afterAll: Wrap resource cleanup in a try/finally block so that MINI_CLUSTER_EXTENSION.after() is always called even if admin.close() or conn.close() throws.
buildTestConfig: Reduce the NetworkBufferPool size from the default 64MB to 32MB via taskmanager.memory.network.min/max. These tests do not exercise high-throughput network paths, so the smaller size is sufficient and reduces direct memory pressure when multiple IT cases run in the same JVM fork.

### Tests

<!-- List UT and IT cases to verify this change -->
Flink118MetricsITCase — passes
Flink119MetricsITCase — passes
Flink120MetricsITCase — passes
Flink22MetricsITCase — passes
Full fluss-flink-1.20 module (mvn verify -pl fluss-flink/fluss-flink-1.20 -am) — BUILD SUCCESS (225 IT tests, 0 failures), confirming no regressions introduced by this change
### API and Format

<!-- Does this change affect API or storage format -->
No API or storage format changes
### Documentation

<!-- Does this change introduce a new feature -->
No new feature introduced. No documentation changes required.