### PR TITLE
Fix Unstable test FlussAuthorizationITCase.testDeleteProducerOffsetsAuthorization

### DIFF
--- a/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
+++ b/fluss-client/src/test/java/org/apache/fluss/client/security/acl/FlussAuthorizationITCase.java
@@ -150,6 +150,8 @@ public class FlussAuthorizationITCase {
                         DATA1_TABLE_PATH_PK.getDatabaseName(), DatabaseDescriptor.EMPTY, true)
                 .get();
         rootAdmin.createTable(DATA1_TABLE_PATH_PK, DATA1_TABLE_DESCRIPTOR_PK, true).get();
+        TableInfo setupTableInfo = rootAdmin.getTableInfo(DATA1_TABLE_PATH_PK).get();
+        FLUSS_CLUSTER_EXTENSION.waitUntilTableReady(setupTableInfo.getTableId());
     }
 
     @AfterEach


### PR DESCRIPTION
### Purpose
Linked issue: close #2854 
Fixing the unstable test FlussAuthorizationITCase.testDeleteProducerOffsetsAuthorization

### Brief change log

waitUntilTableReady polls until all bucket replicas for the table are online. Since replica assignment happens after putTablePath in CoordinatorEventProcessor.processCreateTable, by the time waitUntilTableReady returns, the coordinator's tablePathById map is guaranteed to contain the mapping. The @BeforeEach now blocks until the coordinator is fully ready before any test method runs.

### Tests

FlussAuthorizationITCase.testDeleteProducerOffsetsAuthorization should be fixed and it  should pass