### PR TITLE
[helm] Add pod annotations, labels, and pod disruption budget support

### DIFF
--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -22,3 +22,4 @@ APP VERSION: {{ .Chart.AppVersion }}
 
 {{ include "fluss.security.validateValues" . }}
 {{ include "fluss.metrics.validateValues" . }}
+{{ include "fluss.pdb.validateValues" . }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -100,3 +100,34 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 
+{{/*
+  Validate PodDisruptionBudget for a given component.
+  Usage: include "fluss.pdb.validate" (dict "component" "tablet" "pdb" .Values.tablet.podDisruptionBudget)
+*/}}
+{{- define "fluss.pdb.validate" -}}
+{{- if .pdb.enabled -}}
+  {{- $hasMin := hasKey .pdb "minAvailable" -}}
+  {{- $hasMax := hasKey .pdb "maxUnavailable" -}}
+  {{- if and $hasMin $hasMax -}}
+    {{- printf "%s.podDisruptionBudget: cannot set both minAvailable and maxUnavailable" .component -}}
+  {{- else if not (or $hasMin $hasMax) -}}
+    {{- printf "%s.podDisruptionBudget: must set either minAvailable or maxUnavailable when enabled" .component -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+  Aggregate PDB validation for all components.
+  include "fluss.pdb.validateValues" .
+*/}}
+{{- define "fluss.pdb.validateValues" -}}
+{{- $errMessages := list -}}
+{{- $errMessages = append $errMessages (include "fluss.pdb.validate" (dict "component" "tablet" "pdb" .Values.tablet.podDisruptionBudget)) -}}
+{{- $errMessages = append $errMessages (include "fluss.pdb.validate" (dict "component" "coordinator" "pdb" .Values.coordinator.podDisruptionBudget)) -}}
+{{- $errMessages = without $errMessages "" -}}
+{{- $errMessage := join "\n" $errMessages -}}
+{{- if $errMessage -}}
+{{-   printf "\nPDB VALIDATION:\n%s" $errMessage | fail -}}
+{{- end -}}
+{{- end -}}
+

--- a/helm/templates/pdb-coordinator.yaml
+++ b/helm/templates/pdb-coordinator.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.coordinator.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: coordinator-server
+  labels:
+  {{- include "fluss.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.coordinator.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.coordinator.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluss.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: coordinator
+{{- end }}

--- a/helm/templates/pdb-coordinator.yaml
+++ b/helm/templates/pdb-coordinator.yaml
@@ -24,11 +24,11 @@ metadata:
   labels:
   {{- include "fluss.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.coordinator.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ . }}
+  {{- if hasKey .Values.coordinator.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.coordinator.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.coordinator.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.coordinator.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.coordinator.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/helm/templates/pdb-tablet.yaml
+++ b/helm/templates/pdb-tablet.yaml
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+{{- if .Values.tablet.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: tablet-server
+  labels:
+  {{- include "fluss.labels" . | nindent 4 }}
+spec:
+  {{- with .Values.tablet.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.tablet.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "fluss.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: tablet
+{{- end }}

--- a/helm/templates/pdb-tablet.yaml
+++ b/helm/templates/pdb-tablet.yaml
@@ -24,11 +24,11 @@ metadata:
   labels:
   {{- include "fluss.labels" . | nindent 4 }}
 spec:
-  {{- with .Values.tablet.podDisruptionBudget.minAvailable }}
-  minAvailable: {{ . }}
+  {{- if hasKey .Values.tablet.podDisruptionBudget "minAvailable" }}
+  minAvailable: {{ .Values.tablet.podDisruptionBudget.minAvailable }}
   {{- end }}
-  {{- with .Values.tablet.podDisruptionBudget.maxUnavailable }}
-  maxUnavailable: {{ . }}
+  {{- if hasKey .Values.tablet.podDisruptionBudget "maxUnavailable" }}
+  maxUnavailable: {{ .Values.tablet.podDisruptionBudget.maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -34,6 +34,13 @@ spec:
       labels:
         {{- include "fluss.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: coordinator
+        {{- with .Values.coordinator.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.coordinator.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "fluss.fullname" .) }}

--- a/helm/templates/sts-coordinator.yaml
+++ b/helm/templates/sts-coordinator.yaml
@@ -32,11 +32,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluss.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: coordinator
         {{- with .Values.coordinator.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "fluss.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: coordinator
       {{- with .Values.coordinator.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -32,11 +32,11 @@ spec:
   template:
     metadata:
       labels:
-        {{- include "fluss.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: tablet
         {{- with .Values.tablet.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- include "fluss.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: tablet
       {{- with .Values.tablet.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/sts-tablet.yaml
+++ b/helm/templates/sts-tablet.yaml
@@ -34,6 +34,13 @@ spec:
       labels:
         {{- include "fluss.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: tablet
+        {{- with .Values.tablet.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.tablet.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ .Values.serviceAccount.name | default (include "fluss.fullname" .) }}

--- a/helm/tests/pod_metadata_and_pdb_test.yaml
+++ b/helm/tests/pod_metadata_and_pdb_test.yaml
@@ -1,0 +1,215 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+suite: pod-metadata-defaults
+templates:
+  - templates/sts-tablet.yaml
+  - templates/sts-coordinator.yaml
+
+tests:
+  - it: should not render pod annotations by default on tablet
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations
+        template: templates/sts-tablet.yaml
+
+  - it: should not render pod annotations by default on coordinator
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations
+        template: templates/sts-coordinator.yaml
+
+---
+
+suite: tablet-pod-annotations
+templates:
+  - templates/sts-tablet.yaml
+
+tests:
+  - it: should render pod annotations on tablet
+    set:
+      tablet.podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9249"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "9249"
+
+  - it: should not apply coordinator annotations to tablet
+    set:
+      coordinator.podAnnotations:
+        prometheus.io/scrape: "true"
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations
+
+---
+
+suite: coordinator-pod-annotations
+templates:
+  - templates/sts-coordinator.yaml
+
+tests:
+  - it: should render pod annotations on coordinator
+    set:
+      coordinator.podAnnotations:
+        prometheus.io/scrape: "true"
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations
+          value:
+            prometheus.io/scrape: "true"
+
+---
+
+suite: tablet-pod-labels
+templates:
+  - templates/sts-tablet.yaml
+
+tests:
+  - it: should render custom pod labels on tablet
+    set:
+      tablet.podLabels:
+        team: data-platform
+        env: production
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: data-platform
+      - equal:
+          path: spec.template.metadata.labels.env
+          value: production
+
+  - it: should preserve built-in labels when custom labels are added
+    set:
+      tablet.podLabels:
+        custom: label
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: tablet
+      - equal:
+          path: spec.template.metadata.labels.custom
+          value: label
+
+---
+
+suite: coordinator-pod-labels
+templates:
+  - templates/sts-coordinator.yaml
+
+tests:
+  - it: should render custom pod labels on coordinator
+    set:
+      coordinator.podLabels:
+        team: data-platform
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.team
+          value: data-platform
+
+---
+
+suite: pdb-defaults
+templates:
+  - templates/pdb-tablet.yaml
+  - templates/pdb-coordinator.yaml
+
+tests:
+  - it: should not render tablet PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/pdb-tablet.yaml
+
+  - it: should not render coordinator PDB by default
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/pdb-coordinator.yaml
+
+---
+
+suite: tablet-pdb
+templates:
+  - templates/pdb-tablet.yaml
+
+tests:
+  - it: should render tablet PDB with minAvailable
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: tablet-server
+      - equal:
+          path: spec.minAvailable
+          value: 2
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: tablet
+
+  - it: should render tablet PDB with maxUnavailable
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isNull:
+          path: spec.minAvailable
+
+---
+
+suite: coordinator-pdb
+templates:
+  - templates/pdb-coordinator.yaml
+
+tests:
+  - it: should render coordinator PDB with minAvailable
+    set:
+      coordinator.podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: PodDisruptionBudget
+      - equal:
+          path: metadata.name
+          value: coordinator-server
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/component"]
+          value: coordinator

--- a/helm/tests/pod_metadata_and_pdb_test.yaml
+++ b/helm/tests/pod_metadata_and_pdb_test.yaml
@@ -213,3 +213,73 @@ tests:
       - equal:
           path: spec.selector.matchLabels["app.kubernetes.io/component"]
           value: coordinator
+
+---
+
+suite: pdb-validation
+templates:
+  - templates/NOTES.txt
+
+tests:
+  - it: should fail when both minAvailable and maxUnavailable are set on tablet
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+        minAvailable: 2
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot set both minAvailable and maxUnavailable"
+
+  - it: should fail when neither minAvailable nor maxUnavailable is set on tablet
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "must set either minAvailable or maxUnavailable when enabled"
+
+  - it: should fail when both minAvailable and maxUnavailable are set on coordinator
+    set:
+      coordinator.podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorPattern: "cannot set both minAvailable and maxUnavailable"
+
+  - it: should fail when neither minAvailable nor maxUnavailable is set on coordinator
+    set:
+      coordinator.podDisruptionBudget:
+        enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "must set either minAvailable or maxUnavailable when enabled"
+
+---
+
+suite: pdb-zero-values
+templates:
+  - templates/pdb-tablet.yaml
+
+tests:
+  - it: should render tablet PDB with minAvailable set to zero
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+        minAvailable: 0
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 0
+
+  - it: should render tablet PDB with maxUnavailable set to zero
+    set:
+      tablet.podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -48,6 +48,12 @@ tablet:
   initContainers: []
   extraEnv: []
   envFrom: []
+  podAnnotations: {}
+  podLabels: {}
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
 
 coordinator:
   numberOfReplicas: 1
@@ -60,6 +66,12 @@ coordinator:
   initContainers: []
   extraEnv: []
   envFrom: []
+  podAnnotations: {}
+  podLabels: {}
+  podDisruptionBudget:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: 1
 
 # Fluss listener configurations
 listeners:

--- a/website/docs/install-deploy/deploying-with-helm.md
+++ b/website/docs/install-deploy/deploying-with-helm.md
@@ -273,11 +273,21 @@ It is recommended to set these explicitly in production.
 | `coordinator.initContainers` | Init containers to run before the coordinator container starts | `[]` |
 | `coordinator.extraEnv` | Additional environment variables for the coordinator container | `[]` |
 | `coordinator.envFrom` | Additional envFrom sources (e.g., Secrets, ConfigMaps) for the coordinator container | `[]` |
+| `coordinator.podAnnotations` | Annotations to add to CoordinatorServer pods | `{}` |
+| `coordinator.podLabels` | Additional labels to add to CoordinatorServer pods | `{}` |
+| `coordinator.podDisruptionBudget.enabled` | Enable PodDisruptionBudget for CoordinatorServer | `false` |
+| `coordinator.podDisruptionBudget.minAvailable` | Minimum available coordinator pods during disruption | Not set |
+| `coordinator.podDisruptionBudget.maxUnavailable` | Maximum unavailable coordinator pods during disruption | Not set |
 | `tablet.extraVolumes` | Extra volumes to add to TabletServer pod specs | `[]` |
 | `tablet.extraVolumeMounts` | Extra volume mounts to add to the tablet container | `[]` |
 | `tablet.initContainers` | Init containers to run before the tablet container starts | `[]` |
 | `tablet.extraEnv` | Additional environment variables for the tablet container | `[]` |
 | `tablet.envFrom` | Additional envFrom sources (e.g., Secrets, ConfigMaps) for the tablet container | `[]` |
+| `tablet.podAnnotations` | Annotations to add to TabletServer pods | `{}` |
+| `tablet.podLabels` | Additional labels to add to TabletServer pods | `{}` |
+| `tablet.podDisruptionBudget.enabled` | Enable PodDisruptionBudget for TabletServer | `false` |
+| `tablet.podDisruptionBudget.minAvailable` | Minimum available tablet server pods during disruption | Not set |
+| `tablet.podDisruptionBudget.maxUnavailable` | Maximum unavailable tablet server pods during disruption | Not set |
 
 ## Advanced Configuration
 


### PR DESCRIPTION
closes https://github.com/apache/fluss/issues/3115

Production Kubernetes deployments commonly need custom pod annotations for integrations like Prometheus scraping or Vault agent injection, custom labels for service mesh routing and monitoring selectors, and PodDisruptionBudgets to prevent simultaneous eviction of tablet server replicas during node maintenance. 

This PR adds all three as standard Helm chart fields for both coordinator and tablet server components, with PDB disabled by default.   