### PR TITLE
[client] Catch throwable to avoid slient failure on remote file download

### DIFF
--- a/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
+++ b/fluss-client/src/main/java/org/apache/fluss/client/table/scanner/RemoteFileDownloader.java
@@ -76,8 +76,8 @@ public class RemoteFileDownloader implements Closeable {
                         FsPath remoteFilePath = fsPathAndFileName.getPath();
                         long downloadBytes = downloadFile(targetFilePath, remoteFilePath);
                         future.complete(downloadBytes);
-                    } catch (Exception e) {
-                        future.completeExceptionally(e);
+                    } catch (Throwable t) {
+                        future.completeExceptionally(t);
                     }
                 });
         return future;


### PR DESCRIPTION
### Purpose

<!-- Linking this pull request to the issue -->
Linked issue: close https://github.com/apache/fluss/issues/3085

<!-- What is the purpose of the change -->

### Brief change log

<!-- Please describe the changes made in this pull request and explain how they address the issue -->

### Tests

<!-- List UT and IT cases to verify this change -->

### API and Format

<!-- Does this change affect API or storage format -->

### Documentation

<!-- Does this change introduce a new feature -->
