### PR TITLE
[hotfix] Check if batches is empty to prevent readNextOffset from thr…

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogSegment.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogSegment.java
@@ -411,6 +411,9 @@ public final class LogSegment {
             return baseOffset;
         } else {
             Iterable<LogRecordBatch> batches = fetchData.getRecords().batches();
+            if (Iterables.isEmpty(batches)) {
+                return baseOffset;
+            }
             LogRecordBatch lastBatch = Iterables.getLast(batches);
             if (lastBatch != null) {
                 return lastBatch.nextLogOffset();


### PR DESCRIPTION
…owing NoSuchElementException.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: [Fix NoSuchElementException that occurs when recovering log segments](https://github.com/apache/fluss/issues/2943)

<!-- What is the purpose of the change -->
Fix NoSuchElementException that occurs when recovering log segments

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Use Iterables.isEmpty to check if batches is empty in the readNextOffset function. If batches is empty, directly return the baseOffset.

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->
No

### Documentation

<!-- Does this change introduce a new feature -->
No
