### PR TITLE
[spark][bugfix] Use pk index for comparator align with SortMergeReader

### DIFF
--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/read/FlussUpsertPartitionReader.scala
@@ -27,6 +27,7 @@ import org.apache.fluss.record.LogRecord
 import org.apache.fluss.row.{encode, InternalRow, KeyValueRow}
 import org.apache.fluss.spark.SparkFlussConf
 import org.apache.fluss.spark.utils.LogChangesIterator
+import org.apache.fluss.types.{DataField, RowType}
 import org.apache.fluss.utils.CloseableIterator
 
 import org.apache.spark.internal.Logging
@@ -65,13 +66,12 @@ class FlussUpsertPartitionReader(
     extraProjections ++= projection
     pkIndexes.foreach {
       pkIndex =>
-        projection.find(p => p == pkIndex) match {
-          case Some(index) =>
-            _pkProjection += index
-          case _ =>
+        projection.indexOf(pkIndex) match {
+          case -1 =>
             extraProjections += pkIndex
             _pkProjection += projection.length + i
             i += 1
+          case idx => _pkProjection += idx
         }
     }
     (extraProjections.toArray, _pkProjection.toArray)
@@ -99,9 +99,13 @@ class FlussUpsertPartitionReader(
 
   private def createSortMergeReader(): SortMergeReader = {
     // Create key encoder for primary keys
+    val pkIndexes = tableInfo.getSchema.getPrimaryKeyIndexes
+    val pkFields = new java.util.ArrayList[DataField]()
+    pkIndexes.foreach(i => pkFields.add(rowType.getFields.get(i)))
+    val pkRowType = new RowType(pkFields)
     val keyEncoder =
       encode.KeyEncoder.ofPrimaryKeyEncoder(
-        rowType,
+        pkRowType,
         tableInfo.getPhysicalPrimaryKeys,
         tableInfo.getTableConfig,
         tableInfo.isDefaultBucketKey)

--- a/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/utils/LogChangesIterator.scala
+++ b/fluss-spark/fluss-spark-common/src/main/scala/org/apache/fluss/spark/utils/LogChangesIterator.scala
@@ -48,10 +48,15 @@ case class LogChangesIterator(
     comparator: Comparator[InternalRow]
 ) extends CloseableIterator[KeyValueRow] {
 
+  private val projectRow1 = ProjectedRow.from(pkProjection)
+  private val projectRow2 = ProjectedRow.from(pkProjection)
+
   // Sort the records by primary key and then by offset
   private val sortedLogRecords = logRecords.sortWith {
     case (record1, record2) =>
-      val keyComparison = comparator.compare(record1.getRow, record2.getRow)
+      val keyComparison = comparator.compare(
+        projectRow1.replaceRow(record1.getRow),
+        projectRow2.replaceRow(record2.getRow))
       if (keyComparison == 0) {
         record1.logOffset() < record2.logOffset() // For same key, lower offset comes first
       } else {
@@ -62,9 +67,6 @@ case class LogChangesIterator(
   private var recordsIterator = SingleElementHeadIterator.addElementToHead(
     sortedLogRecords.head,
     CloseableIterator.wrap(sortedLogRecords.tail.toIterator.asJava))
-
-  private val projectRow1 = ProjectedRow.from(pkProjection)
-  private val projectRow2 = ProjectedRow.from(pkProjection)
 
   private var currentScanRecord: ScanRecord = _
 

--- a/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
+++ b/fluss-spark/fluss-spark-ut/src/test/scala/org/apache/fluss/spark/SparkPrimaryKeyTableReadTest.scala
@@ -242,6 +242,19 @@ class SparkPrimaryKeyTableReadTest extends FlussSparkTestBase {
     }
   }
 
+  test("Spark Read: primary key table with random project") {
+    withTable("t") {
+      sql(
+        "CREATE TABLE t (id int, name string, pk int, pk2 string) TBLPROPERTIES('primary.key'='pk,pk2')")
+      checkAnswer(sql("SELECT * FROM t"), Nil)
+      sql("INSERT INTO t VALUES (1, 'a', 10, 'x'), (2, 'b', 20, 'y')")
+      checkAnswer(
+        sql("SELECT * FROM t ORDER BY id"),
+        Row(1, "a", 10, "x") :: Row(2, "b", 20, "y") :: Nil)
+      checkAnswer(sql("SELECT pk, id FROM t ORDER BY id"), Row(10, 1) :: Row(20, 2) :: Nil)
+    }
+  }
+
   private def genInputPartition(
       tablePath: TablePath,
       partitionName: String): Array[FlussUpsertInputPartition] = {


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->


### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #2986

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->
`Spark Read: primary key table with random project`

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
