### PR TITLE
[Lake/Iceberg] Fix testLogTableCompaction flakiness by adding compaction timeout and retry logic

### DIFF
--- a/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeWriter.java
+++ b/fluss-lake/fluss-lake-iceberg/src/main/java/org/apache/fluss/lake/iceberg/tiering/IcebergLakeWriter.java
@@ -48,6 +48,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import static org.apache.fluss.lake.iceberg.utils.IcebergConversions.toIceberg;
 
@@ -59,6 +60,10 @@ public class IcebergLakeWriter implements LakeWriter<IcebergWriteResult> {
     private final Catalog icebergCatalog;
     private final Table icebergTable;
     private final RecordWriter recordWriter;
+
+    // Timeout for waiting on the async compaction future during complete().
+    // Prevents complete() from blocking indefinitely when compaction is slow.
+    private static final long COMPACTION_TIMEOUT_SECONDS = 300L;
 
     @Nullable private final ExecutorService compactionExecutor;
     @Nullable private CompletableFuture<RewriteDataFileResult> compactionFuture;
@@ -114,7 +119,17 @@ public class IcebergLakeWriter implements LakeWriter<IcebergWriteResult> {
 
             RewriteDataFileResult rewriteDataFileResult = null;
             if (compactionFuture != null) {
-                rewriteDataFileResult = compactionFuture.get();
+                try {
+                    rewriteDataFileResult =
+                            compactionFuture.get(COMPACTION_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+                } catch (TimeoutException e) {
+                    LOG.warn(
+                            "Compaction timed out after {} seconds for table {}. "
+                                    + "Skipping compaction result for this write.",
+                            COMPACTION_TIMEOUT_SECONDS,
+                            icebergTable.name());
+                    compactionFuture.cancel(true);
+                }
             }
             return new IcebergWriteResult(writeResult, rewriteDataFileResult);
         } catch (Exception e) {

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteITCase.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/maintenance/IcebergRewriteITCase.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.data.Record;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -187,13 +188,20 @@ class IcebergRewriteITCase extends FlinkIcebergTieringTestBase {
             checkFileStatusInIcebergTable(t1, 3, false);
 
             // Write should trigger compaction now since the current data file count is greater or
-            // equal MIN_FILES_TO_COMPACT
+            // equal MIN_FILES_TO_COMPACT. Use a longer timeout because complete() blocks until
+            // compaction finishes.
             flussRows.addAll(
                     writeIcebergTableRecords(
-                            t1, t1Bucket, ++i, true, Collections.singletonList(row(1, "v1"))));
-            // Should only have two files now, one file it for newly written, one file is for target
-            // compacted file
-            checkFileStatusInIcebergTable(t1, 2, false);
+                            t1,
+                            t1Bucket,
+                            ++i,
+                            true,
+                            Collections.singletonList(row(1, "v1")),
+                            Duration.ofMinutes(2)));
+            // Should only have two files now, one file for newly written, one file for target
+            // compacted file. Use retry since compaction commit is part of the same pipeline
+            // round and may not be immediately visible.
+            waitForFileStatusInIcebergTable(t1, 2, false);
 
             // check data in iceberg to make sure compaction won't lose data or duplicate data
             checkRecords(getIcebergRecords(t1), flussRows);
@@ -211,6 +219,19 @@ class IcebergRewriteITCase extends FlinkIcebergTieringTestBase {
             throws Exception {
         writeRows(tablePath, rows, append);
         assertReplicaStatus(tableBucket, expectedLogEndOffset);
+        return rows;
+    }
+
+    private List<InternalRow> writeIcebergTableRecords(
+            TablePath tablePath,
+            TableBucket tableBucket,
+            long expectedLogEndOffset,
+            boolean append,
+            List<InternalRow> rows,
+            Duration assertTimeout)
+            throws Exception {
+        writeRows(tablePath, rows, append);
+        assertReplicaStatus(tableBucket, expectedLogEndOffset, assertTimeout);
         return rows;
     }
 }

--- a/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/testutils/FlinkIcebergTieringTestBase.java
+++ b/fluss-lake/fluss-lake-iceberg/src/test/java/org/apache/fluss/lake/iceberg/testutils/FlinkIcebergTieringTestBase.java
@@ -257,6 +257,33 @@ public class FlinkIcebergTieringTestBase {
                 });
     }
 
+    protected void assertReplicaStatus(
+            TableBucket tb, long expectedLogEndOffset, Duration timeout) {
+        retry(
+                timeout,
+                () -> {
+                    Replica replica = getLeaderReplica(tb);
+                    // datalake snapshot id should be updated
+                    assertThat(replica.getLogTablet().getLakeTableSnapshotId())
+                            .isGreaterThanOrEqualTo(0);
+                    assertThat(replica.getLakeLogEndOffset()).isEqualTo(expectedLogEndOffset);
+                });
+    }
+
+    protected void waitForFileStatusInIcebergTable(
+            TablePath tablePath, int expectedFileCount, boolean shouldDeleteFileExist) {
+        retry(
+                Duration.ofMinutes(2),
+                () -> {
+                    try {
+                        checkFileStatusInIcebergTable(
+                                tablePath, expectedFileCount, shouldDeleteFileExist);
+                    } catch (IOException e) {
+                        throw new AssertionError("Failed to check file status in Iceberg table", e);
+                    }
+                });
+    }
+
     /**
      * Wait until the default number of partitions is created. Return the map from partition id to
      * partition name.


### PR DESCRIPTION
Linked issue: close #2867

The testLogTableCompaction test in IcebergRewriteITCase was flaky due to two root causes:

1. Indefinite blocking: IcebergLakeWriter.complete() called compactionFuture.get() without a timeout, which could block indefinitely if the async compaction was slow or stuck.
2. Tight assertions: After triggering a write+compaction, the test immediately called checkFileStatusInIcebergTable() without any retry, causing it to fail if the compaction commit had not yet been applied.

### Brief change log

- IcebergLakeWriter: Added a 5-minute timeout (COMPACTION_TIMEOUT_SECONDS = 300) to compactionFuture.get(). On timeout, logs a warning and cancels the future rather than hanging indefinitely.
- IcebergRewriteITCase: Updated testLogTableCompaction to use a 2-minute assertReplicaStatus timeout (via a new overload) when waiting for the write+compaction round to complete, and switched to waitForFileStatusInIcebergTable() which retries the file-count assertion.
- FlinkIcebergTieringTestBase: Added two helper methods:
  - assertReplicaStatus(TableBucket, long, Duration) — timeout-aware overload of the existing method.
  - waitForFileStatusInIcebergTable(TablePath, int, boolean) — wraps checkFileStatusInIcebergTable in a 2-minute retry loop.

### Tests

- IcebergRewriteITCase#testLogTableCompaction — the flaky test itself; now uses retry-based assertions and a longer timeout to tolerate compaction latency.

### API and Format

No API or storage format changes.

### Documentation

No new features introduced; this is a stability fix. The Helm docs change is cosmetic table reformatting only.