### PR TITLE
chore: fix docs for RustFS AssumeRole

### DIFF
--- a/website/docs/maintenance/filesystems/s3.md
+++ b/website/docs/maintenance/filesystems/s3.md
@@ -21,3 +21,42 @@ s3.secret-key: <your-secret-key>
 # region
 s3.region: <your-s3-region>
 ```
+
+## S3-Compatible Storage (RustFS, MinIO, etc.)
+
+For S3-compatible storage services such as [RustFS](https://github.com/rustfs/rustfs) or MinIO, you need to configure a custom endpoint and enable path-style access:
+
+```yaml
+remote.data.dir: s3://<your-bucket>/path/to/remote/storage
+s3.endpoint: http://<your-s3-compatible-endpoint>:9000
+s3.access-key: <your-access-key>
+s3.secret-key: <your-secret-key>
+s3.region: us-east-1
+s3.path-style-access: true
+```
+
+### AssumeRole STS Configuration
+
+Some S3-compatible services (such as RustFS) require the use of [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) instead of `GetSessionToken` to obtain temporary security credentials. This is necessary for features like KV snapshots that rely on delegation tokens.
+
+To enable AssumeRole, add the following configurations alongside the base S3 settings above:
+
+```yaml
+remote.data.dir: s3://<your-bucket>/path/to/remote/storage
+s3.endpoint: http://<your-s3-compatible-endpoint>:9000
+s3.access-key: <your-access-key>
+s3.secret-key: <your-secret-key>
+s3.region: us-east-1
+s3.path-style-access: true
+s3.assumed.role.arn: <your-role-arn>
+s3.assumed.role.sts.endpoint: http://<your-s3-compatible-endpoint>:9000
+```
+
+| Configuration | Description |
+|---|---|
+| `s3.assumed.role.arn` | The ARN of the IAM role to assume. When set, Fluss uses `AssumeRole` instead of `GetSessionToken` to obtain temporary credentials. The `s3.access-key` and `s3.secret-key` are still required — they authenticate the AssumeRole call itself. |
+| `s3.assumed.role.sts.endpoint` | Custom STS endpoint URL. Required for S3-compatible services that host their own STS API. When not set, the default AWS STS endpoint is used. |
+
+:::note
+Without `s3.assumed.role.arn`, Fluss falls back to `GetSessionToken` (the default AWS behavior). This is fully backward compatible — existing AWS users do not need to change their configuration.
+:::

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -94,7 +94,7 @@ services:
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
         s3.path-style-access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
   tablet-server:
     image: apache/fluss:$FLUSS_DOCKER_VERSION$
@@ -113,7 +113,7 @@ services:
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
         s3.path-style-access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
   zookeeper:
     restart: always

--- a/website/docs/quickstart/flink.md
+++ b/website/docs/quickstart/flink.md
@@ -92,7 +92,10 @@ services:
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path-style-access: true
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
   tablet-server:
     image: apache/fluss:$FLUSS_DOCKER_VERSION$
     command: tabletServer
@@ -108,8 +111,10 @@ services:
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path-style-access: true
-        kv.snapshot.interval: 0s
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
   zookeeper:
     restart: always
     image: zookeeper:3.9.2
@@ -161,7 +166,7 @@ volumes:
 The Docker Compose environment consists of the following containers:
 - **RustFS:** an S3-compatible object storage for tiered storage. You can access the RustFS console at http://localhost:9001 with credentials `rustfsadmin/rustfsadmin`. An init container (`rustfs-init`) automatically creates the `fluss` bucket on startup.
 - **Fluss Cluster:** a Fluss `CoordinatorServer`, a Fluss `TabletServer` and a `ZooKeeper` server.
-   - Credentials are configured directly with `s3.access-key` and `s3.secret-key`. Production systems should use CredentialsProvider chain specific to cloud environments.
+   - Credentials are configured directly with `s3.access-key` and `s3.secret-key`. The `s3.assumed.role.arn` and `s3.assumed.role.sts.endpoint` options configure [AssumeRole STS](/maintenance/filesystems/s3.md#assumerole-sts-configuration) which is required by RustFS for delegation token support. Production systems should use CredentialsProvider chain specific to cloud environments.
 - **Flink Cluster**: a Flink `JobManager`, a Flink `TaskManager`, and a Flink SQL client container to execute queries.
 
 :::tip

--- a/website/docs/quickstart/lakehouse.md
+++ b/website/docs/quickstart/lakehouse.md
@@ -110,7 +110,10 @@ services:
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path.style.access: true
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
         datalake.paimon.warehouse: s3://fluss/paimon
@@ -135,8 +138,10 @@ services:
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path.style.access: true
-        kv.snapshot.interval: 0s
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
         datalake.paimon.warehouse: s3://fluss/paimon
@@ -327,7 +332,10 @@ services:
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path.style.access: true
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: iceberg
         datalake.iceberg.catalog-impl: org.apache.iceberg.jdbc.JdbcCatalog
         datalake.iceberg.name: fluss_catalog
@@ -356,12 +364,14 @@ services:
         zookeeper.address: zookeeper:2181
         bind.listeners: FLUSS://tablet-server:9123
         data.dir: /tmp/fluss/data
-        kv.snapshot.interval: 0s
         remote.data.dir: s3://fluss/remote-data
         s3.endpoint: http://rustfs:9000
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
+        s3.region: us-east-1
         s3.path.style.access: true
+        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: iceberg
         datalake.iceberg.catalog-impl: org.apache.iceberg.jdbc.JdbcCatalog
         datalake.iceberg.name: fluss_catalog

--- a/website/docs/quickstart/lakehouse.md
+++ b/website/docs/quickstart/lakehouse.md
@@ -111,8 +111,8 @@ services:
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
-        s3.path.style.access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.path-style-access: true
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
@@ -139,8 +139,8 @@ services:
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
-        s3.path.style.access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.path-style-access: true
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: paimon
         datalake.paimon.metastore: filesystem
@@ -333,8 +333,8 @@ services:
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
-        s3.path.style.access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.path-style-access: true
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: iceberg
         datalake.iceberg.catalog-impl: org.apache.iceberg.jdbc.JdbcCatalog
@@ -369,8 +369,8 @@ services:
         s3.access-key: rustfsadmin
         s3.secret-key: rustfsadmin
         s3.region: us-east-1
-        s3.path.style.access: true
-        s3.assumed.role.arn: arn:aws:iam::0:role/rustfsadmin
+        s3.path-style-access: true
+        s3.assumed.role.arn: arn:aws:iam::000000000000:role/rustfsadmin
         s3.assumed.role.sts.endpoint: http://rustfs:9000
         datalake.format: iceberg
         datalake.iceberg.catalog-impl: org.apache.iceberg.jdbc.JdbcCatalog


### PR DESCRIPTION
PR fixes the RustFS STS workaround introduced in #2660. That PR disabled KV snapshots (kv.snapshot.interval: 0s) because RustFS doesn't support GetSessionToken. Now that #2989 added AssumeRole support, we can re-enable snapshots by configuring the AssumeRole STS settings instead.
                                                                                                                                                                                                                                                   
Also adds S3 filesystem documentation for S3-compatible storage and AssumeRole configuration