### PR TITLE
[helm] Support injecting environment variables and external secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,10 +24,12 @@ on:
       - ci-**
     paths-ignore:
       - 'website/**'
+      - 'helm/**'
       - '**/*.md'
   pull_request:
     paths-ignore:
       - 'website/**'
+      - 'helm/**'
       - '**/*.md'
 
 concurrency:

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -48,7 +48,6 @@ jobs:
         run: helm lint ./helm
 
       - name: "Run helm-unittest"
-        uses: d3adb5/helm-unittest-action@v2
-        with:
-          helm-version: latest
-          charts: helm
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest
+          helm unittest ./helm

--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -68,6 +68,13 @@ spec:
             - name: FLUSS_ENV_JAVA_OPTS
               value: "-Djava.security.auth.login.config=/etc/fluss/conf/jaas.conf"
             {{- end }}
+            {{- with .Values.coordinator.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.coordinator.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: internal
               containerPort: {{ .Values.listeners.internal.port }}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -64,6 +64,13 @@ spec:
             - name: FLUSS_ENV_JAVA_OPTS
               value: "-Djava.security.auth.login.config=/etc/fluss/conf/jaas.conf"
             {{- end }}
+            {{- with .Values.tablet.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with .Values.tablet.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: internal
               containerPort: {{ .Values.listeners.internal.port }}

--- a/helm/tests/env_test.yaml
+++ b/helm/tests/env_test.yaml
@@ -1,0 +1,174 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: defaults
+templates:
+  - templates/sts-coordinator.yaml
+  - templates/sts-tablet.yaml
+
+tests:
+  - it: should not render envFrom by default on coordinator
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/sts-coordinator.yaml
+
+  - it: should not render envFrom by default on tablet
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom
+        template: templates/sts-tablet.yaml
+
+---
+
+suite: coordinator env
+templates:
+  - templates/sts-coordinator.yaml
+
+tests:
+  - it: should render envFrom with secretRef on coordinator
+    set:
+      coordinator.envFrom:
+        - secretRef:
+            name: my-eso-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-eso-secret
+
+  - it: should render envFrom with configMapRef on coordinator
+    set:
+      coordinator.envFrom:
+        - configMapRef:
+            name: my-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-config
+
+  - it: should render extraEnv on coordinator
+    set:
+      coordinator.extraEnv:
+        - name: AWS_REGION
+          value: us-east-1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-east-1
+
+  - it: should not apply tablet env to coordinator
+    set:
+      tablet.envFrom:
+        - secretRef:
+            name: tablet-secret
+      tablet.extraEnv:
+        - name: TABLET_ONLY
+          value: "true"
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TABLET_ONLY
+            value: "true"
+
+---
+
+suite: tablet env
+templates:
+  - templates/sts-tablet.yaml
+
+tests:
+  - it: should render envFrom with secretRef on tablet
+    set:
+      tablet.envFrom:
+        - secretRef:
+            name: my-eso-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: my-eso-secret
+
+  - it: should render envFrom with configMapRef on tablet
+    set:
+      tablet.envFrom:
+        - configMapRef:
+            name: my-config
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            configMapRef:
+              name: my-config
+
+  - it: should render extraEnv on tablet
+    set:
+      tablet.extraEnv:
+        - name: AWS_REGION
+          value: us-east-1
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: AWS_REGION
+            value: us-east-1
+
+  - it: should render multiple envFrom sources on tablet
+    set:
+      tablet.envFrom:
+        - secretRef:
+            name: secret-one
+        - secretRef:
+            name: secret-two
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: secret-one
+      - contains:
+          path: spec.template.spec.containers[0].envFrom
+          content:
+            secretRef:
+              name: secret-two
+
+  - it: should not apply coordinator env to tablet
+    set:
+      coordinator.envFrom:
+        - secretRef:
+            name: coordinator-secret
+      coordinator.extraEnv:
+        - name: COORDINATOR_ONLY
+          value: "true"
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: COORDINATOR_ONLY
+            value: "true"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -46,6 +46,8 @@ tablet:
   extraVolumes: []
   extraVolumeMounts: []
   initContainers: []
+  extraEnv: []
+  envFrom: []
 
 coordinator:
   numberOfReplicas: 1
@@ -56,6 +58,8 @@ coordinator:
   extraVolumes: []
   extraVolumeMounts: []
   initContainers: []
+  extraEnv: []
+  envFrom: []
 
 # Fluss listener configurations
 listeners:

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -271,11 +271,44 @@ It is recommended to set these explicitly in production.
 | `coordinator.extraVolumes` | Extra volumes to add to the CoordinatorServer pod spec | `[]` |
 | `coordinator.extraVolumeMounts` | Extra volume mounts to add to the coordinator container | `[]` |
 | `coordinator.initContainers` | Init containers to run before the coordinator container starts | `[]` |
+| `coordinator.extraEnv` | Additional environment variables for the coordinator container | `[]` |
+| `coordinator.envFrom` | Additional envFrom sources (e.g., Secrets, ConfigMaps) for the coordinator container | `[]` |
 | `tablet.extraVolumes` | Extra volumes to add to TabletServer pod specs | `[]` |
 | `tablet.extraVolumeMounts` | Extra volume mounts to add to the tablet container | `[]` |
 | `tablet.initContainers` | Init containers to run before the tablet container starts | `[]` |
+| `tablet.extraEnv` | Additional environment variables for the tablet container | `[]` |
+| `tablet.envFrom` | Additional envFrom sources (e.g., Secrets, ConfigMaps) for the tablet container | `[]` |
 
 ## Advanced Configuration
+
+### Injecting Environment Variables from External Secrets
+
+You can inject environment variables from Kubernetes Secrets or ConfigMaps using `envFrom`. This is useful when combined with the [External Secrets Operator](https://external-secrets.io/) or similar tools that provision Secrets from external stores (AWS Secrets Manager, HashiCorp Vault, etc.).
+
+```yaml
+tablet:
+  envFrom:
+    - secretRef:
+        name: aws-credentials
+coordinator:
+  envFrom:
+    - secretRef:
+        name: aws-credentials
+```
+
+You can also set individual environment variables using `extraEnv`:
+
+```yaml
+tablet:
+  extraEnv:
+    - name: AWS_REGION
+      value: us-east-1
+    - name: MY_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: my-secret
+          key: password
+```
 
 ### Custom ZooKeeper Configuration
 


### PR DESCRIPTION
## Summary

closes https://github.com/apache/fluss/issues/3097

Enable users to inject custom environment variables into coordinator and tablet server pods via `extraEnv` and `envFrom` fields, supporting integration with the External Secrets Operator and similar tools that provision credentials from external stores 
