### PR TITLE
[docs] Fix broken anchors

### DIFF
--- a/website/docs/engine-flink/getting-started.md
+++ b/website/docs/engine-flink/getting-started.md
@@ -35,7 +35,7 @@ For Flink's Table API, Fluss supports the following features:
 | [SQL Show Partitions](ddl.md#show-partitions)                   | ✔️    |                                          |
 | [SQL Add Partition](ddl.md#add-partition)                       | ✔️    |                                          |
 | [SQL Drop Partition](ddl.md#drop-partition)                     | ✔️    |                                          |
-| [Procedures](ddl.md#procedures)                                 | ✔️    | ACL management and cluster configuration |
+| [Procedures](procedures.md)                                     | ✔️    | ACL management and cluster configuration |
 | [SQL Select](reads.md)                                          | ✔️    | Support both streaming and batch mode.   |
 | [SQL Limit](reads.md#limit-read)                                | ✔️    | Only for Log Table                       |
 | [SQL Insert Into](writes.md)                                    | ✔️    | Support both streaming and batch mode.   |

--- a/website/src/pages/downloads.md
+++ b/website/src/pages/downloads.md
@@ -69,7 +69,7 @@ Read the [release blog](/blog/releases/0.8/) about the new features and signific
 - [Fluss 0.7.0 Binary Release](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-bin.tgz) ([asc](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-bin.tgz.asc), [sha512](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-bin.tgz.sha512))
 - [Fluss 0.7.0 Source Release](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-src.tgz) ([asc](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-src.tgz.asc), [sha512](https://github.com/apache/fluss/releases/download/v0.7.0/fluss-0.7.0-src.tgz.sha512))
 
-#### Flink Connector
+#### Flink Connector {#fluss-connector}
 | Flink Version | Download Link                                                                                                                    | Signature & Checksum |
 |---------------|----------------------------------------------------------------------------------------------------------------------------------|----------------------|
 | Flink 1.20 | [fluss-flink-1.20-0.7.0.jar](https://repo1.maven.org/maven2/com/alibaba/fluss/fluss-flink-1.20/0.7.0/fluss-flink-1.20-0.7.0.jar) | [asc](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-1.20/0.7.0/fluss-flink-1.20-0.7.0.jar.asc), [sha](https://repo1.maven.org/maven2/org/apache/fluss/fluss-flink-1.20/0.7.0/fluss-flink-1.20-0.7.0.jar.sha1) |


### PR DESCRIPTION
Found a couple of broken links while reviewing the docs. The procedures reference in getting-started.md points to a non-existent anchor, and the Flink Connector heading in downloads.md is missing its anchor tag.

### Purpose
Closes #3038

### Brief change log
Fixed the procedures link in getting-started.md to point to procedures.md. Added the anchor tag to the Flink Connector heading in downloads.md.

### Tests
N/A

### API and Format
N/A

### Documentation
Fixed broken documentation links.