### PR TITLE
[dependencies] Bump org.apache.logging.log4j:log4j-1.2-api to 2.25.4 in release-0.9

### DIFF
--- a/fluss-dist/src/main/resources/META-INF/NOTICE
+++ b/fluss-dist/src/main/resources/META-INF/NOTICE
@@ -6,4 +6,4 @@ The Apache Software Foundation (http://www.apache.org/).
 
 This project bundles the following dependencies under the Apache Software License 2.0 (http://www.apache.org/licenses/LICENSE-2.0.txt)
 
-- org.apache.logging.log4j:log4j-api:2.17.1
+- org.apache.logging.log4j:log4j-api:2.25.4

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <fluss.hadoop.version>3.4.0</fluss.hadoop.version>
         <frocksdb.version>6.20.3-ververica-2.0</frocksdb.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <log4j.version>2.17.1</log4j.version>
+        <log4j.version>2.25.4</log4j.version>
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <junit5.version>5.9.1</junit5.version>
         <mockito.version>3.4.6</mockito.version>


### PR DESCRIPTION
### Purpose

Linked issue: N/A (backport of #3109)

Backport commit `53a20a7caf2b1b65b41d583894db409739ce5575` to `release-0.9` so the release branch picks up the `org.apache.logging.log4j:log4j-1.2-api` bump to `2.25.4`.

### Brief change log

- Cherry-pick the upstream dependency bump onto `release-0.9`
- Update the root `log4j.version` property from `2.17.1` to `2.25.4`
- Refresh the bundled NOTICE entry in `fluss-dist`

### Tests

- `mvn -N -DskipTests -Drat.skip=true validate`
- Attempted broader validation with `mvn -pl fluss-dist -am -DskipTests -Dcheckstyle.skip=true -Drat.skip=true -Dspotless.skip=true validate`, but it is blocked in the local environment by cached snapshot/plugin resolution failures for `org.apache.fluss:fluss-protogen-maven-plugin:0.9-SNAPSHOT`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes are required.
