### PR TITLE
[Server] Fix PeriodicSnapshotManager.start() silently disables snapshot

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManager.java
@@ -165,14 +165,13 @@ public class PeriodicSnapshotManager implements Closeable {
     }
 
     public void start() {
-        // disable periodic snapshot when periodicMaterializeDelay is not positive
-        if (!started && initialDelay > 0) {
+        if (!started && snapshotIntervalSupplier.getAsLong() > 0) {
 
             started = true;
 
             LOG.info("TableBucket {} starts periodic snapshot", tableBucket);
 
-            scheduleNextSnapshot(initialDelay);
+            scheduleNextSnapshot(Math.max(initialDelay, 1));
         }
     }
 

--- a/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/kv/snapshot/PeriodicSnapshotManagerTest.java
@@ -128,6 +128,22 @@ class PeriodicSnapshotManagerTest {
     }
 
     @Test
+    void testStartWhenInitialDelayIsZero() {
+        // When periodicSnapshotDelay = 1, murmurHash(...) % 1 == 0 always,
+        // so initialDelay = 0. With a positive snapshot interval, start()
+        // should still schedule snapshots — but the current "initialDelay > 0"
+        // guard silently skips scheduling.
+        periodicSnapshotManager = createSnapshotManager(1L, NopSnapshotTarget.INSTANCE);
+        periodicSnapshotManager.start();
+
+        // A positive interval means snapshots should be scheduled.
+        // With the bug, this assertion fails: no task is scheduled.
+        assertThat(scheduledExecutorService.getAllScheduledTasks())
+                .as("snapshot should be scheduled even when initialDelay is 0")
+                .hasSize(1);
+    }
+
+    @Test
     void testDynamicSnapshotInterval() {
         long initialInterval = 10_000L;
         long updatedInterval = 5_000L;


### PR DESCRIPTION

When murmurHash(tableBucket.hashCode()) % snapshotInterval == 0, initialDelay is 0. The original guard `initialDelay > 0` incorrectly treats this as "snapshot disabled", causing the affected TableBucket to never take snapshots.

Fix: check `snapshotIntervalSupplier.getAsLong() > 0` to determine whether snapshot is enabled, and use `Math.max(initialDelay, 1)` to avoid zero delay.

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.


**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2977 2977

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
