### PR TITLE
[server] Handle corrupt log data after unclean shutdown to prevent TabletServer startup failure

### DIFF
--- a/fluss-server/src/main/java/org/apache/fluss/server/exception/CorruptLogException.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/exception/CorruptLogException.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.server.exception;
+
+import org.apache.fluss.annotation.Internal;
+
+/**
+ * Exception thrown when the log data is corrupt and cannot be recovered. This typically happens
+ * after an unclean shutdown when the log file contains incomplete or invalid data.
+ *
+ * @since 0.10
+ */
+@Internal
+public class CorruptLogException extends RuntimeException {
+    public CorruptLogException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogLoader.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogLoader.java
@@ -24,6 +24,7 @@ import org.apache.fluss.exception.LogSegmentOffsetOverflowException;
 import org.apache.fluss.exception.LogStorageException;
 import org.apache.fluss.metadata.LogFormat;
 import org.apache.fluss.server.exception.CorruptIndexException;
+import org.apache.fluss.server.exception.CorruptLogException;
 import org.apache.fluss.utils.FlussPaths;
 import org.apache.fluss.utils.types.Tuple2;
 
@@ -84,6 +85,20 @@ final class LogLoader {
      * @return the offsets of the Log successfully loaded from disk
      */
     public LoadedLogOffsets load() throws IOException {
+        try {
+            return doLoad();
+        } catch (CorruptLogException e) {
+            throw e;
+        } catch (IOException
+                | CorruptIndexException
+                | LogSegmentOffsetOverflowException
+                | InvalidOffsetException e) {
+            throw new CorruptLogException(
+                    "Failed to load log from " + logTabletDir.getAbsolutePath(), e);
+        }
+    }
+
+    private LoadedLogOffsets doLoad() throws IOException {
         // load all the log and index files.
         logSegments.close();
         logSegments.clear();

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogManager.java
@@ -29,6 +29,7 @@ import org.apache.fluss.metadata.TableBucket;
 import org.apache.fluss.metadata.TableInfo;
 import org.apache.fluss.metadata.TablePath;
 import org.apache.fluss.server.TabletManagerBase;
+import org.apache.fluss.server.exception.CorruptLogException;
 import org.apache.fluss.server.log.checkpoint.OffsetCheckpointFile;
 import org.apache.fluss.server.metrics.group.TabletServerMetricGroup;
 import org.apache.fluss.server.zk.ZooKeeperClient;
@@ -492,33 +493,41 @@ public final class LogManager extends TabletManagerBase {
                                 "schema not exist, table for {} has already been dropped, the residual data will be removed.",
                                 tabletDir,
                                 e);
-                        FileUtils.deleteDirectoryQuietly(tabletDir);
-
-                        // Also delete corresponding KV tablet directory if it exists
-                        try {
-                            Tuple2<PhysicalTablePath, TableBucket> pathAndBucket =
-                                    FlussPaths.parseTabletDir(tabletDir);
-                            File kvTabletDir =
-                                    FlussPaths.kvTabletDir(
-                                            dataDir, pathAndBucket.f0, pathAndBucket.f1);
-                            if (kvTabletDir.exists()) {
-                                LOG.info(
-                                        "Also removing corresponding KV tablet directory: {}",
-                                        kvTabletDir);
-                                FileUtils.deleteDirectoryQuietly(kvTabletDir);
-                            }
-                        } catch (Exception kvDeleteException) {
-                            LOG.warn(
-                                    "Failed to delete corresponding KV tablet directory for log {}: {}",
-                                    tabletDir,
-                                    kvDeleteException.getMessage());
-                        }
+                        deleteTabletAndKvDir(tabletDir);
+                        return;
+                    }
+                    if (e instanceof CorruptLogException) {
+                        LOG.error(
+                                "Corrupt log data detected for {}. "
+                                        + "Removing corrupted local data to allow re-replication from leader.",
+                                tabletDir,
+                                e);
+                        deleteTabletAndKvDir(tabletDir);
                         return;
                     }
                     throw new FlussRuntimeException(e);
                 }
             }
         };
+    }
+
+    /** Delete the tablet directory and corresponding KV tablet directory if it exists. */
+    private void deleteTabletAndKvDir(File tabletDir) {
+        FileUtils.deleteDirectoryQuietly(tabletDir);
+        try {
+            Tuple2<PhysicalTablePath, TableBucket> pathAndBucket =
+                    FlussPaths.parseTabletDir(tabletDir);
+            File kvTabletDir = FlussPaths.kvTabletDir(dataDir, pathAndBucket.f0, pathAndBucket.f1);
+            if (kvTabletDir.exists()) {
+                LOG.info("Also removing corresponding KV tablet directory: {}", kvTabletDir);
+                FileUtils.deleteDirectoryQuietly(kvTabletDir);
+            }
+        } catch (Exception e) {
+            LOG.warn(
+                    "Failed to delete corresponding KV tablet directory for log {}: {}",
+                    tabletDir,
+                    e.getMessage());
+        }
     }
 
     @VisibleForTesting

--- a/fluss-server/src/main/java/org/apache/fluss/server/log/LogSegment.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/log/LogSegment.java
@@ -45,6 +45,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
+import java.util.Iterator;
 import java.util.Optional;
 
 import static org.apache.fluss.record.LogRecordBatchFormat.V0_RECORD_BATCH_HEADER_SIZE;
@@ -409,15 +410,14 @@ public final class LogSegment {
                         false);
         if (fetchData == null) {
             return baseOffset;
-        } else {
-            Iterable<LogRecordBatch> batches = fetchData.getRecords().batches();
-            LogRecordBatch lastBatch = Iterables.getLast(batches);
-            if (lastBatch != null) {
-                return lastBatch.nextLogOffset();
-            } else {
-                return baseOffset;
-            }
         }
+        Iterable<LogRecordBatch> batches = fetchData.getRecords().batches();
+        Iterator<LogRecordBatch> iterator = batches.iterator();
+        if (!iterator.hasNext()) {
+            return baseOffset;
+        }
+        LogRecordBatch lastBatch = Iterables.getLast(batches);
+        return lastBatch.nextLogOffset();
     }
 
     /** Flush this log segment to disk. */

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogLoaderTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogLoaderTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.Files;
@@ -625,6 +626,37 @@ final class LogLoaderTest extends LogTestBase {
                                 .map(snapshotFile -> snapshotFile.offset)
                                 .sorted())
                 .containsExactly(1L, 2L, 4L);
+    }
+
+    @Test
+    void testLoadTruncatesCorruptedLogFileOnRecovery() throws Exception {
+        // Write some valid records, then corrupt the log file to simulate unclean shutdown.
+        // LogLoader recovery should truncate the corrupted segment gracefully.
+        LogTablet logTablet = createLogTablet(true);
+        appendRecords(logTablet, 10);
+        long endOffsetBeforeCorruption = logTablet.localLogEndOffset();
+        assertThat(endOffsetBeforeCorruption).isEqualTo(10);
+        List<LogSegment> segments = logTablet.logSegments();
+        File logFile = segments.get(0).getFileLogRecords().file();
+        logTablet.close();
+
+        // Corrupt the log file by writing garbage and truncating
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.seek(12);
+            raf.write(new byte[] {0x7F, 0x7F, 0x7F, 0x7F});
+            raf.setLength(20);
+        }
+
+        // Delete index files to force recovery which will hit the corrupted data
+        for (LogSegment segment : segments) {
+            segment.offsetIndex().deleteIfExists();
+        }
+
+        // Reopen with recovery (unclean shutdown) — recovery should truncate
+        // the corrupted segment rather than throwing an exception
+        LogTablet recovered = createLogTablet(false);
+        assertThat(recovered.localLogEndOffset()).isLessThan(endOffsetBeforeCorruption);
+        recovered.close();
     }
 
     private LogTablet createLogTablet(boolean isCleanShutdown) throws Exception {

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogSegmentTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogSegmentTest.java
@@ -36,6 +36,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.stream.Stream;
@@ -298,6 +301,49 @@ final class LogSegmentTest extends LogTestBase {
                                 new Object[] {2, "there"},
                                 new Object[] {2, "you"})));
         assertThat(segment.readNextOffset()).isEqualTo(53);
+    }
+
+    @Test
+    void testReadNextOffsetWithIncompleteTrailingBatch() throws Exception {
+        // After unclean shutdown, the log file may contain only a batch header
+        // without record data. readNextOffset() should handle this gracefully
+        // by returning baseOffset instead of crashing.
+        //
+        // We write a 48-byte fake batch header (V0_RECORD_BATCH_HEADER_SIZE) in
+        // little-endian format (Fluss record format uses LE). The length field is
+        // set to 36 so that LOG_OVERHEAD(12) + length(36) = 48 = file size.
+        // This makes:
+        // 1. searchForOffsetWithSize() find the batch (header is parseable)
+        // 2. read() see adjustedMaxSize(=48) <= V0_RECORD_BATCH_HEADER_SIZE(48),
+        //    returning MemoryLogRecords.EMPTY
+        // 3. readNextOffset() detects empty batches and returns baseOffset
+        LogSegment segment = createSegment(0);
+        File logFile = segment.getFileLogRecords().file();
+        segment.close();
+
+        // Write a 48-byte fake batch header in little-endian byte order.
+        ByteBuffer buf = ByteBuffer.allocate(48);
+        buf.order(ByteOrder.LITTLE_ENDIAN);
+        buf.putLong(0L); // baseOffset = 0
+        buf.putInt(36); // length = 36 (so sizeInBytes = 12 + 36 = 48)
+        buf.put((byte) 0); // magic = 0
+        // Fill remaining 35 bytes with zeros.
+        buf.put(new byte[35]);
+        buf.flip();
+        try (RandomAccessFile raf = new RandomAccessFile(logFile, "rw")) {
+            raf.getChannel().write(buf);
+            raf.setLength(48);
+        }
+        assertThat(logFile.length()).isEqualTo(48);
+
+        // Reopen the segment with the corrupted file.
+        LogSegment reopened = createSegment(0, true, 0);
+
+        // After fix: readNextOffset() should return baseOffset (0) instead of
+        // throwing NoSuchElementException.
+        assertThat(reopened.readNextOffset()).isEqualTo(0);
+
+        reopened.close();
     }
 
     @Test


### PR DESCRIPTION
When a TabletServer shuts down uncleanly, log files may contain incomplete batch headers. This caused readNextOffset() to throw NoSuchElementException via Iterables.getLast() on empty batches, crashing the server on restart.

- Add CorruptLogException for unrecoverable log corruption
- Fix LogSegment.readNextOffset() to check iterator.hasNext() before getLast()
- Wrap LogLoader.load() to convert unexpected errors to CorruptLogException
- Catch CorruptLogException in LogManager to delete corrupted local data and allow re-replication from leader
- Extract deleteTabletAndKvDir() to reduce duplication

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

**(The sections below can be removed for hotfixes or typos)**
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3009 3009

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
