### PR TITLE
[common] Optimize getNullCounts() to return int[] instead of Long[]

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/predicate/And.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/And.java
@@ -51,7 +51,7 @@ public class And extends CompoundPredicate.Function {
             long rowCount,
             InternalRow minValues,
             InternalRow maxValues,
-            Long[] nullCounts,
+            int[] nullCounts,
             List<Predicate> children) {
         for (Predicate child : children) {
             if (!child.test(rowCount, minValues, maxValues, nullCounts)) {

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/CompoundPredicate.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/CompoundPredicate.java
@@ -58,7 +58,7 @@ public class CompoundPredicate implements Predicate {
 
     @Override
     public boolean test(
-            long rowCount, InternalRow minValues, InternalRow maxValues, Long[] nullCounts) {
+            long rowCount, InternalRow minValues, InternalRow maxValues, int[] nullCounts) {
         return function.test(rowCount, minValues, maxValues, nullCounts, children);
     }
 
@@ -102,7 +102,7 @@ public class CompoundPredicate implements Predicate {
                 long rowCount,
                 InternalRow minValues,
                 InternalRow maxValues,
-                Long[] nullCounts,
+                int[] nullCounts,
                 List<Predicate> children);
 
         public abstract Optional<Predicate> negate(List<Predicate> children);

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/Contains.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/Contains.java
@@ -47,7 +47,7 @@ public class Contains extends NullFalseLeafBinaryFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             Object patternLiteral) {
         return true;
     }

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/EndsWith.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/EndsWith.java
@@ -51,7 +51,7 @@ public class EndsWith extends NullFalseLeafBinaryFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             Object patternLiteral) {
         return true;
     }

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/Equal.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/Equal.java
@@ -44,7 +44,7 @@ public class Equal extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         return compareLiteral(type, literal, min) >= 0 && compareLiteral(type, literal, max) <= 0;
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/GreaterOrEqual.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/GreaterOrEqual.java
@@ -44,7 +44,7 @@ public class GreaterOrEqual extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         return compareLiteral(type, literal, max) <= 0;
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/GreaterThan.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/GreaterThan.java
@@ -44,7 +44,7 @@ public class GreaterThan extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         return compareLiteral(type, literal, max) < 0;
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/In.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/In.java
@@ -56,9 +56,9 @@ public class In extends LeafFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             List<Object> literals) {
-        if (nullCount != null && rowCount == nullCount) {
+        if (nullCount >= 0 && rowCount == nullCount) {
             return false;
         }
         for (Object literal : literals) {

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/IsNotNull.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/IsNotNull.java
@@ -41,8 +41,8 @@ public class IsNotNull extends LeafUnaryFunction {
     }
 
     @Override
-    public boolean test(DataType type, long rowCount, Object min, Object max, Long nullCount) {
-        return nullCount == null || nullCount < rowCount;
+    public boolean test(DataType type, long rowCount, Object min, Object max, long nullCount) {
+        return nullCount < 0 || nullCount < rowCount;
     }
 
     @Override

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/IsNull.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/IsNull.java
@@ -41,8 +41,8 @@ public class IsNull extends LeafUnaryFunction {
     }
 
     @Override
-    public boolean test(DataType type, long rowCount, Object min, Object max, Long nullCount) {
-        return nullCount == null || nullCount > 0;
+    public boolean test(DataType type, long rowCount, Object min, Object max, long nullCount) {
+        return nullCount < 0 || nullCount > 0;
     }
 
     @Override

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/LeafFunction.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/LeafFunction.java
@@ -49,7 +49,7 @@ public abstract class LeafFunction implements Serializable {
      * @param rowCount the total number of rows
      * @param min the minimum value of the field in the rows
      * @param max the maximum value of the field in the rows
-     * @param nullCount the number of null values in the field, or null if unknown
+     * @param nullCount the number of null values in the field, or -1 if unknown
      * @param literals the literals to test against the field
      * @return true if there is any row satisfies the condition, false otherwise
      */
@@ -58,7 +58,7 @@ public abstract class LeafFunction implements Serializable {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             List<Object> literals);
 
     public abstract Optional<LeafFunction> negate();

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/LeafPredicate.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/LeafPredicate.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.predicate;
 
+import org.apache.fluss.record.LogRecordBatchStatistics;
 import org.apache.fluss.row.InternalRow;
 import org.apache.fluss.types.DataType;
 import org.apache.fluss.types.DecimalType;
@@ -87,11 +88,14 @@ public class LeafPredicate implements Predicate {
 
     @Override
     public boolean test(
-            long rowCount, InternalRow minValues, InternalRow maxValues, Long[] nullCounts) {
+            long rowCount, InternalRow minValues, InternalRow maxValues, int[] nullCounts) {
         Object min = get(minValues, fieldIndex, type);
         Object max = get(maxValues, fieldIndex, type);
-        Long nullCount = nullCounts != null ? nullCounts[fieldIndex] : null;
-        if (nullCount == null || rowCount != nullCount) {
+        long nullCount =
+                nullCounts != null
+                        ? nullCounts[fieldIndex]
+                        : LogRecordBatchStatistics.NULL_COUNT_UNAVAILABLE;
+        if (nullCount < 0 || rowCount != nullCount) {
             // not all null
             // min or max is null
             // unknown stats

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/LeafUnaryFunction.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/LeafUnaryFunction.java
@@ -33,7 +33,7 @@ public abstract class LeafUnaryFunction extends LeafFunction {
     public abstract boolean test(DataType type, Object value);
 
     public abstract boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount);
+            DataType type, long rowCount, Object min, Object max, long nullCount);
 
     @Override
     public boolean test(DataType type, Object value, List<Object> literals) {
@@ -46,7 +46,7 @@ public abstract class LeafUnaryFunction extends LeafFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             List<Object> literals) {
         return test(type, rowCount, min, max, nullCount);
     }

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/LessOrEqual.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/LessOrEqual.java
@@ -44,7 +44,7 @@ public class LessOrEqual extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         return compareLiteral(type, literal, min) >= 0;
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/LessThan.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/LessThan.java
@@ -44,7 +44,7 @@ public class LessThan extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         return compareLiteral(type, literal, min) > 0;
     }
 

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/NotEqual.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/NotEqual.java
@@ -44,7 +44,7 @@ public class NotEqual extends NullFalseLeafBinaryFunction {
 
     @Override
     public boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal) {
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal) {
         // ony when max == min == literal, the result is false,
         // otherwise, the row set MAY contain the literal.
         return compareLiteral(type, literal, min) != 0 || compareLiteral(type, literal, max) != 0;

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/NotIn.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/NotIn.java
@@ -55,9 +55,9 @@ public class NotIn extends LeafFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             List<Object> literals) {
-        if (nullCount != null && rowCount == nullCount) {
+        if (nullCount >= 0 && rowCount == nullCount) {
             return false;
         }
         for (Object literal : literals) {

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/NullFalseLeafBinaryFunction.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/NullFalseLeafBinaryFunction.java
@@ -33,7 +33,7 @@ public abstract class NullFalseLeafBinaryFunction extends LeafFunction {
     public abstract boolean test(DataType type, Object field, Object literal);
 
     public abstract boolean test(
-            DataType type, long rowCount, Object min, Object max, Long nullCount, Object literal);
+            DataType type, long rowCount, Object min, Object max, long nullCount, Object literal);
 
     @Override
     public boolean test(DataType type, Object field, List<Object> literals) {
@@ -49,9 +49,9 @@ public abstract class NullFalseLeafBinaryFunction extends LeafFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             List<Object> literals) {
-        if (nullCount != null) {
+        if (nullCount >= 0) {
             if (rowCount == nullCount || literals.get(0) == null) {
                 return false;
             }

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/Or.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/Or.java
@@ -51,7 +51,7 @@ public class Or extends CompoundPredicate.Function {
             long rowCount,
             InternalRow minValues,
             InternalRow maxValues,
-            Long[] nullCounts,
+            int[] nullCounts,
             List<Predicate> children) {
         for (Predicate child : children) {
             if (child.test(rowCount, minValues, maxValues, nullCounts)) {

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/Predicate.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/Predicate.java
@@ -45,7 +45,7 @@ public interface Predicate extends Serializable {
      * @return return true is likely to hit (there may also be false positives), return false is
      *     absolutely not possible to hit.
      */
-    boolean test(long rowCount, InternalRow minValues, InternalRow maxValues, Long[] nullCounts);
+    boolean test(long rowCount, InternalRow minValues, InternalRow maxValues, int[] nullCounts);
 
     /**
      * @return the negation predicate of this predicate if possible.

--- a/fluss-common/src/main/java/org/apache/fluss/predicate/StartsWith.java
+++ b/fluss-common/src/main/java/org/apache/fluss/predicate/StartsWith.java
@@ -51,7 +51,7 @@ public class StartsWith extends NullFalseLeafBinaryFunction {
             long rowCount,
             Object min,
             Object max,
-            Long nullCount,
+            long nullCount,
             Object patternLiteral) {
         String minStr = min.toString();
         String maxStr = max.toString();

--- a/fluss-common/src/main/java/org/apache/fluss/record/DefaultLogRecordBatchStatistics.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/DefaultLogRecordBatchStatistics.java
@@ -70,7 +70,7 @@ public class DefaultLogRecordBatchStatistics implements LogRecordBatchStatistics
 
     private final int[] statsIndexMapping;
 
-    private final Long[] statsNullCounts;
+    private final int[] statsNullCounts;
 
     // Offsets for min/max values in the byte array
     private final int minValuesOffset;
@@ -80,7 +80,7 @@ public class DefaultLogRecordBatchStatistics implements LogRecordBatchStatistics
 
     private InternalRow cachedMinRow;
     private InternalRow cachedMaxRow;
-    private Long[] cachedNullCounts;
+    private int[] cachedNullCounts;
 
     private final int[] reversedStatsIndexMapping;
 
@@ -91,7 +91,7 @@ public class DefaultLogRecordBatchStatistics implements LogRecordBatchStatistics
             int size,
             RowType rowType,
             int schemaId,
-            Long[] nullCounts,
+            int[] nullCounts,
             int minValuesOffset,
             int maxValuesOffset,
             int minValuesSize,
@@ -146,16 +146,15 @@ public class DefaultLogRecordBatchStatistics implements LogRecordBatchStatistics
     }
 
     @Override
-    public Long[] getNullCounts() {
+    public int[] getNullCounts() {
         if (cachedNullCounts != null) {
             return cachedNullCounts;
         }
-        cachedNullCounts = new Long[rowType.getFieldCount()];
+        cachedNullCounts = new int[rowType.getFieldCount()];
+        Arrays.fill(cachedNullCounts, LogRecordBatchStatistics.NULL_COUNT_UNAVAILABLE);
         for (int i = 0; i < rowType.getFieldCount(); i++) {
             if (this.reversedStatsIndexMapping[i] >= 0) {
                 cachedNullCounts[i] = statsNullCounts[reversedStatsIndexMapping[i]];
-            } else {
-                cachedNullCounts[i] = -1L;
             }
         }
         return cachedNullCounts;

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatistics.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatistics.java
@@ -22,6 +22,9 @@ import org.apache.fluss.row.InternalRow;
 /** Statistics information of {@link LogRecordBatch LogRecordBatch}. */
 public interface LogRecordBatchStatistics {
 
+    /** Sentinel value indicating that null count statistics are not available for a field. */
+    int NULL_COUNT_UNAVAILABLE = -1;
+
     /**
      * Get the minimum values as an InternalRow.
      *
@@ -37,11 +40,12 @@ public interface LogRecordBatchStatistics {
     InternalRow getMaxValues();
 
     /**
-     * Get the null counts for each field.
+     * Get the null counts for each field. Uses {@code -1} to indicate that null count statistics
+     * are not available for a particular field.
      *
-     * @return Array of null counts
+     * @return Array of null counts, where -1 means not available
      */
-    Long[] getNullCounts();
+    int[] getNullCounts();
 
     /**
      * Whether the statistics information for a specific field is available.

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsCollector.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsCollector.java
@@ -47,7 +47,7 @@ public class LogRecordBatchStatisticsCollector {
     // Statistics arrays (only for columns that need statistics)
     private final Object[] minValues;
     private final Object[] maxValues;
-    private final Long[] nullCounts;
+    private final int[] nullCounts;
 
     private final LogRecordBatchStatisticsWriter statisticsWriter;
 
@@ -58,11 +58,11 @@ public class LogRecordBatchStatisticsCollector {
         // Initialize statistics arrays
         this.minValues = new Object[statsIndexMapping.length];
         this.maxValues = new Object[statsIndexMapping.length];
-        this.nullCounts = new Long[statsIndexMapping.length];
+        this.nullCounts = new int[statsIndexMapping.length];
 
         this.statisticsWriter = new LogRecordBatchStatisticsWriter(rowType, statsIndexMapping);
 
-        Arrays.fill(nullCounts, 0L);
+        Arrays.fill(nullCounts, 0);
     }
 
     /**
@@ -116,7 +116,7 @@ public class LogRecordBatchStatisticsCollector {
 
     /** Reset the collector to collect new statistics. */
     public void reset() {
-        Arrays.fill(nullCounts, 0L);
+        Arrays.fill(nullCounts, 0);
         Arrays.fill(minValues, null);
         Arrays.fill(maxValues, null);
     }

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsParser.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsParser.java
@@ -113,9 +113,9 @@ public class LogRecordBatchStatisticsParser {
 
             // Read null counts at fixed offset
             int nullCountsStart = position + nullCountsOffset(statisticsColumnCount);
-            Long[] nullCounts = new Long[statisticsColumnCount];
+            int[] nullCounts = new int[statisticsColumnCount];
             for (int i = 0; i < statisticsColumnCount; i++) {
-                nullCounts[i] = (long) segment.getInt(nullCountsStart + 4 * i);
+                nullCounts[i] = segment.getInt(nullCountsStart + 4 * i);
             }
 
             // Read min values size at fixed offset

--- a/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsWriter.java
+++ b/fluss-common/src/main/java/org/apache/fluss/record/LogRecordBatchStatisticsWriter.java
@@ -56,7 +56,7 @@ import static org.apache.fluss.record.LogRecordBatchFormat.STATISTICS_VERSION;
  *
  * InternalRow minValues = ...;
  * InternalRow maxValues = ...;
- * Long[] nullCounts = ...;
+ * int[] nullCounts = ...;
  *
  * int bytesWritten = writer.writeStatistics(minValues, maxValues, nullCounts, outputView);
  * </pre>
@@ -114,7 +114,7 @@ public class LogRecordBatchStatisticsWriter {
      * @throws IOException If writing fails
      */
     public int writeStatistics(
-            InternalRow minValues, InternalRow maxValues, Long[] nullCounts, OutputView outputView)
+            InternalRow minValues, InternalRow maxValues, int[] nullCounts, OutputView outputView)
             throws IOException {
 
         int totalBytesWritten = 0;
@@ -134,9 +134,8 @@ public class LogRecordBatchStatisticsWriter {
         }
 
         // Write null counts for statistics columns only (4 bytes per count)
-        for (Long count : nullCounts) {
-            long nullCount = count != null ? count : 0;
-            outputView.writeInt((int) nullCount);
+        for (int count : nullCounts) {
+            outputView.writeInt(count);
             totalBytesWritten += 4;
         }
 

--- a/fluss-common/src/test/java/org/apache/fluss/predicate/PredicateBuilderTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/predicate/PredicateBuilderTest.java
@@ -22,8 +22,6 @@ import org.apache.fluss.types.RowType;
 
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
-
 import java.util.Arrays;
 
 import static org.apache.fluss.testutils.DataTestUtils.row;
@@ -43,11 +41,11 @@ public class PredicateBuilderTest {
         assertThat(predicate.test(row(4))).isEqualTo(false);
         assertThat(predicate.test(row((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 2, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 2, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 2, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 2, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -61,11 +59,11 @@ public class PredicateBuilderTest {
         assertThat(predicate.test(row(4))).isEqualTo(false);
         assertThat(predicate.test(row((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 2, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 2, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 2, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 2, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -97,12 +95,7 @@ public class PredicateBuilderTest {
                                 child3));
     }
 
-    static boolean test(
-            Predicate predicate,
-            long rowCount,
-            @Nullable Object min,
-            @Nullable Object max,
-            @Nullable Long nullCount) {
-        return predicate.test(rowCount, row(min), row(max), new Long[] {nullCount});
+    static boolean test(Predicate predicate, long rowCount, Object min, Object max, int nullCount) {
+        return predicate.test(rowCount, row(min), row(max), new int[] {nullCount});
     }
 }

--- a/fluss-common/src/test/java/org/apache/fluss/predicate/PredicateTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/predicate/PredicateTest.java
@@ -45,10 +45,10 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(5))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 6, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 6, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.notEqual(0, 5));
     }
@@ -58,9 +58,9 @@ public class PredicateTest {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         Predicate predicate = builder.equal(0, null);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
         // null not equal to null
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
@@ -75,11 +75,11 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(5))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 6, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, 5, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 6, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, 5, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.equal(0, 5));
     }
@@ -92,8 +92,8 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -106,11 +106,11 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(6))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 4, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 6, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 4, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 6, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.lessOrEqual(0, 5));
     }
@@ -123,8 +123,8 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 1, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 1, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -137,11 +137,11 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(6))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 4, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 6, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 4, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 6, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.lessThan(0, 5));
     }
@@ -154,8 +154,8 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 1, 0, 4, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 1, 0, 4, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -168,11 +168,11 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(6))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 5, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 4, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, 3, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 5, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 4, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, 3, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterOrEqual(0, 5));
     }
@@ -185,8 +185,8 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 1, 3, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 1, 3, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -199,11 +199,11 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(6))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 5, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 4, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, 3, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 5, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 4, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, 3, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.greaterThan(0, 5));
     }
@@ -216,8 +216,8 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 1, 3, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 1, 3, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -228,10 +228,10 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(true);
 
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 5, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 5, 7, 1L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 5, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 5, 7, 1)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(true);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.isNotNull(0));
     }
@@ -244,10 +244,10 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(4))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 5, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 5, 7, 1L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 5, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 5, 7, 1)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null)).isEqualTo(builder.isNull(0));
     }
@@ -263,9 +263,9 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -279,9 +279,9 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -295,12 +295,12 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 1, 1, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 3, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 1, 3, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 1, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 3, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 3, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -314,12 +314,12 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 1, 1, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 3, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 1, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 1, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 3, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -331,9 +331,9 @@ public class PredicateTest {
 
         GenericRow max = row(fromString("aaba"));
         GenericRow min = row(fromString("aabb"));
-        Long[] nullCounts = {null};
+        int[] nullCounts = {-1};
         assertThat(predicate.test(10, min, max, nullCounts)).isEqualTo(true);
-        assertThat(predicate.test(10, min, max, new Long[] {10L})).isEqualTo(false);
+        assertThat(predicate.test(10, min, max, new int[] {10})).isEqualTo(false);
     }
 
     @Test
@@ -347,11 +347,11 @@ public class PredicateTest {
         GenericRow aaba = row(fromString("aaba"));
         GenericRow bbaa = row(fromString("bbaa"));
         GenericRow ccbb = row(fromString("ccbb"));
-        Long[] nullCounts = {null};
+        int[] nullCounts = {-1};
         assertThat(predicate.test(10, aaab, aaba, nullCounts)).isEqualTo(true);
         assertThat(predicate.test(10, aaba, bbaa, nullCounts)).isEqualTo(true);
         assertThat(predicate.test(10, bbaa, ccbb, nullCounts)).isEqualTo(false);
-        assertThat(predicate.test(10, aaab, aaba, new Long[] {10L})).isEqualTo(false);
+        assertThat(predicate.test(10, aaab, aaba, new int[] {10})).isEqualTo(false);
     }
 
     @Test
@@ -365,9 +365,9 @@ public class PredicateTest {
 
         GenericRow aaab = row(fromString("aaab"));
         GenericRow aaba = row(fromString("aaba"));
-        Long[] nullCounts = {null};
+        int[] nullCounts = {-1};
         assertThat(predicate.test(10, aaab, aaba, nullCounts)).isEqualTo(true);
-        assertThat(predicate.test(10, aaab, aaba, new Long[] {10L})).isEqualTo(false);
+        assertThat(predicate.test(10, aaab, aaba, new int[] {10})).isEqualTo(false);
     }
 
     @Test
@@ -387,10 +387,10 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 29, 32, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 29, 32, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -411,10 +411,10 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 29, 32, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 29, 32, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -434,13 +434,13 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 1, 1, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 3, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 1, 3, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 3, 29, 32, 0L)).isEqualTo(true);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 1, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 3, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 3, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(true);
+        assertThat(test(predicate, 3, 29, 32, 0)).isEqualTo(true);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -461,13 +461,13 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3))).isEqualTo(false);
         assertThat(predicate.test(GenericRow.of((Object) null))).isEqualTo(false);
 
-        assertThat(test(predicate, 3, 1, 1, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 3, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 1, 3, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 0, 5, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 6, 7, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 3, 29, 32, 0L)).isEqualTo(false);
-        assertThat(test(predicate, 1, null, null, 1L)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 1, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 3, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 1, 3, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 0, 5, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 6, 7, 0)).isEqualTo(false);
+        assertThat(test(predicate, 3, 29, 32, 0)).isEqualTo(false);
+        assertThat(test(predicate, 1, null, null, 1)).isEqualTo(false);
     }
 
     @Test
@@ -480,9 +480,9 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3, 5))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of(null, 5))).isEqualTo(false);
 
-        assertThat(predicate.test(3, row(3, 4), row(6, 6), new Long[] {0L, 0L})).isEqualTo(true);
-        assertThat(predicate.test(3, row(3, 6), row(6, 8), new Long[] {0L, 0L})).isEqualTo(false);
-        assertThat(predicate.test(3, row(6, 4), row(7, 6), new Long[] {0L, 0L})).isEqualTo(false);
+        assertThat(predicate.test(3, row(3, 4), row(6, 6), new int[] {0, 0})).isEqualTo(true);
+        assertThat(predicate.test(3, row(3, 6), row(6, 8), new int[] {0, 0})).isEqualTo(false);
+        assertThat(predicate.test(3, row(6, 4), row(7, 6), new int[] {0, 0})).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null))
                 .isEqualTo(PredicateBuilder.or(builder.notEqual(0, 3), builder.notEqual(1, 5)));
@@ -498,9 +498,9 @@ public class PredicateTest {
         assertThat(predicate.test(GenericRow.of(3, 5))).isEqualTo(true);
         assertThat(predicate.test(GenericRow.of(null, 5))).isEqualTo(true);
 
-        assertThat(predicate.test(3, row(3, 4), row(6, 6), new Long[] {0L, 0L})).isEqualTo(true);
-        assertThat(predicate.test(3, row(3, 6), row(6, 8), new Long[] {0L, 0L})).isEqualTo(true);
-        assertThat(predicate.test(3, row(6, 8), row(7, 10), new Long[] {0L, 0L})).isEqualTo(false);
+        assertThat(predicate.test(3, row(3, 4), row(6, 6), new int[] {0, 0})).isEqualTo(true);
+        assertThat(predicate.test(3, row(3, 6), row(6, 8), new int[] {0, 0})).isEqualTo(true);
+        assertThat(predicate.test(3, row(6, 8), row(7, 10), new int[] {0, 0})).isEqualTo(false);
 
         assertThat(predicate.negate().orElse(null))
                 .isEqualTo(PredicateBuilder.and(builder.notEqual(0, 3), builder.notEqual(1, 5)));
@@ -511,8 +511,8 @@ public class PredicateTest {
         PredicateBuilder builder = new PredicateBuilder(RowType.of(new IntType()));
         Predicate predicate = builder.equal(0, 5);
 
-        assertThat(test(predicate, 3, null, null, null)).isEqualTo(true);
-        assertThat(test(predicate, 3, null, null, 3L)).isEqualTo(false);
+        assertThat(test(predicate, 3, null, null, -1)).isEqualTo(true);
+        assertThat(test(predicate, 3, null, null, 3)).isEqualTo(false);
     }
 
     @Test

--- a/fluss-common/src/test/java/org/apache/fluss/predicate/SimpleColStatsTestUtils.java
+++ b/fluss-common/src/test/java/org/apache/fluss/predicate/SimpleColStatsTestUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.fluss.predicate;
 
+import org.apache.fluss.record.LogRecordBatchStatistics;
 import org.apache.fluss.row.GenericRow;
 
 /** Utils for testing with {@link SimpleColStats}. */
@@ -26,11 +27,13 @@ public class SimpleColStatsTestUtils {
     public static boolean test(Predicate predicate, long rowCount, SimpleColStats[] fieldStats) {
         Object[] min = new Object[fieldStats.length];
         Object[] max = new Object[fieldStats.length];
-        Long[] nullCounts = new Long[fieldStats.length];
+        int[] nullCounts = new int[fieldStats.length];
         for (int i = 0; i < fieldStats.length; i++) {
             min[i] = fieldStats[i].min();
             max[i] = fieldStats[i].max();
-            nullCounts[i] = fieldStats[i].nullCount();
+            Long nc = fieldStats[i].nullCount();
+            nullCounts[i] =
+                    nc == null ? LogRecordBatchStatistics.NULL_COUNT_UNAVAILABLE : nc.intValue();
         }
 
         return predicate.test(rowCount, GenericRow.of(min), GenericRow.of(max), nullCounts);

--- a/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsCollectorTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsCollectorTest.java
@@ -95,7 +95,7 @@ public class LogRecordBatchStatisticsCollectorTest {
 
         // All null counts should be 0
         for (int i = 0; i < 6; i++) {
-            assertThat(statistics.getNullCounts()[i]).isEqualTo(0L);
+            assertThat(statistics.getNullCounts()[i]).isEqualTo(0);
         }
     }
 
@@ -160,9 +160,9 @@ public class LogRecordBatchStatisticsCollectorTest {
                 LogRecordBatchStatisticsParser.parseStatistics(segment, 0, nullableRowType, 1);
 
         // Verify null counts
-        assertThat(statistics.getNullCounts()[0]).isEqualTo(1L);
-        assertThat(statistics.getNullCounts()[1]).isEqualTo(1L);
-        assertThat(statistics.getNullCounts()[2]).isEqualTo(1L);
+        assertThat(statistics.getNullCounts()[0]).isEqualTo(1);
+        assertThat(statistics.getNullCounts()[1]).isEqualTo(1);
+        assertThat(statistics.getNullCounts()[2]).isEqualTo(1);
 
         // Verify min/max values exclude nulls
         assertThat(statistics.getMinValues().getInt(0)).isEqualTo(1);
@@ -308,9 +308,9 @@ public class LogRecordBatchStatisticsCollectorTest {
         assertThat(statistics).isNotNull();
 
         // All null counts should be 0
-        Long[] nullCounts = statistics.getNullCounts();
+        int[] nullCounts = statistics.getNullCounts();
         for (int i = 0; i < rowType.getFieldCount(); i++) {
-            assertThat(nullCounts[i]).isEqualTo(0L);
+            assertThat(nullCounts[i]).isEqualTo(0);
         }
 
         // Min/max values row exists but all fields should be null since no rows were processed
@@ -368,8 +368,8 @@ public class LogRecordBatchStatisticsCollectorTest {
         assertThat(maxValues.isNullAt(2)).isTrue();
 
         // Other columns should have correct min/max
-        assertThat(statistics.getNullCounts()[0]).isEqualTo(0L);
-        assertThat(statistics.getNullCounts()[1]).isEqualTo(0L);
+        assertThat(statistics.getNullCounts()[0]).isEqualTo(0);
+        assertThat(statistics.getNullCounts()[1]).isEqualTo(0);
         assertThat(minValues.getInt(0)).isEqualTo(1);
         assertThat(maxValues.getInt(0)).isEqualTo(5);
         assertThat(minValues.getString(1)).isEqualTo(BinaryString.fromString("a"));

--- a/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsParserTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsParserTest.java
@@ -54,7 +54,7 @@ public class LogRecordBatchStatisticsParserTest {
         RowType rowType = DataTypes.ROW(new IntType(false), new StringType(false));
 
         // Create test data
-        Long[] nullCounts = new Long[] {10L, 0L};
+        int[] nullCounts = new int[] {10, 0};
         IndexedRow minValues = createTestIndexedRow(rowType, -100, "aaa");
         IndexedRow maxValues = createTestIndexedRow(rowType, 999, "zzz");
 
@@ -79,7 +79,7 @@ public class LogRecordBatchStatisticsParserTest {
         RowType rowType = DataTypes.ROW(new IntType(false), new StringType(false));
 
         // Create test data
-        Long[] nullCounts = new Long[] {3L, 7L};
+        int[] nullCounts = new int[] {3, 7};
         IndexedRow minValues = createTestIndexedRow(rowType, 0, "first");
         IndexedRow maxValues = createTestIndexedRow(rowType, 500, "last");
 
@@ -106,7 +106,7 @@ public class LogRecordBatchStatisticsParserTest {
         RowType rowType = DataTypes.ROW(new IntType(false), new StringType(false));
 
         // Create test data
-        Long[] nullCounts = new Long[] {1L, 2L};
+        int[] nullCounts = new int[] {1, 2};
         IndexedRow minValues = createTestIndexedRow(rowType, 42, "test");
         IndexedRow maxValues = createTestIndexedRow(rowType, 84, "testing");
 
@@ -132,7 +132,7 @@ public class LogRecordBatchStatisticsParserTest {
         RowType rowType = DataTypes.ROW(new IntType(false), new StringType(false));
 
         // Create valid test statistics
-        Long[] nullCounts = new Long[] {1L, 2L};
+        int[] nullCounts = new int[] {1, 2};
         IndexedRow minValues = createTestIndexedRow(rowType, 1, "min");
         IndexedRow maxValues = createTestIndexedRow(rowType, 100, "max");
 
@@ -165,7 +165,7 @@ public class LogRecordBatchStatisticsParserTest {
         RowType rowType = DataTypes.ROW(new IntType(false), new StringType(false));
 
         // Create test statistics
-        Long[] nullCounts = new Long[] {1L, 2L};
+        int[] nullCounts = new int[] {1, 2};
         IndexedRow minValues = createTestIndexedRow(rowType, 1, "a");
         IndexedRow maxValues = createTestIndexedRow(rowType, 100, "z");
 
@@ -202,7 +202,7 @@ public class LogRecordBatchStatisticsParserTest {
         // Test basic write and parse cycle without detailed verification
         RowType rowType = DataTypes.ROW(new IntType(false));
 
-        Long[] nullCounts = new Long[] {0L};
+        int[] nullCounts = new int[] {0};
         IndexedRow minValues = createTestIndexedRow(rowType, 1);
         IndexedRow maxValues = createTestIndexedRow(rowType, 100);
 
@@ -251,7 +251,7 @@ public class LogRecordBatchStatisticsParserTest {
             LogRecordBatchStatisticsWriter writer,
             InternalRow minValues,
             InternalRow maxValues,
-            Long[] nullCounts)
+            int[] nullCounts)
             throws IOException {
 
         // Allocate enough memory for statistics

--- a/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsTest.java
+++ b/fluss-common/src/test/java/org/apache/fluss/record/LogRecordBatchStatisticsTest.java
@@ -264,7 +264,7 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
     @Test
     void testDefaultLogRecordBatchStatisticsBasicMethods() {
         MemorySegment segment = MemorySegment.allocateHeapMemory(512);
-        Long[] nullCounts = new Long[] {0L, 1L, 2L};
+        int[] nullCounts = new int[] {0, 1, 2};
         int[] statsIndexMapping = new int[] {0, 1, 2};
 
         DefaultLogRecordBatchStatistics stats =
@@ -287,14 +287,14 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
         assertThat(stats.hasMinValues()).isTrue();
         assertThat(stats.hasMaxValues()).isTrue();
         assertThat(stats.hasColumnStatistics(0)).isTrue();
-        assertThat(stats.getNullCounts()[0]).isEqualTo(0L);
-        assertThat(stats.getNullCounts()[1]).isEqualTo(1L);
+        assertThat(stats.getNullCounts()[0]).isEqualTo(0);
+        assertThat(stats.getNullCounts()[1]).isEqualTo(1);
     }
 
     @Test
     void testDefaultLogRecordBatchStatisticsPartialColumns() {
         MemorySegment segment = MemorySegment.allocateHeapMemory(512);
-        Long[] nullCounts = new Long[] {0L, 2L};
+        int[] nullCounts = new int[] {0, 2};
         int[] statsIndexMapping = new int[] {0, 2}; // Skip column 1
 
         DefaultLogRecordBatchStatistics stats =
@@ -319,7 +319,7 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
     @Test
     void testDefaultLogRecordBatchStatisticsNoMinMaxValues() {
         MemorySegment segment = MemorySegment.allocateHeapMemory(512);
-        Long[] nullCounts = new Long[] {0L, 1L, 2L};
+        int[] nullCounts = new int[] {0, 1, 2};
         int[] statsIndexMapping = new int[] {0, 1, 2};
 
         assertThatThrownBy(
@@ -361,7 +361,7 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
     void testDefaultLogRecordBatchStatisticsWithSerializedData() throws IOException {
         InternalRow minRow = DataTestUtils.row(new Object[] {1, "a", 10.5});
         InternalRow maxRow = DataTestUtils.row(new Object[] {100, "z", 99.9});
-        Long[] nullCounts = new Long[] {0L, 2L, 1L};
+        int[] nullCounts = new int[] {0, 2, 1};
         int[] statsIndexMapping = new int[] {0, 1, 2};
 
         LogRecordBatchStatisticsWriter writer =
@@ -391,7 +391,7 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
     void testPartialStatisticsWrapperThrowsForUnavailableColumns() throws IOException {
         InternalRow minRow = DataTestUtils.row(1, 10.5);
         InternalRow maxRow = DataTestUtils.row(100, 99.9);
-        Long[] nullCounts = new Long[] {0L, 1L};
+        int[] nullCounts = new int[] {0, 1};
         int[] statsIndexMapping = new int[] {0, 2}; // Skip column 1
 
         RowType fullRowType =
@@ -424,7 +424,7 @@ public class LogRecordBatchStatisticsTest extends LogTestBase {
     @Test
     void testDefaultLogRecordBatchStatisticsEqualsAndHashCode() {
         MemorySegment segment = MemorySegment.allocateHeapMemory(512);
-        Long[] nullCounts = new Long[] {0L, 1L, 2L};
+        int[] nullCounts = new int[] {0, 1, 2};
         int[] statsIndexMapping = new int[] {0, 1, 2};
 
         DefaultLogRecordBatchStatistics stats1 =

--- a/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
+++ b/fluss-lake/fluss-lake-paimon/src/test/java/org/apache/fluss/lake/paimon/source/PaimonLakeSourceTest.java
@@ -177,7 +177,7 @@ class PaimonLakeSourceTest extends PaimonSourceTestBase {
                 long rowCount,
                 Object min,
                 Object max,
-                Long nullCount,
+                long nullCount,
                 List<Object> literals) {
             return false;
         }

--- a/fluss-server/src/test/java/org/apache/fluss/server/log/LogSegmentTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/log/LogSegmentTest.java
@@ -692,7 +692,7 @@ final class LogSegmentTest extends LogTestBase {
                             long rowCount,
                             org.apache.fluss.row.InternalRow minValues,
                             org.apache.fluss.row.InternalRow maxValues,
-                            Long[] nullCounts) {
+                            int[] nullCounts) {
                         throw new RuntimeException("Simulated filter failure");
                     }
 


### PR DESCRIPTION
Since null counts are stored as 4-byte integers in the batch statistics binary format, int[] is sufficient and avoids boxing overhead (8 bytes per Long vs 4 bytes per int). Use -1 as the sentinel for "not available" instead of null. This reduces memory usage for cachedNullCounts and statsNullCounts, especially for wide tables with many fields.

Closes #3021

<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3021

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
