### PR TITLE
[IT][fix]ServerITCaseBase fails when stderr contains "Picked up JAVA_TOOL_OPTIONS" 

### DIFF
--- a/fluss-server/src/test/java/org/apache/fluss/server/ServerITCaseBase.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/ServerITCaseBase.java
@@ -115,11 +115,11 @@ public abstract class ServerITCaseBase {
         CommonTestUtils.waitUntil(
                 () ->
                         process.getProcessOutput().toString().contains(SERVER_STARTED_MARKER)
-                                || !process.getErrorOutput().toString().isEmpty(),
+                                || !process.getProcess().isAlive(),
                 Duration.ofMinutes(2),
                 null);
-        String errorMsg = process.getErrorOutput().toString();
-        if (!errorMsg.isEmpty()) {
+        if (!process.getProcess().isAlive()) {
+            String errorMsg = process.getErrorOutput().toString();
             throw new IllegalStateException("Server process failed to start: " + errorMsg);
         }
     }


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2631

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Changed ServerITCaseBase.java so server ITs fail only when the spawned process exits, not when stderr is merely non-empty. This prevents false failures from the JVM’s Picked up JAVA_TOOL_OPTIONS banner in Jenkins/Java 17.


### Tests

<!-- List UT and IT cases to verify this change -->
Existing  IT is enough. 
### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
