### PR TITLE
[flink] Skip LogSplit for empty buckets in lake union read

### DIFF
--- a/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeSplitGenerator.java
+++ b/fluss-flink/fluss-flink-common/src/main/java/org/apache/fluss/flink/lake/LakeSplitGenerator.java
@@ -235,10 +235,15 @@ public class LakeSplitGenerator {
                 Long snapshotLogOffset = tableBucketSnapshotLogOffset.get(tableBucket);
                 Long stoppingOffset = bucketEndOffset.get(bucket);
                 if (snapshotLogOffset == null) {
-                    // no any data commit to this bucket, scan from fluss log
-                    splits.add(
-                            new LogSplit(
-                                    tableBucket, partitionName, EARLIEST_OFFSET, stoppingOffset));
+                    // no data committed to lake for this bucket, scan from fluss log
+                    if (stoppingOffset == NO_STOPPING_OFFSET || stoppingOffset > 0) {
+                        splits.add(
+                                new LogSplit(
+                                        tableBucket,
+                                        partitionName,
+                                        EARLIEST_OFFSET,
+                                        stoppingOffset));
+                    }
                 } else {
                     // need to read remain fluss log
                     if (stoppingOffset == NO_STOPPING_OFFSET


### PR DESCRIPTION
closes #2957 

Skip creating LogSplit for empty buckets where no data was committed to either lake or log (stoppingOffset is 0). 

The reader would otherwise block for the full poll timeout per empty bucket and return nothing. Matches the existing guard in the non-null snapshot offset branch.    