### PR TITLE
[filesystem] Support default AWS credential chain for S3 delegation

### DIFF
--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
@@ -45,6 +45,8 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
 
     private static final String ACCESS_KEY_ID = "fs.s3a.access.key";
 
+    private static final String ROLE_ARN_KEY = "fs.s3a.assumed.role.arn";
+
     private static final String[][] MIRRORED_CONFIG_KEYS = {
         {"fs.s3a.access-key", "fs.s3a.access.key"},
         {"fs.s3a.secret-key", "fs.s3a.secret.key"},
@@ -122,7 +124,15 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
     }
 
     private void setCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
-        if (hadoopConfig.get(ACCESS_KEY_ID) == null) {
+        boolean hasStaticKeys = hadoopConfig.get(ACCESS_KEY_ID) != null;
+        boolean hasRoleArn = hadoopConfig.get(ROLE_ARN_KEY) != null;
+
+        if (hasStaticKeys || hasRoleArn) {
+            LOG.info(
+                    hasStaticKeys
+                            ? "Using provided static credentials."
+                            : "Using default AWS credential chain with AssumeRole.");
+        } else {
             if (Objects.equals(getScheme(), "s3")) {
                 S3DelegationTokenReceiver.updateHadoopConfig(hadoopConfig);
             } else if (Objects.equals(getScheme(), "s3a")) {
@@ -131,11 +141,8 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
                 throw new IllegalArgumentException("Unsupported scheme: " + getScheme());
             }
             LOG.info(
-                    "{} is not set, using credential provider {}.",
-                    ACCESS_KEY_ID,
+                    "Using credential provider {} for delegated tokens.",
                     hadoopConfig.get(PROVIDER_CONFIG_NAME));
-        } else {
-            LOG.info("{} is set, using provided access key id and secret.", ACCESS_KEY_ID);
         }
     }
 }

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
@@ -62,16 +62,20 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
 
     @Override
     public FileSystem create(URI fsUri, Configuration flussConfig) throws IOException {
-        org.apache.hadoop.conf.Configuration hadoopConfig =
-                mirrorCertainHadoopConfig(getHadoopConfiguration(flussConfig));
-
-        // set credential provider
-        setCredentialProvider(hadoopConfig);
+        org.apache.hadoop.conf.Configuration hadoopConfig = buildHadoopConfiguration(flussConfig);
 
         // create the Hadoop FileSystem
         org.apache.hadoop.fs.FileSystem fs = new S3AFileSystem();
         fs.initialize(getInitURI(fsUri, hadoopConfig), hadoopConfig);
         return new S3FileSystem(getScheme(), fs, hadoopConfig);
+    }
+
+    @VisibleForTesting
+    org.apache.hadoop.conf.Configuration buildHadoopConfiguration(Configuration flussConfig) {
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                mirrorCertainHadoopConfig(getHadoopConfiguration(flussConfig));
+        setCredentialProvider(hadoopConfig);
+        return hadoopConfig;
     }
 
     org.apache.hadoop.conf.Configuration getHadoopConfiguration(Configuration flussConfig) {
@@ -125,8 +129,7 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
         return fsUri;
     }
 
-    @VisibleForTesting
-    void setCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
+    private void setCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
         boolean hasStaticKeys =
                 hadoopConfig.get(ACCESS_KEY_ID) != null
                         && hadoopConfig.get(ACCESS_KEY_SECRET) != null;

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/S3FileSystemPlugin.java
@@ -17,6 +17,7 @@
 
 package org.apache.fluss.fs.s3;
 
+import org.apache.fluss.annotation.VisibleForTesting;
 import org.apache.fluss.config.ConfigBuilder;
 import org.apache.fluss.config.Configuration;
 import org.apache.fluss.fs.FileSystem;
@@ -44,6 +45,7 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
     private static final String HADOOP_CONFIG_PREFIX = "fs.s3a.";
 
     private static final String ACCESS_KEY_ID = "fs.s3a.access.key";
+    private static final String ACCESS_KEY_SECRET = "fs.s3a.secret.key";
 
     private static final String ROLE_ARN_KEY = "fs.s3a.assumed.role.arn";
 
@@ -123,8 +125,11 @@ public class S3FileSystemPlugin implements FileSystemPlugin {
         return fsUri;
     }
 
-    private void setCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
-        boolean hasStaticKeys = hadoopConfig.get(ACCESS_KEY_ID) != null;
+    @VisibleForTesting
+    void setCredentialProvider(org.apache.hadoop.conf.Configuration hadoopConfig) {
+        boolean hasStaticKeys =
+                hadoopConfig.get(ACCESS_KEY_ID) != null
+                        && hadoopConfig.get(ACCESS_KEY_SECRET) != null;
         boolean hasRoleArn = hadoopConfig.get(ROLE_ARN_KEY) != null;
 
         if (hasStaticKeys || hasRoleArn) {

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.apache.fluss.utils.Preconditions.checkArgument;
-import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** Delegation token provider for S3 Hadoop filesystems. */
 public class S3DelegationTokenProvider {
@@ -68,7 +67,7 @@ public class S3DelegationTokenProvider {
     public S3DelegationTokenProvider(String scheme, Configuration conf) {
         this.scheme = scheme;
         this.region = conf.get(REGION_KEY);
-        checkNotNull(region, "Region is not set.");
+        checkArgument(region != null, "Region is not set.");
         this.accessKey = conf.get(ACCESS_KEY_ID);
         this.secretKey = conf.get(ACCESS_KEY_SECRET);
         this.roleArn = conf.get(ROLE_ARN_KEY);
@@ -76,11 +75,11 @@ public class S3DelegationTokenProvider {
 
         checkArgument(
                 (accessKey == null) == (secretKey == null),
-                "fs.s3a.access.key and fs.s3a.secret.key must both be set or both be unset.");
+                "S3 access key and secret key must both be set or both be unset.");
         if (accessKey == null) {
             checkArgument(
                     roleArn != null,
-                    ROLE_ARN_KEY + " must be set when static credentials are not provided.");
+                    "Role ARN must be set when static credentials are not provided.");
         }
 
         this.additionInfos = new HashMap<>();

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -58,8 +58,8 @@ public class S3DelegationTokenProvider {
 
     private final String scheme;
     private final String region;
-    private final String accessKey;
-    private final String secretKey;
+    @Nullable private final String accessKey;
+    @Nullable private final String secretKey;
     @Nullable private final String roleArn;
     @Nullable private final String stsEndpoint;
     private final Map<String, String> additionInfos;
@@ -72,6 +72,13 @@ public class S3DelegationTokenProvider {
         this.secretKey = conf.get(ACCESS_KEY_SECRET);
         this.roleArn = conf.get(ROLE_ARN_KEY);
         this.stsEndpoint = conf.get(STS_ENDPOINT_KEY);
+
+        if (accessKey == null || secretKey == null) {
+            checkNotNull(
+                    roleArn,
+                    ROLE_ARN_KEY + " must be set when static credentials are not provided.");
+        }
+
         this.additionInfos = new HashMap<>();
         for (String key : Arrays.asList(REGION_KEY, ENDPOINT_KEY)) {
             if (conf.get(key) != null) {
@@ -86,10 +93,7 @@ public class S3DelegationTokenProvider {
             Credentials credentials;
 
             if (roleArn != null) {
-                LOG.info(
-                        "Obtaining session credentials via AssumeRole with access key: {}, role: {}",
-                        accessKey,
-                        roleArn);
+                LOG.info("Obtaining session credentials via AssumeRole, role: {}", roleArn);
                 AssumeRoleRequest request =
                         new AssumeRoleRequest()
                                 .withRoleArn(roleArn)
@@ -121,10 +125,13 @@ public class S3DelegationTokenProvider {
 
     private AWSSecurityTokenService buildStsClient() {
         AWSSecurityTokenServiceClientBuilder builder =
-                AWSSecurityTokenServiceClientBuilder.standard()
-                        .withCredentials(
-                                new AWSStaticCredentialsProvider(
-                                        new BasicAWSCredentials(accessKey, secretKey)));
+                AWSSecurityTokenServiceClientBuilder.standard();
+
+        if (accessKey != null && secretKey != null) {
+            builder.withCredentials(
+                    new AWSStaticCredentialsProvider(
+                            new BasicAWSCredentials(accessKey, secretKey)));
+        }
 
         if (stsEndpoint != null) {
             builder.withEndpointConfiguration(

--- a/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
+++ b/fluss-filesystems/fluss-fs-s3/src/main/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProvider.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.apache.fluss.utils.Preconditions.checkArgument;
 import static org.apache.fluss.utils.Preconditions.checkNotNull;
 
 /** Delegation token provider for S3 Hadoop filesystems. */
@@ -73,9 +74,12 @@ public class S3DelegationTokenProvider {
         this.roleArn = conf.get(ROLE_ARN_KEY);
         this.stsEndpoint = conf.get(STS_ENDPOINT_KEY);
 
-        if (accessKey == null || secretKey == null) {
-            checkNotNull(
-                    roleArn,
+        checkArgument(
+                (accessKey == null) == (secretKey == null),
+                "fs.s3a.access.key and fs.s3a.secret.key must both be set or both be unset.");
+        if (accessKey == null) {
+            checkArgument(
+                    roleArn != null,
                     ROLE_ARN_KEY + " must be set when static credentials are not provided.");
         }
 

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/S3FileSystemPluginTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/S3FileSystemPluginTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.s3;
+
+import org.apache.fluss.fs.s3.token.DynamicTemporaryAWSCredentialsProvider;
+import org.apache.fluss.fs.s3.token.S3DelegationTokenReceiver;
+import org.apache.fluss.fs.token.Credentials;
+import org.apache.fluss.fs.token.CredentialsJsonSerde;
+import org.apache.fluss.fs.token.ObtainedSecurityToken;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Tests for server/client detection in {@link S3FileSystemPlugin}. */
+class S3FileSystemPluginTest {
+
+    private static final String PROVIDER_CONFIG = "fs.s3a.aws.credentials.provider";
+
+    @Test
+    void testServerModeWithStaticKeys() {
+        Configuration hadoopConfig = new Configuration();
+        hadoopConfig.set("fs.s3a.access.key", "testAccessKey");
+        hadoopConfig.set("fs.s3a.secret.key", "testSecretKey");
+
+        S3FileSystemPlugin plugin = new S3FileSystemPlugin();
+        plugin.setCredentialProvider(hadoopConfig);
+
+        String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
+        assertThat(providers).doesNotContain(DynamicTemporaryAWSCredentialsProvider.NAME);
+    }
+
+    @Test
+    void testServerModeWithRoleArnOnly() {
+        Configuration hadoopConfig = new Configuration();
+        hadoopConfig.set("fs.s3a.assumed.role.arn", "arn:aws:iam::123456789012:role/test-role");
+
+        S3FileSystemPlugin plugin = new S3FileSystemPlugin();
+        plugin.setCredentialProvider(hadoopConfig);
+
+        String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
+        assertThat(providers).doesNotContain(DynamicTemporaryAWSCredentialsProvider.NAME);
+    }
+
+    @Test
+    void testClientModeWithDelegatedCredentials() {
+        // Pre-populate receiver so updateHadoopConfig does not throw.
+        Credentials creds = new Credentials("testKey", "testSecret", "testToken");
+        ObtainedSecurityToken token =
+                new ObtainedSecurityToken(
+                        "s3",
+                        CredentialsJsonSerde.toJson(creds),
+                        System.currentTimeMillis() + 3600000,
+                        Collections.singletonMap("fs.s3a.region", "us-east-1"));
+        S3DelegationTokenReceiver receiver = new S3DelegationTokenReceiver();
+        receiver.onNewTokensObtained(token);
+
+        Configuration hadoopConfig = new Configuration();
+
+        S3FileSystemPlugin plugin = new S3FileSystemPlugin();
+        plugin.setCredentialProvider(hadoopConfig);
+
+        String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
+        assertThat(providers).contains(DynamicTemporaryAWSCredentialsProvider.NAME);
+    }
+}

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/S3FileSystemPluginTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/S3FileSystemPluginTest.java
@@ -17,13 +17,13 @@
 
 package org.apache.fluss.fs.s3;
 
+import org.apache.fluss.config.Configuration;
 import org.apache.fluss.fs.s3.token.DynamicTemporaryAWSCredentialsProvider;
 import org.apache.fluss.fs.s3.token.S3DelegationTokenReceiver;
 import org.apache.fluss.fs.token.Credentials;
 import org.apache.fluss.fs.token.CredentialsJsonSerde;
 import org.apache.fluss.fs.token.ObtainedSecurityToken;
 
-import org.apache.hadoop.conf.Configuration;
 import org.junit.jupiter.api.Test;
 
 import java.util.Collections;
@@ -37,12 +37,13 @@ class S3FileSystemPluginTest {
 
     @Test
     void testServerModeWithStaticKeys() {
-        Configuration hadoopConfig = new Configuration();
-        hadoopConfig.set("fs.s3a.access.key", "testAccessKey");
-        hadoopConfig.set("fs.s3a.secret.key", "testSecretKey");
+        Configuration flussConfig = new Configuration();
+        flussConfig.setString("fs.s3a.access.key", "testAccessKey");
+        flussConfig.setString("fs.s3a.secret.key", "testSecretKey");
 
         S3FileSystemPlugin plugin = new S3FileSystemPlugin();
-        plugin.setCredentialProvider(hadoopConfig);
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                plugin.buildHadoopConfiguration(flussConfig);
 
         String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
         assertThat(providers).doesNotContain(DynamicTemporaryAWSCredentialsProvider.NAME);
@@ -50,11 +51,13 @@ class S3FileSystemPluginTest {
 
     @Test
     void testServerModeWithRoleArnOnly() {
-        Configuration hadoopConfig = new Configuration();
-        hadoopConfig.set("fs.s3a.assumed.role.arn", "arn:aws:iam::123456789012:role/test-role");
+        Configuration flussConfig = new Configuration();
+        flussConfig.setString(
+                "fs.s3a.assumed.role.arn", "arn:aws:iam::123456789012:role/test-role");
 
         S3FileSystemPlugin plugin = new S3FileSystemPlugin();
-        plugin.setCredentialProvider(hadoopConfig);
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                plugin.buildHadoopConfiguration(flussConfig);
 
         String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
         assertThat(providers).doesNotContain(DynamicTemporaryAWSCredentialsProvider.NAME);
@@ -73,10 +76,11 @@ class S3FileSystemPluginTest {
         S3DelegationTokenReceiver receiver = new S3DelegationTokenReceiver();
         receiver.onNewTokensObtained(token);
 
-        Configuration hadoopConfig = new Configuration();
+        Configuration flussConfig = new Configuration();
 
         S3FileSystemPlugin plugin = new S3FileSystemPlugin();
-        plugin.setCredentialProvider(hadoopConfig);
+        org.apache.hadoop.conf.Configuration hadoopConfig =
+                plugin.buildHadoopConfiguration(flussConfig);
 
         String providers = hadoopConfig.get(PROVIDER_CONFIG, "");
         assertThat(providers).contains(DynamicTemporaryAWSCredentialsProvider.NAME);

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
@@ -44,4 +44,15 @@ class S3DelegationTokenProviderTest {
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("fs.s3a.assumed.role.arn must be set");
     }
+
+    @Test
+    void testPartialStaticCredentialsThrows() {
+        Configuration conf = new Configuration();
+        conf.set("fs.s3a.region", "us-east-1");
+        conf.set("fs.s3a.access.key", "testAccessKey");
+
+        assertThatThrownBy(() -> new S3DelegationTokenProvider("s3", conf))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("must both be set or both be unset");
+    }
 }

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
@@ -42,7 +42,7 @@ class S3DelegationTokenProviderTest {
 
         assertThatThrownBy(() -> new S3DelegationTokenProvider("s3", conf))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("fs.s3a.assumed.role.arn must be set");
+                .hasMessageContaining("Role ARN must be set");
     }
 
     @Test

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
@@ -41,7 +41,7 @@ class S3DelegationTokenProviderTest {
         conf.set("fs.s3a.region", "us-east-1");
 
         assertThatThrownBy(() -> new S3DelegationTokenProvider("s3", conf))
-                .isInstanceOf(NullPointerException.class)
+                .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("fs.s3a.assumed.role.arn must be set");
     }
 }

--- a/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
+++ b/fluss-filesystems/fluss-fs-s3/src/test/java/org/apache/fluss/fs/s3/token/S3DelegationTokenProviderTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.fluss.fs.s3.token;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Tests for {@link S3DelegationTokenProvider} constructor validation. */
+class S3DelegationTokenProviderTest {
+
+    @Test
+    void testDefaultChainWithRoleArn() {
+        Configuration conf = new Configuration();
+        conf.set("fs.s3a.region", "us-east-1");
+        conf.set("fs.s3a.assumed.role.arn", "arn:aws:iam::123456789012:role/test-role");
+
+        assertThatCode(() -> new S3DelegationTokenProvider("s3", conf)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void testDefaultChainWithoutRoleArnThrows() {
+        Configuration conf = new Configuration();
+        conf.set("fs.s3a.region", "us-east-1");
+
+        assertThatThrownBy(() -> new S3DelegationTokenProvider("s3", conf))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("fs.s3a.assumed.role.arn must be set");
+    }
+}

--- a/website/docs/maintenance/filesystems/s3.md
+++ b/website/docs/maintenance/filesystems/s3.md
@@ -60,3 +60,23 @@ s3.assumed.role.sts.endpoint: http://<your-s3-compatible-endpoint>:9000
 :::note
 Without `s3.assumed.role.arn`, Fluss falls back to `GetSessionToken` (the default AWS behavior). This is fully backward compatible — existing AWS users do not need to change their configuration.
 :::
+
+### Default AWS Credential Chain (IRSA, Instance Profiles)
+
+When running Fluss on Kubernetes with [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or on EC2 with instance profiles, you can omit `s3.access-key` and `s3.secret-key`. The server will authenticate using the default AWS credential chain.
+
+In this mode, `s3.assumed.role.arn` is required — the server uses `AssumeRole` to generate temporary credentials for clients (Flink/Spark connectors) that read tiered data from S3.
+
+```yaml
+remote.data.dir: s3://<your-bucket>/path/to/remote/storage
+s3.region: <your-s3-region>
+s3.assumed.role.arn: <your-delegation-role-arn>
+```
+
+The server's IAM role (e.g., the IRSA service account role) must have:
+- Read/write permissions on the S3 bucket (for the server's own data access)
+- `sts:AssumeRole` permission on the role specified in `s3.assumed.role.arn`
+
+:::note
+The server uses the same underlying identity for both its own S3 access and the STS `AssumeRole` call. Configuring separate roles for data access and delegation is not currently supported; a full credential delegation redesign is planned.
+:::

--- a/website/docs/maintenance/filesystems/s3.md
+++ b/website/docs/maintenance/filesystems/s3.md
@@ -78,5 +78,5 @@ The server's IAM role (e.g., the IRSA service account role) must have:
 - `sts:AssumeRole` permission on the role specified in `s3.assumed.role.arn`
 
 :::note
-The server uses the same underlying identity for both its own S3 access and the STS `AssumeRole` call. Configuring separate roles for data access and delegation is not currently supported; a full credential delegation redesign is planned.
+The server authenticates using its own credentials (static keys, IRSA, instance profile, or environment variables) for S3 data access. For delegation, the server calls AssumeRole with the configured `s3.assumed.role.arn`, so clients receive credentials for that role — which can have different permissions (e.g., read-only). Note that the server uses the same identity for both its own S3 access and the STS AssumeRole call. Further decoupling is planned.
 :::


### PR DESCRIPTION
## Summary

resolves https://github.com/apache/fluss/issues/3066

 Currently the STS client in `S3DelegationTokenProvider` is hardcoded to use `AWSStaticCredentialsProvider`, so credential delegation only works when static access keys are in the config. This prevents using IRSA, instance profiles, or any other credential method from the default AWS chain. Additionally, `S3FileSystemPlugin` uses the presence of `access.key` to distinguish server from client, so a server without static keys is misdetected as a client and crashes with `NoAwsCredentialsException`.
 
 This PR makes the STS client fall back to `DefaultAWSCredentialsProviderChain` when no static keys are configured, and requires `roleArn` in that case since `GetSessionToken` does not work with temporary credentials. The plugin now also treats `roleArn` presence as a server-mode indicator.
                                                                                                                                                                                                                                                     
This is a targeted fix that does not change the delegation protocol or add new config keys. 
The full credential delegation redesign (#2662) can build on top. See also #1245 which attempted a broader approach.                                   
   
Tested E2E with LocalStack: Fluss server with env-var credentials (no static keys in config) + AssumeRole delegation, Flink client reading tiered log segments via delegated credentials.