### PR TITLE
[filesystem] Support AssumeRole STS for RustFS

### DIFF
--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -82,34 +82,41 @@ public class S3DelegationTokenProvider {
 
     public ObtainedSecurityToken obtainSecurityToken() {
         AWSSecurityTokenService stsClient = buildStsClient();
-        Credentials credentials;
+        try {
+            Credentials credentials;
 
-        if (roleArn != null) {
+            if (roleArn != null) {
+                LOG.info(
+                        "Obtaining session credentials via AssumeRole with access key: {}, role: {}",
+                        accessKey,
+                        roleArn);
+                AssumeRoleRequest request =
+                        new AssumeRoleRequest()
+                                .withRoleArn(roleArn)
+                                .withRoleSessionName("fluss-" + UUID.randomUUID());
+                AssumeRoleResult result = stsClient.assumeRole(request);
+                credentials = result.getCredentials();
+            } else {
+                LOG.info(
+                        "Obtaining session credentials via GetSessionToken with access key: {}",
+                        accessKey);
+                GetSessionTokenResult result = stsClient.getSessionToken();
+                credentials = result.getCredentials();
+            }
+
             LOG.info(
-                    "Obtaining session credentials via AssumeRole with access key: {}, role: {}",
-                    accessKey,
-                    roleArn);
-            AssumeRoleRequest request =
-                    new AssumeRoleRequest()
-                            .withRoleArn(roleArn)
-                            .withRoleSessionName("fluss-" + UUID.randomUUID());
-            AssumeRoleResult result = stsClient.assumeRole(request);
-            credentials = result.getCredentials();
-        } else {
-            LOG.info(
-                    "Obtaining session credentials via GetSessionToken with access key: {}",
-                    accessKey);
-            GetSessionTokenResult result = stsClient.getSessionToken();
-            credentials = result.getCredentials();
+                    "Session credentials obtained successfully with access key: {} expiration: {}",
+                    credentials.getAccessKeyId(),
+                    credentials.getExpiration());
+
+            return new ObtainedSecurityToken(
+                    scheme,
+                    toJson(credentials),
+                    credentials.getExpiration().getTime(),
+                    additionInfos);
+        } finally {
+            stsClient.shutdown();
         }
-
-        LOG.info(
-                "Session credentials obtained successfully with access key: {} expiration: {}",
-                credentials.getAccessKeyId(),
-                credentials.getExpiration());
-
-        return new ObtainedSecurityToken(
-                scheme, toJson(credentials), credentials.getExpiration().getTime(), additionInfos);
     }
 
     private AWSSecurityTokenService buildStsClient() {


### PR DESCRIPTION
## Summary

closes #2661

Fix verified end-to-end against RustFS following https://github.com/apache/fluss/pull/2569
for tiering setup you may consult this: https://github.com/lakekeeper/lakekeeper/pull/1688 in order to make it work with iceberg and lakekeeper

  Before fix:
```
  SecurityTokenException: Failed to get file access security token: Region is not set.
  -> NoAwsCredentialsException: Dynamic session credentials for Fluss: No AWS Credentials
  ->  Flink job FAILED
```

  After fix:
```
  S3DelegationTokenProvider - Obtaining session credentials via AssumeRole with access key: rustfsadmin, role: arn:xxx:xxx:xxx:xxxx
  S3DelegationTokenProvider - Session credentials obtained successfully with access key: I4MVXCHH4OV01YLLA9MC
  S3DelegationTokenReceiver - Session credentials updated successfully
  -> Flink job RUNNING
```

  Config required for RustFS users:
```
  s3.region: us-east-1
  s3.assumed.role.arn: arn:xxx:xxx:xxx:xxxx
  s3.assumed.role.sts.endpoint: http://rustfs:9000
```

  Backward compatibility:

  - Without s3.assumed.role.arn, falls back to GetSessionToken (existing AWS behavior)
  - Zero breaking changes for existing users
