### PR TITLE
[lake/tiering] add tiering table pending time and freshness metrics

### DIFF
--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -70,6 +70,8 @@ public class MetricNames {
     public static final String LAKE_TIERING_TABLE_FAILURES_TOTAL = "failuresTotal";
     public static final String LAKE_TIERING_TABLE_FILE_SIZE = "fileSize";
     public static final String LAKE_TIERING_TABLE_RECORD_COUNT = "recordCount";
+    public static final String LAKE_TIERING_TABLE_PENDING_TIME = "pendingTime";
+    public static final String LAKE_TIERING_TABLE_FRESHNESS = "freshness";
 
     // --------------------------------------------------------------------------------------------
     // metrics for tablet server

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -224,11 +224,13 @@ public class MetricNames {
     // metrics for table bucket
     // --------------------------------------------------------------------------------------------
 
+    // for tablet
+    public static final String LAKE_PENDING_RECORDS = "pendingRecords";
+
     // for log tablet
     public static final String LOG_NUM_SEGMENTS = "numSegments";
     public static final String LOG_END_OFFSET = "endOffset";
     public static final String REMOTE_LOG_SIZE = "size";
-    public static final String LOG_LAKE_PENDING_RECORDS = "pendingRecords";
     public static final String LOG_LAKE_TIMESTAMP_LAG = "timestampLag";
 
     // for logic storage

--- a/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
+++ b/fluss-common/src/main/java/org/apache/fluss/metrics/MetricNames.java
@@ -224,13 +224,11 @@ public class MetricNames {
     // metrics for table bucket
     // --------------------------------------------------------------------------------------------
 
-    // for tablet
-    public static final String LAKE_PENDING_RECORDS = "pendingRecords";
-
     // for log tablet
     public static final String LOG_NUM_SEGMENTS = "numSegments";
     public static final String LOG_END_OFFSET = "endOffset";
     public static final String REMOTE_LOG_SIZE = "size";
+    public static final String LOG_LAKE_PENDING_RECORDS = "pendingRecords";
     public static final String LOG_LAKE_TIMESTAMP_LAG = "timestampLag";
 
     // for logic storage

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/LakeTableTieringManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/LakeTableTieringManager.java
@@ -141,6 +141,9 @@ public class LakeTableTieringManager implements AutoCloseable {
     // table_id -> start time (ms) of the currently in-progress tiering round
     private final Map<Long, Long> currentTieringStartTime;
 
+    // table_id -> time (ms) when the table entered pending queue
+    private final Map<Long, Long> pendingEnterTime;
+
     // the live tables that are tiering,
     // from table_id -> last heartbeat time by the tiering service
     private final Map<Long, Long> liveTieringTableIds;
@@ -184,6 +187,7 @@ public class LakeTableTieringManager implements AutoCloseable {
         this.delayedTieringByTableId = new HashMap<>();
         this.tableFailureCounters = new HashMap<>();
         this.currentTieringStartTime = new HashMap<>();
+        this.pendingEnterTime = new HashMap<>();
         this.tieringMetricGroup = lakeTieringMetricGroup;
         registerMetrics();
     }
@@ -279,6 +283,17 @@ public class LakeTableTieringManager implements AutoCloseable {
                 MetricNames.LAKE_TIERING_TABLE_TIER_DURATION,
                 () -> inReadLock(lock, () -> getLastResultField(tableId, r -> r.tierDuration)));
 
+        // pendingTime: how long the table has been waiting in the pending queue
+        tableMetricGroup.gauge(
+                MetricNames.LAKE_TIERING_TABLE_PENDING_TIME,
+                () ->
+                        inReadLock(
+                                lock,
+                                () -> {
+                                    long enterTime = pendingEnterTime.getOrDefault(tableId, 0L);
+                                    return enterTime > 0 ? clock.milliseconds() - enterTime : 0L;
+                                }));
+
         // failuresTotal: total failure count for this table
         Counter failuresCounter =
                 tableMetricGroup.counter(MetricNames.LAKE_TIERING_TABLE_FAILURES_TOTAL);
@@ -293,6 +308,11 @@ public class LakeTableTieringManager implements AutoCloseable {
         tableMetricGroup.gauge(
                 MetricNames.LAKE_TIERING_TABLE_RECORD_COUNT,
                 () -> inReadLock(lock, () -> getLastResultField(tableId, r -> r.recordCount)));
+
+        // freshness: the user-configured table data freshness interval in milliseconds
+        tableMetricGroup.gauge(
+                MetricNames.LAKE_TIERING_TABLE_FRESHNESS,
+                () -> inReadLock(lock, () -> tableLakeFreshness.getOrDefault(tableId, -1L)));
     }
 
     /**
@@ -316,6 +336,7 @@ public class LakeTableTieringManager implements AutoCloseable {
                     tableLakeFreshness.remove(tableId);
                     lastTieringResult.remove(tableId);
                     currentTieringStartTime.remove(tableId);
+                    pendingEnterTime.remove(tableId);
                     tableFailureCounters.remove(tableId);
                     // close and remove the metric group to unregister metrics
                     tieringMetricGroup.removeTableLakeTieringMetricGroup(tableId);
@@ -579,10 +600,12 @@ public class LakeTableTieringManager implements AutoCloseable {
                 // increase tiering epoch and initialize the heartbeat of the tiering table
                 tableTierEpoch.computeIfPresent(tableId, (t, v) -> v + 1);
                 pendingTieringTables.add(tableId);
+                pendingEnterTime.put(tableId, clock.milliseconds());
                 break;
             case Tiering:
                 liveTieringTableIds.put(tableId, clock.milliseconds());
                 currentTieringStartTime.put(tableId, clock.milliseconds());
+                pendingEnterTime.put(tableId, 0L);
                 break;
             case Tiered:
                 liveTieringTableIds.remove(tableId);

--- a/fluss-server/src/main/java/org/apache/fluss/server/coordinator/LakeTableTieringManager.java
+++ b/fluss-server/src/main/java/org/apache/fluss/server/coordinator/LakeTableTieringManager.java
@@ -285,14 +285,7 @@ public class LakeTableTieringManager implements AutoCloseable {
 
         // pendingTime: how long the table has been waiting in the pending queue
         tableMetricGroup.gauge(
-                MetricNames.LAKE_TIERING_TABLE_PENDING_TIME,
-                () ->
-                        inReadLock(
-                                lock,
-                                () -> {
-                                    long enterTime = pendingEnterTime.getOrDefault(tableId, 0L);
-                                    return enterTime > 0 ? clock.milliseconds() - enterTime : 0L;
-                                }));
+                MetricNames.LAKE_TIERING_TABLE_PENDING_TIME, () -> getTablePendingTime(tableId));
 
         // failuresTotal: total failure count for this table
         Counter failuresCounter =
@@ -605,7 +598,7 @@ public class LakeTableTieringManager implements AutoCloseable {
             case Tiering:
                 liveTieringTableIds.put(tableId, clock.milliseconds());
                 currentTieringStartTime.put(tableId, clock.milliseconds());
-                pendingEnterTime.put(tableId, 0L);
+                pendingEnterTime.remove(tableId);
                 break;
             case Tiered:
                 liveTieringTableIds.remove(tableId);
@@ -847,5 +840,15 @@ public class LakeTableTieringManager implements AutoCloseable {
     @VisibleForTesting
     long getLastTieringResultField(long tableId, ToLongFunction<LastTieringResult> fieldExtractor) {
         return inReadLock(lock, () -> getLastResultField(tableId, fieldExtractor));
+    }
+
+    @VisibleForTesting
+    long getTablePendingTime(long tableId) {
+        return inReadLock(
+                lock,
+                () -> {
+                    Long enterTime = pendingEnterTime.get(tableId);
+                    return enterTime != null ? clock.milliseconds() - enterTime : 0L;
+                });
     }
 }

--- a/fluss-server/src/test/java/org/apache/fluss/server/coordinator/LakeTableTieringManagerTest.java
+++ b/fluss-server/src/test/java/org/apache/fluss/server/coordinator/LakeTableTieringManagerTest.java
@@ -304,6 +304,31 @@ class LakeTableTieringManagerTest {
 
         // Advance time and request table
         manualClock.advanceTime(Duration.ofSeconds(10));
+
+        // Wait for the delayed task to execute and move to pending
+        waitValue(
+                () ->
+                        tableTieringManager.getTableState(tableId1)
+                                        == LakeTableTieringManager.TieringState.Pending
+                                ? Optional.of(true)
+                                : Optional.empty(),
+                Duration.ofSeconds(5),
+                "Table should be in pending state");
+
+        // pendingTime should be > 0 when in pending state
+        // The table entered pending after the 10s delay, so pendingTime should reflect time since
+        // then
+        assertThat(tableTieringManager.getTableState(tableId1))
+                .isEqualTo(LakeTableTieringManager.TieringState.Pending);
+
+        // Verify pendingTime is 0 initially (just entered pending state)
+        assertThat(tableTieringManager.getTablePendingTime(tableId1)).isEqualTo(0L);
+
+        // Advance time while in pending state - pendingTime should increase
+        manualClock.advanceTime(Duration.ofSeconds(5));
+        assertThat(tableTieringManager.getTablePendingTime(tableId1)).isEqualTo(5000L);
+
+        // Request table - should transition to Tiering and pendingTime should reset to 0
         assertRequestTable(tableId1, tablePath1, 1);
 
         // State should be Tiering (4)
@@ -372,6 +397,13 @@ class LakeTableTieringManagerTest {
         // State should be Pending (3) after failure
         assertThat(tableTieringManager.getTableState(tableId1))
                 .isEqualTo(LakeTableTieringManager.TieringState.Pending);
+
+        // After failure, table re-enters pending state, pendingTime should be 0 initially
+        assertThat(tableTieringManager.getTablePendingTime(tableId1)).isEqualTo(0L);
+
+        // Advance time - pendingTime should increase from failure time
+        manualClock.advanceTime(Duration.ofSeconds(3));
+        assertThat(tableTieringManager.getTablePendingTime(tableId1)).isEqualTo(3000L);
     }
 
     @Test

--- a/website/docs/maintenance/observability/monitor-metrics.md
+++ b/website/docs/maintenance/observability/monitor-metrics.md
@@ -294,7 +294,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
   </thead>
   <tbody>
     <tr>
-       <th rowspan="25"><strong>coordinator</strong></th>
+       <th rowspan="27"><strong>coordinator</strong></th>
       <td style={{textAlign: 'center', verticalAlign: 'middle' }} rowspan="10">-</td>
       <td>activeCoordinatorCount</td>
       <td>The number of active CoordinatorServer (only leader) in this cluster.</td>
@@ -401,7 +401,7 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
       <td>Gauge</td>
     </tr>
     <tr>
-      <td rowspan="5">lakeTiering_table</td>
+      <td rowspan="7">lakeTiering_table</td>
       <td>tierLag</td>
       <td>Time in milliseconds since the last successful tiering operation for this table. For newly registered tables that have never completed a tiering round, the lag is measured from the time the table was registered.</td>
       <td>Gauge</td>
@@ -424,6 +424,16 @@ Some metrics might not be exposed when using other JVM implementations (e.g. IBM
     <tr>
       <td>recordCount</td>
       <td>Cumulative total record count of the lake table after the last tiering round. Returns -1 if no tiering has completed yet.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>pendingTime</td>
+      <td>How long (in milliseconds) the table has been waiting in the pending queue for tiering. Returns 0 when the table is not currently pending.</td>
+      <td>Gauge</td>
+    </tr>
+    <tr>
+      <td>freshness</td>
+      <td>The user-configured data freshness interval (in milliseconds) for this table.</td>
       <td>Gauge</td>
     </tr>
   </tbody>


### PR DESCRIPTION
<!--
*Thank you very much for contributing to Fluss - we are happy that you want to help us improve Fluss. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [GitHub issue](https://github.com/apache/fluss/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no issue.

  - Name the pull request in the format "[component] Title of the pull request", where *[component]* should be replaced by the name of the component being changed. Typically, this corresponds to the component label assigned to the issue (e.g., [kv], [log], [client], [flink]). Skip *[component]* if you are unsure about which is the best component.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.

  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes.

  - Each pull request should address only one issue, not mix up code from multiple issues.

  - **Generative AI disclosure:** Indicate whether generative AI tools were used in authoring this PR. If yes, specify the tool below.
    - [ ] No generative AI tools used
    - [ ] Yes (please specify the tool below)

**(The sections below can be removed for hotfixes or typos)**
-->

<!--
Generated-by: [Tool Name and Version] following [the guidelines](https://github.com/apache/fluss/blob/main/AGENTS.md)
-->

### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close #3075

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->
Add two new table-level metrics for lake tiering monitoring:
- **pendingTime**: Tracks how long a table has been waiting in the pending queue
- **freshness**: Exposes the user-configured table data freshness interval

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
