### PR TITLE
[docs] chore: fix overlapping table and sidebar in docs

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -231,6 +231,7 @@
     table tr td {
         padding: 0.65rem 0.8125rem;
         border-color: #dfe5f0;
+        word-break: break-word;
     }
     a {
         color: var(--ifm-color-primary);


### PR DESCRIPTION
resolves https://github.com/apache/fluss/issues/3093

before: 
<img width="1686" height="646" alt="image" src="https://github.com/user-attachments/assets/a602d4f2-0cad-40e4-b281-4b5810c3392b" />

after:
<img width="1679" height="676" alt="image" src="https://github.com/user-attachments/assets/4360c63c-e2ed-423c-add4-90110e46d54c" />
