### PR TITLE
[dependencies] Bump com.google.protobuf:protobuf-java from 2.5.0 to 3.25.5

### DIFF
--- a/fluss-filesystems/fluss-fs-hdfs/pom.xml
+++ b/fluss-filesystems/fluss-fs-hdfs/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>2.5.0</version>
+            <version>3.25.5</version>
         </dependency>
 
         <dependency>

--- a/fluss-filesystems/fluss-fs-hdfs/src/main/resources/META-INF/NOTICE
+++ b/fluss-filesystems/fluss-fs-hdfs/src/main/resources/META-INF/NOTICE
@@ -18,4 +18,4 @@ This project bundles the following dependencies under the Apache Software Licens
 This project bundles the following dependencies under BSD-3 License (https://opensource.org/licenses/BSD-3-Clause).
 See bundled license files for details.
 
-- com.google.protobuf:protobuf-java:2.5.0
+- com.google.protobuf:protobuf-java:3.25.5


### PR DESCRIPTION
## Summary
- Cherry-pick of #1775 to release-0.9 branch
- Bumps `com.google.protobuf:protobuf-java` from 2.5.0 to 3.25.5 in `fluss-filesystems/fluss-fs-hdfs`
- Updates NOTICE file to reflect the new version