### PR TITLE
[helm][hotfix] Go template whitespace trimming caused exceptions

### DIFF
--- a/helm/templates/secret-jaas-config.yaml
+++ b/helm/templates/secret-jaas-config.yaml
@@ -1,8 +1,3 @@
-{{- if (include "fluss.security.sasl.plain.enabled" .) }}
-{{- $internalMechanism := include "fluss.security.listener.mechanism" (dict "context" .Values "listener" "internal") -}}
-{{- $clientMechanism := include "fluss.security.listener.mechanism" (dict "context" .Values "listener" "client") -}}
-{{- $internalUsername := include "fluss.security.sasl.plain.internal.username" . -}}
-{{- $internalPassword := include "fluss.security.sasl.plain.internal.password" . -}}
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -21,6 +16,11 @@
 # limitations under the License.
 #
 
+{{ if (include "fluss.security.sasl.plain.enabled" .) }}
+{{- $internalMechanism := include "fluss.security.listener.mechanism" (dict "context" .Values "listener" "internal") -}}
+{{- $clientMechanism := include "fluss.security.listener.mechanism" (dict "context" .Values "listener" "client") -}}
+{{- $internalUsername := include "fluss.security.sasl.plain.internal.username" . -}}
+{{- $internalPassword := include "fluss.security.sasl.plain.internal.password" . -}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.serviceAccount.create }}
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file
@@ -17,6 +16,7 @@
 # limitations under the License.
 #
 
+{{ if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close NA

In `secret-jaas-config.yaml`, the variable assignments between the license comment block and `apiVersion` use Go templating whitespace trimming `({{- ... -}})` approach. 

Since assignments produce no output, they consume all surrounding whitespaces, including the newline after the last `#` comment line. This glues `#` and `apiVersion: v1` into `#apiVersion: v1`, which YAML parses as a comment. 

The resulting document has no `apiVersion` field, causing Helm to reject it with "apiVersion not set."

The same issue also affects `serviceaccount.yaml`, where the license block sits outside the `{{- if .Values.serviceAccount.create }}` guard, producing a comment-only YAML document when disabled.

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

Move the variable assignments before the license block so the comment to apiVersion gap is no longer merged by trimming directives.

### Tests

<!-- List UT and IT cases to verify this change -->
Existing tests pass

### API and Format

<!-- Does this change affect API or storage format -->
NA

### Documentation

<!-- Does this change introduce a new feature -->
NA