### PR TITLE
[dependencies] Bump org.assertj:assertj-core to 3.27.7 in release-0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <jaxb.api.version>2.3.1</jaxb.api.version>
         <junit5.version>5.9.1</junit5.version>
         <mockito.version>3.4.6</mockito.version>
-        <assertj.version>3.23.1</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
 
         <protobuf.version>3.25.5</protobuf.version>
         <protostuff.version>1.7.2</protostuff.version>


### PR DESCRIPTION
### Purpose

Linked issue: N/A (backport of #2488)

Backport commit `a0467ad59772760c5740405a30ae54ea2e6d0ae9` to `release-0.9` so the release branch picks up the `org.assertj:assertj-core` bump to `3.27.7`.

### Brief change log

- Cherry-pick the upstream dependency bump onto `release-0.9`
- Update the root `assertj.version` property from `3.23.1` to `3.27.7`

### Tests

- `mvn -N -DskipTests -Drat.skip=true validate`

### API and Format

No API or storage format changes.

### Documentation

No documentation changes are required.
