### PR TITLE
[docs] Add documentation for how contributors can become committers

### DIFF
--- a/website/community/become-a-committer.md
+++ b/website/community/become-a-committer.md
@@ -1,0 +1,44 @@
+---
+title: How to become a Committer
+sidebar_position: 5
+---
+
+# Committer
+
+## Become a Committer
+
+#### How to become a committer
+
+There is no strict protocol for becoming a committer. Candidates for new committers are typically people that are active contributors and community members. Candidates are suggested by current committers or PPMC members, and voted upon by the PPMC.
+
+If you would like to become a committer, you should engage with the community and start contributing to Apache Fluss in any of the ways described in the [How to Contribute](how-to-contribute/contribute-code.md) guides. You might also want to talk to other committers and ask for their advice and guidance.
+
+- **Community contributions** include helping to answer user questions on the [mailing lists](welcome.mdx#mailing-lists), verifying release candidates (see [Verifying a Fluss Release](how-to-release/verifying-a-fluss-release.md)), giving talks, organizing community events, [contributing to documentation](how-to-contribute/contribute-docs.md), and other forms of evangelism and community building. The "Apache Way" has a strong focus on the project community, and committers can be recognized for outstanding community contributions even without any code contributions.
+
+- **Code/technology contributions** include contributed pull requests (see [Contribute Code](how-to-contribute/contribute-code.md) for the process), design discussions, reviews, testing, and other help in identifying and fixing bugs. Especially constructive and high quality design discussions, as well as helping other contributors, are strong indicators.
+
+#### Identify promising candidates
+
+While the prior points give ways to identify promising candidates, the following are "must haves" for any committer candidate:
+
+- **Being community minded**: The candidate understands the meritocratic principles of community management. They do not always optimize for as much as possible personal contribution, but will help and empower others where it makes sense.
+
+- **Responsibility with write access**: We trust that a committer candidate will use their write access to the repositories responsibly, and if in doubt, conservatively. It is important that committers are aware of what they know and what they don't know. In doubt, committers should ask for a second pair of eyes rather than commit to parts that they are not well familiar with.
+
+- **Respectful and constructive**: They have shown to be respectful towards other community members and constructive in discussions.
+
+#### Path to PPMC Membership
+
+Outstanding committers may be invited to join the Project Management Committee (PPMC). As described in [Fluss Team](fluss-team.md), the PPMC is the vehicle through which decision-making power and responsibility for oversight devolves to developers. While committers have the ability to update the code, only the PPMC as a body has the authority to:
+
+- Vote on formal releases of the project's software
+- Vote in new committers and PPMC members
+- Manage the incubator project
+
+For more details on PPMC roles and responsibilities, see [Fluss Team](fluss-team.md).
+
+## Committer Rights
+
+JetBrains provides a free license to Apache Committers, allowing them to access all JetBrains IDEs, such as IntelliJ IDEA, PyCharm, and other desktop tools.
+
+Please use your @apache.org email address to apply for [All Products Packs for Apache committers](https://www.jetbrains.com/shop/eform/apache?product=ALL).

--- a/website/community/become-a-committer.md
+++ b/website/community/become-a-committer.md
@@ -3,11 +3,7 @@ title: How to become a Committer
 sidebar_position: 5
 ---
 
-# Committer
-
-## Become a Committer
-
-#### How to become a committer
+# How to become a committer
 
 There is no strict protocol for becoming a committer. Candidates for new committers are typically people that are active contributors and community members. Candidates are suggested by current committers or PPMC members, and voted upon by the PPMC.
 
@@ -17,17 +13,17 @@ If you would like to become a committer, you should engage with the community an
 
 - **Code/technology contributions** include contributed pull requests (see [Contribute Code](how-to-contribute/contribute-code.md) for the process), design discussions, reviews, testing, and other help in identifying and fixing bugs. Especially constructive and high quality design discussions, as well as helping other contributors, are strong indicators.
 
-#### Identify promising candidates
+## Identify promising candidates
 
 While the prior points give ways to identify promising candidates, the following are "must haves" for any committer candidate:
 
-- **Being community minded**: The candidate understands the meritocratic principles of community management. They do not always optimize for as much as possible personal contribution, but will help and empower others where it makes sense.
+- **Being community minded**: The candidate understands the meritocratic principles of community management. They do not always optimize for as much personal contribution as possible, but will help and empower others where it makes sense.
 
 - **Responsibility with write access**: We trust that a committer candidate will use their write access to the repositories responsibly, and if in doubt, conservatively. It is important that committers are aware of what they know and what they don't know. In doubt, committers should ask for a second pair of eyes rather than commit to parts that they are not well familiar with.
 
-- **Respectful and constructive**: They have shown to be respectful towards other community members and constructive in discussions.
+- **Respectful and constructive**: They have shown themselves to be respectful towards other community members and constructive in discussions.
 
-#### Path to PPMC Membership
+## Path to PPMC Membership
 
 Outstanding committers may be invited to join the Project Management Committee (PPMC). As described in [Fluss Team](fluss-team.md), the PPMC is the vehicle through which decision-making power and responsibility for oversight devolves to developers. While committers have the ability to update the code, only the PPMC as a body has the authority to:
 

--- a/website/community/fluss-logos.md
+++ b/website/community/fluss-logos.md
@@ -1,6 +1,6 @@
 ---
 title: Fluss Logos
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Fluss Logos

--- a/website/community/fluss-team.md
+++ b/website/community/fluss-team.md
@@ -1,6 +1,6 @@
 ---
 title: Fluss Team
-sidebar_position: 5
+sidebar_position: 6
 ---
 
 ## Fluss Team


### PR DESCRIPTION
## What is the purpose of the change

This PR adds documentation describing how contributors can be granted more rights such as commit access and decision power, as requested in #3073.

## Brief change log

- Add `website/community/become-a-committer.md` with:
  - How to become a committer (contribution paths and requirements)
  - Identify promising candidates criteria
  - Path to PPMC Membership
  - Committer Rights
- Adjust sidebar positions for community documentation:
  - `fluss-team.md`: position 5 → 6
  - `fluss-logos.md`: position 6 → 7

## Verifying this change

- [ ] Preview the documentation locally using `npm start` in the website directory
- [ ] Verify the new page appears correctly in the Community sidebar
- [ ] Check all cross-links are working

## Does this pull request introduce a breaking change?

- [ ] No
- [ ] Yes

## Documentation

- New documentation added: `become-a-committer.md`

Closes #3073