### PR TITLE
[release-0.9] Bump org.apache.kafka:kafka-clients from 3.9.1 to 3.9.2 in /fluss-kafka

### DIFF
--- a/fluss-kafka/pom.xml
+++ b/fluss-kafka/pom.xml
@@ -30,7 +30,7 @@
     <name>Fluss : Kafka Compatibility</name>
 
     <properties>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
## Summary
- Cherry-pick of https://github.com/apache/fluss/commit/5ff51962d0aa872182bf459fe0dca9eda24c2f7f to `release-0.9` branch
- Bumps `org.apache.kafka:kafka-clients` from 3.9.1 to 3.9.2 in `/fluss-kafka`