### PR TITLE
[hotfix] Fix flaky TableChangeWatcherTest by awaiting CuratorCache init

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcher.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcher.java
@@ -48,6 +48,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /** A watcher to watch the table changes(create/delete) in zookeeper. */
 public class TableChangeWatcher {
@@ -59,6 +61,7 @@ public class TableChangeWatcher {
 
     private final EventManager eventManager;
     private final ZooKeeperClient zooKeeperClient;
+    private final CountDownLatch initializedLatch = new CountDownLatch(1);
 
     public TableChangeWatcher(ZooKeeperClient zooKeeperClient, EventManager eventManager) {
         this.zooKeeperClient = zooKeeperClient;
@@ -73,6 +76,15 @@ public class TableChangeWatcher {
         curatorCache.start();
     }
 
+    /**
+     * Waits until the CuratorCache has completed its initial sync with ZooKeeper. This should be
+     * called after {@link #start()} to ensure the cache is fully warmed up before relying on change
+     * events.
+     */
+    public boolean awaitInitialized(long timeout, TimeUnit unit) throws InterruptedException {
+        return initializedLatch.await(timeout, unit);
+    }
+
     public void stop() {
         if (!running) {
             return;
@@ -84,6 +96,12 @@ public class TableChangeWatcher {
 
     /** A listener to monitor the changes of table nodes in zookeeper. */
     private final class TablePathChangeListener implements CuratorCacheListener {
+
+        @Override
+        public void initialized() {
+            LOG.info("CuratorCache initial sync completed for TableChangeWatcher.");
+            initializedLatch.countDown();
+        }
 
         @Override
         public void event(Type type, ChildData oldData, ChildData newData) {

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/event/watcher/TableChangeWatcherTest.java
@@ -99,7 +99,7 @@ class TableChangeWatcherTest {
     }
 
     @BeforeEach
-    void before() {
+    void before() throws Exception {
         // Clean up ZK state from previous tests to prevent CuratorCache initial sync
         // from picking up leftover data
         try {
@@ -111,6 +111,15 @@ class TableChangeWatcherTest {
         eventManager = new TestingEventManager();
         tableChangeWatcher = new TableChangeWatcher(zookeeperClient, eventManager);
         tableChangeWatcher.start();
+        // Wait for CuratorCache to complete its initial sync before creating tables.
+        // Without this, the cache may fire NODE_CHANGED events from the initial tree
+        // scan that race with table creation, causing processCreateTable() to read
+        // stale or incomplete ZK state.
+        assertThat(tableChangeWatcher.awaitInitialized(30, java.util.concurrent.TimeUnit.SECONDS))
+                .as("CuratorCache should complete initial sync within timeout")
+                .isTrue();
+        // Clear any events generated during initial sync (e.g., from leftover ZK nodes)
+        eventManager.clearEvents();
     }
 
     @AfterEach


### PR DESCRIPTION
TableChangeWatcherTest.testSchemaChanges intermittently fails because tables are created before CuratorCache completes its initial sync. During initial sync, NODE_CHANGED events from the tree scan can race with table creation, causing processCreateTable() to observe incomplete ZK state and silently drop the CreateTableEvent.

Add awaitInitialized() to TableChangeWatcher using CuratorCacheListener .initialized() callback, and wait for it in beforeEach before creating tables. Clear any stale events from initial sync afterward.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2935 2935

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
